### PR TITLE
docs(release): record the completed Alpha 2 publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 反应域
 
-**反应域（REACTION FIELD）** 当前仓库正在准备 Web Playtest Alpha `0.13.0-alpha.3` 替代发布候选，规则版本严格为 `MVP0-P10`。对外产品阶段仍称 Reaction Field Alpha 2；本候选恢复 alpha.2 的发布验证，并建立 Apache-2.0 许可基础，不增加任何游戏功能或规则。这是一个基于 React、TypeScript、Vite、Vitest 与 Playwright 的本地同屏双人公开试玩版本，不是正式发行版。
+**反应域（REACTION FIELD）** 已公开发布 Web Playtest Alpha，技术版本为 `0.13.0-alpha.3`，规则版本严格为 `MVP0-P10`，对外阶段名为 Reaction Field Alpha 2。本次发布不增加任何游戏功能或规则。这是一个基于 React、TypeScript、Vite、Vitest 与 Playwright 的本地同屏双人公开试玩版本，不是正式发行版。
 
 ## 当前能力
 
@@ -18,7 +18,7 @@ Web Playtest Alpha 公开双方手牌、牌堆数量、状态与完整日志。�
 
 ## 公开试玩地址与本轮状态
 
-公开试玩入口为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)。Phase 13 首局引导已经实现并合并。`web-playtest-v0.13.0-alpha.2` 已存在并保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 对旧 commit 的固定断言失败，alpha.2 未成功部署，也未完成公开 URL 验收。`0.13.0-alpha.3` 是替代发布候选，尚未创建标签或部署。`web-playtest-v0.13.0-alpha.1` 同样是永久保持不变的历史标签。本地实现阶段未联网复核公开地址的实时可用性；除非取得实时证据，公开站点可能仍运行 alpha.1。
+公开试玩入口为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)，GitHub Release 为 [web-playtest-v0.13.0-alpha.3](https://github.com/9947447-alt/Chemistry-online-Card-Game/releases/tag/web-playtest-v0.13.0-alpha.3)。当前公开发布事实为：对外阶段 Reaction Field Alpha 2，技术版本 `0.13.0-alpha.3`，规则版本 `MVP0-P10`，标签 `web-playtest-v0.13.0-alpha.3`，peeled commit `0f50b2c8011ee108bc4b6ab3178ad4aa0acbe6cd`。`main` 已包含完整稳定历史；Pages workflow、部署和简略公开页面验收均已成功，但这不等同于广泛跨浏览器兼容性验收。`web-playtest-v0.13.0-alpha.2` 已存在并保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 对旧 commit 的固定断言失败，alpha.2 未成功部署。`web-playtest-v0.13.0-alpha.1` 与 alpha.2 标签均保持不可变。
 
 ## 固定工具链
 
@@ -101,9 +101,9 @@ Commit：<短 SHA 或 dev/unknown>
 
 - 仅本地同屏双人公开试玩，无私密手牌和持久化；刷新即丢失进度。
 - 真实金属卡池及实验反击金属选项、方程式、沉淀、响应 DIY、多人、联网、账号、存档和回放均延期。
-- 首个静态公开目标是 GitHub Pages；本地实现不执行部署，最终公开仍需人工批准。
+- 当前公开发布使用 GitHub Pages；本地开发与验证不执行部署。
 - Tauri、Electron、PWA、service worker、APP / DMG / EXE / MSI、签名、公证和自动更新均未实现，也不在本阶段范围。
-- 已知兼容性边界：在 iOS 27 beta 的 Firefox 中，打开帮助或重开确认框可能进入 `ROOT_RUNTIME_FAILED`。此前的 `requestAnimationFrame` 聚焦实验未解决该问题，未进入稳定分支；Safari 与已测试的 Edge 路径正常只是已有真机/浏览器记录，不构成所有版本的普遍保证。本次 alpha.3 替代候选不修复也不声称修复 iOS Firefox beta；失败热修复分支 `fix/ios-firefox-modal-focus-alpha2` 不复制、不合并、不修改。
+- 已知兼容性边界：在 iOS 27 beta 的 Firefox 中，打开帮助或重开确认框可能进入 `ROOT_RUNTIME_FAILED`。此前的 `requestAnimationFrame` 聚焦实验未解决该问题，未进入稳定分支；Safari 与已测试的 Edge 路径正常只是已有真机/浏览器记录，不构成所有版本的普遍保证。本次 alpha.3 发布不修复也不声称修复 iOS Firefox beta；失败热修复分支 `fix/ios-firefox-modal-focus-alpha2` 不复制、不合并、不修改。
 
 发布、标签、回滚与停止公开试玩说明见 [`docs/PHASE12_REACTION_FIELD_WEB_PLAYTEST_FREEZE.md`](docs/PHASE12_REACTION_FIELD_WEB_PLAYTEST_FREEZE.md)。Phase 11 是历史稳定性基线；规则边界继续由 [`docs/MVP0_RULE_FREEZE.md`](docs/MVP0_RULE_FREEZE.md)、[`docs/PHASE8_CHARACTER_RULE_FREEZE.md`](docs/PHASE8_CHARACTER_RULE_FREEZE.md)、[`docs/PHASE9_DEBUG_UI_RULE_FREEZE.md`](docs/PHASE9_DEBUG_UI_RULE_FREEZE.md) 和 [`docs/PHASE10_REACTION_EVENT_RULE_FREEZE.md`](docs/PHASE10_REACTION_EVENT_RULE_FREEZE.md) 冻结；阶段总览见 [`docs/MVP_PLAN.md`](docs/MVP_PLAN.md)。
 

--- a/docs/CODEX_CAPABILITIES.md
+++ b/docs/CODEX_CAPABILITIES.md
@@ -2,12 +2,12 @@
 
 ## 审计基线
 
-- 审计日期：2026-08-10
-- 审计分支：`feat/debug-ui-alpha`
-- 审计 HEAD：`57550f70856d5d5e27ac3fcb0fa508cd698d3be6`
+- 审计日期：2026-08-11
+- 审计分支：`docs/alpha2-release-closeout`
+- 审计 HEAD：`0f50b2c8011ee108bc4b6ab3178ad4aa0acbe6cd`
 - 本文是基于该提交的仓库快照；后续架构、分支或发布状态变化后必须重新核验。
-- 本轮文档写入和验证仅针对当前主工作树；其他 linked worktree 不在本文件操作范围。
-- 本轮未安装依赖、未运行测试/构建/审计、未联网验证 GitHub Pages，也未创建或修改发布状态。
+- 本轮文档写入和验证仅针对 `/Users/a0000/Documents/Chemistry-online-Card-Game-alpha2-release-closeout`；其他 linked worktree 不在本文件操作范围。
+- 本轮未安装依赖、未运行测试/构建/审计；本轮未修改标签、Release、Pages workflow、部署或 GitHub 设置。
 
 ## 项目目标与范围
 
@@ -73,8 +73,8 @@ engine modules → game/data definitions → typed GameState / GameAction
 - `src/game/engine/reducer.ts` 是正式 `GameAction` 入口；UI 对局操作经会话层转发。
 - fatal 会话从本地状态移除旧 `GameState`，旧 action 被拒绝；恢复需要重新创建匹配阵容的状态。
 - 测试文件分布在 `src` 和 `scripts`，覆盖引擎规则、会话边界、UI 组件、产物扫描、标签检查和静态服务器。
-- E2E 配置当前只声明 Chromium；本轮没有取得 Firefox、Safari、真实 iOS 或 Pages 运行结果。
-- 本地 Git 已确认 `web-playtest-v0.13.0-alpha.2` 指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 的旧 commit 固定断言失败，未成功部署。alpha.3 是替代候选；这不证明公开站点当前运行的版本。
+- E2E 配置当前只声明 Chromium；本轮没有取得 Firefox、Safari 或真实 iOS 运行结果，也未进行广泛跨浏览器兼容性验收。
+- `web-playtest-v0.13.0-alpha.2` 保持不可变并指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 的旧 commit 固定断言失败，alpha.2 未成功部署。alpha.3 已公开发布：对外阶段 Reaction Field Alpha 2，技术版本 `0.13.0-alpha.3`，规则版本 `MVP0-P10`，标签 `web-playtest-v0.13.0-alpha.3` peeled 到 `0f50b2c8011ee108bc4b6ab3178ad4aa0acbe6cd`；GitHub Release 为 [web-playtest-v0.13.0-alpha.3](https://github.com/9947447-alt/Chemistry-online-Card-Game/releases/tag/web-playtest-v0.13.0-alpha.3)，公开试玩为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)。Pages workflow、部署和简略公开页面验收已成功。
 
 ## Codex 可协助的工作矩阵
 
@@ -83,7 +83,7 @@ engine modules → game/data definitions → typed GameState / GameAction
 | 类别 | 可协助事项 | 关键文件 | 风险 | 推荐验证方式 |
 |---|---|---|---|---|
 | 功能开发 | 在规则冻结后补齐真实金属卡池和实验反击金属选项 | `src/game/data/*`、`src/game/engine/experimentCounterattack.ts`、`docs/PHASE8_CHARACTER_RULE_FREEZE.md` | 高 | reducer/不变量测试、E2E、卡池计数复核 |
-| Bug 修复 | 修复 production E2E 的旧 commit 断言并准备 alpha.3 替代候选 | `e2e/production/reaction-field.spec.ts`、`README.md`、`docs/MVP_PLAN.md`、`docs/PHASE13_NEW_PLAYER_GUIDANCE_FREEZE.md`、`scripts/check-web-playtest-tag.mjs` | 低 | 本地 tag 目标、当前 HEAD、package 版本、文档交叉检查 |
+| 发布文档 | 收口 Reaction Field Alpha 2 的 alpha.3 已发布事实，保留 alpha.2 失败与不可变标签记录 | `README.md`、`docs/MVP_PLAN.md`、`docs/PHASE13_NEW_PLAYER_GUIDANCE_FREEZE.md`、`docs/REACTION_FIELD_BRAND_ASSETS.md`、`docs/CODEX_CAPABILITIES.md`、`docs/CODEX_PITFALLS.md` | 低 | Git 基线、tag peeled commit、版本、公开试玩与 Release URL、允许路径差异检查 |
 | 测试与质量 | 增加覆盖率和浏览器矩阵（需单独批准后形成门禁） | `vite.config.ts`、`package.json`、`playwright.config.ts`、`playwright.production.config.ts`、`.github/workflows/phase11-debug-alpha.yml` | 中 | 实际执行测试、覆盖率报告、浏览器 E2E |
 | 架构和重构 | 抽取正式 fixture builder，减少直接拼装 `GameState`；清理未使用脚手架 | `e2e/fixtureScenarios.ts`、`src/game/tests/*`、`src/game/data/debugScenarios.ts`、`src/game/data/statusDefinitions.ts`、`src/app/routes.tsx`、`src/game/engine/statuses.ts`、`src/shared/ids.ts` | 中 | 牌区/pending 不变量、全量 Vitest |
 | 性能 | 评估长日志和大牌区的渲染成本，必要时优化 | `src/features/local-game/components/GameLog.tsx`、`src/features/local-game/local-game.css`、`scripts/check-size.mjs` | 中 | 长日志场景、浏览器 profile、体积检查 |
@@ -94,4 +94,4 @@ engine modules → game/data definitions → typed GameState / GameAction
 
 ## 仍未取得的证据
 
-本快照不包含当前测试/构建通过结论、漏洞扫描结果、Firefox 结果、远端标签状态或 GitHub Pages 部署状态。后续报告必须逐项标记实际执行与未验证项。
+本快照不包含当前测试/构建通过结论、漏洞扫描结果、Firefox、Safari 或真实 iOS 结果，也不构成广泛跨浏览器兼容性结论。Alpha.3 的公开发布、标签、GitHub Release、Pages 部署和简略公开页面验收按本轮权威发布记录已完成；后续报告仍必须逐项标记实际执行与未验证项。

--- a/docs/CODEX_PITFALLS.md
+++ b/docs/CODEX_PITFALLS.md
@@ -1,6 +1,6 @@
 # Codex 踩坑与保护边界
 
-本文件只记录可复核的信息。历史事故、根因和修复结果必须有代码、测试、日志、CI 或可复现步骤证据；推测只能放入“待验证候选”。最近核验日期：2026-08-10。
+本文件只记录可复核的信息。历史事故、根因和修复结果必须有代码、测试、日志、CI 或可复现步骤证据；推测只能放入“待验证候选”。最近核验日期：2026-08-11。
 
 ## A. 已确认踩坑
 
@@ -16,23 +16,23 @@
 - 正确做法：先确认根目录、分支、HEAD、状态；若仍有歧义，停止并请求路径确认
 - 验证方法：在用户指定路径执行 `git rev-parse --show-toplevel`、`git branch --show-current`、`git rev-parse HEAD` 和 `git status --short`
 - 证据文件/测试/提交：2026-08-10 只读 Git 基线检查与用户路径确认；无专门测试；无新增提交
-- 最近核验日期：2026-08-10
+- 最近核验日期：2026-08-11
 
 ### PIT-002：alpha.2 本地标签与发布文档状态不一致
 
 - ID：`PIT-002`
 - 标题：本地 `web-playtest-v0.13.0-alpha.2` 已存在，但文档仍写“尚未创建”
-- 状态：已确认；在 alpha.3 发布恢复候选中已同步文档，保留本历史记录
+- 状态：已确认；alpha.3 已成功公开发布，保留本历史记录
 - 适用范围：本地 Git 发布核对、README/Phase 发布说明、候选版本判断
 - 症状：2026-08-10，本地标签 `web-playtest-v0.13.0-alpha.2` 的提交目标是审计 HEAD；`README.md`、`docs/MVP_PLAN.md`、`docs/PHASE13_NEW_PLAYER_GUIDANCE_FREEZE.md` 当时仍描述该标签尚未创建
 - 根因：本地 Git ref 与文档文本快照不一致；本轮只确认了本地状态和文档内容
 - 错误做法：据此推断远端 Pages 已部署或未部署，或移动/重写标签来“修正文档”
-- 正确做法：分别记录本地 tag、文档状态和远端部署证据；标签/部署动作必须获得明确授权。2026-08-11 已确认 alpha.2 Pages workflow 因 production E2E 的旧 commit 固定断言失败，alpha.2 未成功部署；改用不移动旧标签的 alpha.3 替代候选。
+- 正确做法：分别记录本地 tag、文档状态和远端部署证据；标签/部署动作必须获得明确授权。2026-08-11 已确认 alpha.2 Pages workflow 因 production E2E 的旧 commit 固定断言失败，alpha.2 未成功部署；改用不移动旧标签的 alpha.3 替代发布。alpha.3 已成功公开发布，对外阶段为 Reaction Field Alpha 2，技术版本为 `0.13.0-alpha.3`，规则版本为 `MVP0-P10`，标签 `web-playtest-v0.13.0-alpha.3` peeled 到 `0f50b2c8011ee108bc4b6ab3178ad4aa0acbe6cd`；GitHub Release 为 [web-playtest-v0.13.0-alpha.3](https://github.com/9947447-alt/Chemistry-online-Card-Game/releases/tag/web-playtest-v0.13.0-alpha.3)，公开试玩为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)。
 - 验证方法：`git rev-parse web-playtest-v0.13.0-alpha.2^{commit}`、`git rev-parse HEAD`，并检索 `README.md`、`docs/MVP_PLAN.md`、`docs/PHASE13_NEW_PLAYER_GUIDANCE_FREEZE.md` 中的发布状态文字
-- 证据文件/测试/提交：`README.md`、`docs/MVP_PLAN.md`、`docs/PHASE13_NEW_PLAYER_GUIDANCE_FREEZE.md`；本地 Git tag；审计 HEAD `57550f7`
-- 最近核验日期：2026-08-10
+- 证据文件/测试/提交：`README.md`、`docs/MVP_PLAN.md`、`docs/PHASE13_NEW_PLAYER_GUIDANCE_FREEZE.md`；本地 Git tag；当时审计 HEAD `57550f7`
+- 最近核验日期：2026-08-11
 
-本项不证明 GitHub Pages 已经部署，也不证明没有部署；远端状态需要单独授权和独立证据。
+本项中关于 alpha.2 的历史描述不用于推断 alpha.3 的当前状态；alpha.3 的公开发布、Pages 部署和 URL 事实见上文记录。
 
 ## B. 项目保护性不变量
 

--- a/docs/MVP_PLAN.md
+++ b/docs/MVP_PLAN.md
@@ -27,13 +27,13 @@ Phase 13 的权威实现边界见 `docs/PHASE13_NEW_PLAYER_GUIDANCE_FREEZE.md`�
 
 - 配置阶段位于角色选择操作之前；playing 阶段位于 preparation、main action、response、status、counterattack 与 game over 操作区之前。窄屏保持正常文档流，不使用浮层、遮罩、sticky coach mark 或 modal。
 - 阶段文案覆盖配置、备课、主行动、响应、状态处理、实验反击与对局结束；不复制合法性、卡牌匹配、伤害、反应或出牌建议，不 dispatch `GameAction`，不增加任何规则表。
-- 保持 `MVP0-P10`、68 张普通实体卡池、角色和冻结规则不变；Phase 13 引导实现已在 alpha.1 基线完成，`web-playtest-v0.13.0-alpha.1` 标签永久保持不变。当前应用版本为 `0.13.0-alpha.3`，由 `package.json` 作为唯一真值来源，`releaseMetadata` 继续读取构建注入的版本。`0.13.0-alpha.3` 是 alpha.2 失败后的替代发布候选；对外产品阶段仍称 Reaction Field Alpha 2。发布仍需用户单独确认，公开试玩地址的实时可用性不由本地实现阶段联网确认。
+- 保持 `MVP0-P10`、68 张普通实体卡池、角色和冻结规则不变；Phase 13 引导实现已在 alpha.1 基线完成，`web-playtest-v0.13.0-alpha.1` 标签永久保持不变。当前应用版本为 `0.13.0-alpha.3`，由 `package.json` 作为唯一真值来源，`releaseMetadata` 继续读取构建注入的版本。该版本已公开发布，对外阶段名为 Reaction Field Alpha 2；公开试玩地址为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)，GitHub Release 为 [web-playtest-v0.13.0-alpha.3](https://github.com/9947447-alt/Chemistry-online-Card-Game/releases/tag/web-playtest-v0.13.0-alpha.3)。
 
-## 0.13.0-alpha.3 发布恢复候选（未发布）
+## 0.13.0-alpha.3 已公开发布（Reaction Field Alpha 2）
 
-alpha.2 的品牌资产更新包含 01-B 游戏图标、favicon、Apple Touch Icon 与 11-C RF 品牌资产。`web-playtest-v0.13.0-alpha.2` 已存在并保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 对旧 commit 的固定断言失败，alpha.2 未成功部署，也未完成公开 URL 验收。alpha.3 是替代候选，修复该断言并添加 Apache-2.0 许可基础，不增加游戏功能或规则；`MVP0-P10`、68 张普通实体卡池、初始 `event_lab_fire` 数量与三类结构化反应定义均保持不变。alpha.1 与 alpha.2 标签均不移动、不重写；alpha.3 在最终批准前不创建标签或部署。除非有实时证据，公开站点可能仍运行 alpha.1。
+alpha.2 的品牌资产更新包含 01-B 游戏图标、favicon、Apple Touch Icon 与 11-C RF 品牌资产。`web-playtest-v0.13.0-alpha.2` 已存在并保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 对旧 commit 的固定断言失败，alpha.2 未成功部署，也未完成公开 URL 验收。alpha.3 将该断言修复为动态 checked-out HEAD 短 SHA，并已在不增加游戏功能或规则的前提下公开发布；技术版本为 `0.13.0-alpha.3`，规则版本为 `MVP0-P10`，标签 `web-playtest-v0.13.0-alpha.3` 精确 peeled 到 `0f50b2c8011ee108bc4b6ab3178ad4aa0acbe6cd`。Pages workflow、部署和简略公开页面验收已成功；不宣称广泛跨浏览器兼容性验收。alpha.1 与 alpha.2 标签均不移动、不重写，alpha.3 发布对象保持不变。
 
-已知兼容性边界：iOS 27 beta 的 Firefox 在打开帮助或重开确认框时可能进入 `ROOT_RUNTIME_FAILED`；先前的 `requestAnimationFrame` 聚焦实验未解决该问题，未进入稳定分支。Safari 与已测试的 Edge 路径正常属于已有真机/浏览器记录，不代表所有版本的普遍保证。本次 alpha.3 替代候选不修复也不声称修复 iOS Firefox beta；失败热修复分支 `fix/ios-firefox-modal-focus-alpha2` 不复制、不合并、不修改。
+已知兼容性边界：iOS 27 beta 的 Firefox 在打开帮助或重开确认框时可能进入 `ROOT_RUNTIME_FAILED`；先前的 `requestAnimationFrame` 聚焦实验未解决该问题，未进入稳定分支。Safari 与已测试的 Edge 路径正常属于已有真机/浏览器记录，不代表所有版本的普遍保证。本次 alpha.3 发布不修复也不声称修复 iOS Firefox beta；失败热修复分支 `fix/ios-firefox-modal-focus-alpha2` 不复制、不合并、不修改。
 
 ## MVP 0 定案范围
 

--- a/docs/PHASE13_NEW_PLAYER_GUIDANCE_FREEZE.md
+++ b/docs/PHASE13_NEW_PLAYER_GUIDANCE_FREEZE.md
@@ -2,7 +2,7 @@
 
 ## 结论
 
-Phase 13 采用一个独立、非模态的阶段引导面板，集中解释既有 MVP0-P10 的当前阶段、当前参与者、阶段目标与已有操作入口。它是纯展示层，不改变规则、合法性、发布身份或任何游戏状态。实现已经完成并合并；当前仓库正在准备 `0.13.0-alpha.3` 发布恢复 Web Playtest 替代候选。
+Phase 13 采用一个独立、非模态的阶段引导面板，集中解释既有 MVP0-P10 的当前阶段、当前参与者、阶段目标与已有操作入口。它是纯展示层，不改变规则、合法性、发布身份或任何游戏状态。实现已经完成并合并；`0.13.0-alpha.3` 已公开发布，对外阶段名为 Reaction Field Alpha 2。
 
 ## 权威来源与范围
 
@@ -43,7 +43,7 @@ About 首局速查固定说明：响应 DIY 关闭；虚拟 H2O / CO2 不创建 
 ## 不变量、测试与发布边界
 
 - 不修改 `GameState`、`GameAction`、reducer、引擎、数据、starter deck、CardInstance 数量或实例化规则；引导控件仅更新 React 本地可见/折叠状态，且不 dispatch `GameAction`。
-- 规则版本严格保持 `MVP0-P10`；应用版本由 `package.json` 唯一提供，当前为 `0.13.0-alpha.3`，`releaseMetadata` 继续从构建注入值读取版本。Phase 13 引导已在 alpha.1 基线实现并合并，`web-playtest-v0.13.0-alpha.1` 标签永久保持不变。`web-playtest-v0.13.0-alpha.2` 已存在并保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 对旧 commit 的固定断言失败，alpha.2 未成功部署，也未完成公开 URL 验收。alpha.3 是替代发布候选，修复验证并增加 Apache-2.0 许可基础，不增加游戏功能或规则；对外产品阶段仍称 Reaction Field Alpha 2。发布仍需用户单独确认，且在 alpha.3 真正部署前不能宣称 Alpha 2 已发布成功；除非有实时证据，公开站点可能仍运行 alpha.1。
+- 规则版本严格保持 `MVP0-P10`；应用版本由 `package.json` 唯一提供，当前为 `0.13.0-alpha.3`，`releaseMetadata` 继续从构建注入值读取版本。Phase 13 引导已在 alpha.1 基线实现并合并，`web-playtest-v0.13.0-alpha.1` 标签永久保持不变。`web-playtest-v0.13.0-alpha.2` 已存在并保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 对旧 commit 的固定断言失败，alpha.2 未成功部署，也未完成公开 URL 验收。alpha.3 已公开发布，不增加游戏功能或规则；对外阶段名为 Reaction Field Alpha 2，标签 `web-playtest-v0.13.0-alpha.3` 精确 peeled 到 `0f50b2c8011ee108bc4b6ab3178ad4aa0acbe6cd`。公开试玩地址为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)，GitHub Release 为 [web-playtest-v0.13.0-alpha.3](https://github.com/9947447-alt/Chemistry-online-Card-Game/releases/tag/web-playtest-v0.13.0-alpha.3)。Pages workflow、部署和简略公开页面验收已成功，但不宣称广泛跨浏览器兼容性验收。
 - 组件测试覆盖七类阶段文案、默认可见、折叠、跳过、重新显示与焦点稳定；Chromium E2E 覆盖配置和真实 reducer 可到达的引导，并以 fixture 覆盖难稳定进入的窗口。桌面与 390×844 均检查无水平溢出、console error、pageerror 与本地静态资源失败。
 
 ## 已知兼容性边界
@@ -51,4 +51,4 @@ About 首局速查固定说明：响应 DIY 关闭；虚拟 H2O / CO2 不创建 
 - 在 iOS 27 beta 的 Firefox 中，打开帮助或重开确认框可能进入 `ROOT_RUNTIME_FAILED`。
 - 先前的 `requestAnimationFrame` 聚焦实验未解决该问题，未进入稳定分支；失败热修复分支 `fix/ios-firefox-modal-focus-alpha2` 不复制、不合并、不修改。
 - Safari 与已测试的 Edge 路径正常属于已有真机/浏览器记录，不代表所有版本的普遍保证。
-- 本次 alpha.3 替代候选不修复也不声称修复 iOS Firefox beta。
+- 本次 alpha.3 发布不修复也不声称修复 iOS Firefox beta。

--- a/docs/REACTION_FIELD_BRAND_ASSETS.md
+++ b/docs/REACTION_FIELD_BRAND_ASSETS.md
@@ -2,9 +2,9 @@
 
 本说明仅记录已冻结品牌资产的网页接入用途，不构成新的规则或发布冻结文档。
 
-## 0.13.0-alpha.3 发布恢复候选范围
+## 0.13.0-alpha.3 已公开发布范围
 
-alpha.2 的品牌资产更新包含 01-B 游戏图标、favicon、Apple Touch Icon 与 11-C RF 品牌资产。`web-playtest-v0.13.0-alpha.2` 已存在并保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 对旧 commit 的固定断言失败，alpha.2 未成功部署，也未完成公开 URL 验收。`0.13.0-alpha.3` 是替代发布候选，修复验证并添加 Apache-2.0 许可基础，不增加游戏功能或规则；对外产品阶段仍称 Reaction Field Alpha 2。alpha.1 与 alpha.2 标签永久保持不变，alpha.3 在最终批准前不创建标签或部署；除非有实时证据，公开站点可能仍运行 alpha.1。iOS 27 beta Firefox 已知问题仍未修复，本候选不作修复声明。
+alpha.2 的品牌资产更新包含 01-B 游戏图标、favicon、Apple Touch Icon 与 11-C RF 品牌资产。`web-playtest-v0.13.0-alpha.2` 已存在并保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 对旧 commit 的固定断言失败，alpha.2 未成功部署，也未完成公开 URL 验收。`0.13.0-alpha.3` 已公开发布，技术版本为 `0.13.0-alpha.3`，规则版本为 `MVP0-P10`，对外阶段名为 Reaction Field Alpha 2；标签 `web-playtest-v0.13.0-alpha.3` 精确 peeled 到 `0f50b2c8011ee108bc4b6ab3178ad4aa0acbe6cd`。公开试玩地址为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)，GitHub Release 为 [web-playtest-v0.13.0-alpha.3](https://github.com/9947447-alt/Chemistry-online-Card-Game/releases/tag/web-playtest-v0.13.0-alpha.3)。Pages workflow、部署和简略公开页面验收已成功；不宣称广泛跨浏览器兼容性验收。alpha.1 与 alpha.2 标签永久保持不变，iOS 27 beta Firefox 已知问题仍未修复，本次发布不作修复声明。
 
 ## 许可证与品牌资产边界
 


### PR DESCRIPTION
Updates public release documentation after the successful Reaction Field Alpha 2 deployment. This documents v0.13.0-alpha.3, the immutable alpha.2 failure history, the public playtest and Release URLs, and the existing iOS Firefox beta limitation.