### PR TITLE
feat: add Alpha 4 international playtest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,120 +1,141 @@
-# 反应域
+English | [简体中文](./README.zh-CN.md)
 
-**反应域（REACTION FIELD）** 已公开发布 Web Playtest Alpha，技术版本为 `0.13.0-alpha.3`，规则版本严格为 `MVP0-P10`，对外阶段名为 Reaction Field Alpha 2。本次发布不增加任何游戏功能或规则。这是一个基于 React、TypeScript、Vite、Vitest 与 Playwright 的本地同屏双人公开试玩版本，不是正式发行版。
+# Reaction Field / 反应域
 
-## 当前能力
+**Reaction Field** is an experimental, same-screen card game for two local players, built with React and TypeScript and currently distributed as a public Web Playtest Alpha.
 
-- 7 个正式角色及 49 种有序双人阵容，允许镜像角色；默认预选实验室老师与化工厂 CEO。
-- 68 张普通实体卡池；`event_lab_fire` 初始普通 `CardInstance` 数量为 0。
-- 本地开局、备课、周期、轮次、行动、响应、状态处理、牌堆重洗、淘汰、胜负和公开日志。
-- 关联出牌与 `tableReference`，主动 DIY、角色技能、统一伤害管线和实验反击的已实现部分。
-- 三类结构化成功反应事件：酸碱中和、酸与碳酸盐、SO2 碱性吸收；虚拟 H2O / CO2 不创建卡牌实例。
-- fatal 会话边界：初始化、重开或引擎操作发生未处理异常时停止旧对局，移除旧 `GameState`，只允许全新恢复或返回角色选择。
-- React ErrorBoundary、根级 React 回调与浏览器 `error` / `unhandledrejection` 最后保护。
-- 对局进行中重开和返回角色选择使用可访问的页面内二次确认；`gameOver` 后直接执行。
-- 角色选择、playing 和 `gameOver` 均可打开同一个“关于与帮助”界面，查看版本、能力、操作、安全和延期边界。
+## Try the Web Playtest
 
-Web Playtest Alpha 公开双方手牌、牌堆数量、状态与完整日志。没有联网、账号、房间、存档、遥测或远程错误上报；刷新会丢失当前对局并回到默认角色预选。
+- Play: [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)
+- Current public milestone: **Reaction Field Alpha 2**
+- Current published technical version: `0.13.0-alpha.3`
+- Rules version: `MVP0-P10`
+- GitHub Release: [web-playtest-v0.13.0-alpha.3](https://github.com/9947447-alt/Chemistry-online-Card-Game/releases/tag/web-playtest-v0.13.0-alpha.3)
 
-## 公开试玩地址与本轮状态
+The Alpha 4 international playtest work described below is implemented on the current feature branch. It has not been merged, released, or deployed. The public URL and Release above still serve Alpha 2 / `0.13.0-alpha.3`.
 
-公开试玩入口为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)，GitHub Release 为 [web-playtest-v0.13.0-alpha.3](https://github.com/9947447-alt/Chemistry-online-Card-Game/releases/tag/web-playtest-v0.13.0-alpha.3)。当前公开发布事实为：对外阶段 Reaction Field Alpha 2，技术版本 `0.13.0-alpha.3`，规则版本 `MVP0-P10`，标签 `web-playtest-v0.13.0-alpha.3`，peeled commit `0f50b2c8011ee108bc4b6ab3178ad4aa0acbe6cd`。`main` 已包含完整稳定历史；Pages workflow、部署和简略公开页面验收均已成功，但这不等同于广泛跨浏览器兼容性验收。`web-playtest-v0.13.0-alpha.2` 已存在并保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 对旧 commit 的固定断言失败，alpha.2 未成功部署。`web-playtest-v0.13.0-alpha.1` 与 alpha.2 标签均保持不可变。
+## What Is Reaction Field?
 
-## Feedback / 反馈
+Reaction Field is a local, same-screen two-player game with open hands, public deck counts, public status, and a full game log. It has no online multiplayer, accounts, rooms, saves, telemetry, or remote error reporting. Refreshing the page discards the current match and returns to the default character selection.
 
-<a href="https://forms.cloud.microsoft/r/QG8PACUnsa" target="_blank" rel="noopener noreferrer">Feedback / 反馈 — opens Microsoft Forms in a new tab / 将在新标签页打开 Microsoft Forms</a>
+This is an alpha playtest, not a stable release.
 
-点击反馈会离开游戏，提交内容由 Microsoft Forms 处理。游戏不会向该表单传递手牌、日志、角色、浏览器信息、错误诊断、语言偏好或任何 `GameState` 内容。 / Clicking Feedback leaves the game and Microsoft Forms handles submitted content. The game sends the form no hand, log, character, browser information, error diagnostic, language preference, or `GameState` content.
+## Core Gameplay
 
-## 固定工具链
+- Choose from 7 released characters across 49 ordered two-player lineups; mirror matchups are allowed. The Laboratory Teacher and Chemical Plant CEO are selected by default.
+- Play through setup, preparation, cycles, turns, actions, responses, status handling, deck reshuffles, elimination, and victory resolution.
+- Use linked card play and `tableReference`, active DIY actions, character skills, the shared damage pipeline, and the currently implemented part of experiment counterattacks.
+- Trigger three structured successful reaction events: acid-base neutralization, acid-carbonate reaction, and alkaline absorption of SO2. Virtual H2O and CO2 do not create card instances.
 
-- Node.js `24.18.0`，见 `.node-version`。
-- pnpm `11.9.0`，见 `package.json#packageManager`。
-- 只为 E2E 安装 Playwright Chromium。
+## Current Features
 
-安装依赖：
+- A 68-card ordinary physical card pool. `event_lab_fire` has zero ordinary `CardInstance` entries at initialization.
+- Public hands, deck counts, status, and the complete game log for both players.
+- Accessible in-page confirmation dialogs for restarting or returning to character selection during a match; after `gameOver`, these actions run directly.
+- One shared About & Help view from character selection, play, and `gameOver`, covering version, capabilities, controls, safety, and deferred scope.
+- A fatal-session boundary: an unhandled initialization, restart, or engine error stops the old match and removes its `GameState`; recovery must start a new matching lineup or return to character selection.
+- React ErrorBoundary handling, root-level React callbacks, and browser `error` / `unhandledrejection` fallback handling.
+
+## Alpha Status
+
+The current public release is Reaction Field Alpha 2, technical version `0.13.0-alpha.3`, rules version `MVP0-P10`, tag `web-playtest-v0.13.0-alpha.3`, peeled commit `0f50b2c8011ee108bc4b6ab3178ad4aa0acbe6cd`. Its Pages workflow, deployment, and limited public-page acceptance check completed successfully; this is not evidence of broad cross-browser compatibility.
+
+The earlier `web-playtest-v0.13.0-alpha.2` tag remains unchanged at `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`. Its Pages workflow failed because a production E2E assertion was pinned to an older commit, so alpha.2 was not deployed successfully. The alpha.1 and alpha.2 tags remain immutable. The published alpha.3 release did not add gameplay features or rules.
+
+## International Playtest Status
+
+Alpha 4 is implemented on this branch but is not merged, released, or deployed. It provides Simplified Chinese and English presentation layers without changing game state or rules.
+
+- The display language is suggested from browser language preferences and can be switched in the page.
+- The selection is held only for the current React page lifecycle. It is not persisted; after a refresh, the suggestion is evaluated again from the browser language.
+- Ordinary formal game-log messages remain in Simplified Chinese in English mode. Some structured reaction presentation is localized, but the game must not be described as having a fully English game log.
+
+## Feedback
+
+[Open Microsoft Forms feedback in a new tab](https://forms.cloud.microsoft/r/QG8PACUnsa).
+
+The game does not contact Microsoft Forms before the user clicks the feedback link. It does not automatically pass `GameState`, hands, logs, characters, browser information, error diagnostics, or language preference to the form. After the link is opened, Microsoft Forms handles the content entered there. This project does not claim that the form is anonymous, requires no sign-in, or collects no identity information.
+
+## Running Locally
+
+The pinned toolchain is Node.js `24.18.0` from `.node-version` and pnpm `11.9.0` from `package.json#packageManager`. Only Playwright Chromium is installed for E2E coverage.
 
 ```bash
 pnpm install --frozen-lockfile
 pnpm exec playwright install chromium
-```
-
-## 本地运行与验证
-
-开发服务器：
-
-```bash
 pnpm run dev
 ```
 
-正式构建和 production preview：
+Build and preview the production output:
 
 ```bash
 pnpm run build
 pnpm run preview
 ```
 
-常规和固定 seed Vitest：
+## Testing
+
+Run the regular and fixed-seed Vitest suites:
 
 ```bash
 pnpm run test:run
 pnpm run test:shuffle
 ```
 
-production-mode 独立 fixture 构建和 Chromium E2E：
+Run the isolated production-mode fixture build and Chromium E2E suite:
 
 ```bash
 pnpm run test:e2e
 ```
 
-正式 `src/main.tsx` / `dist/index.html` 试玩路径（同时覆盖根路径和 GitHub Pages 子路径）：
+Test the real `src/main.tsx` / `dist/index.html` playtest paths at both the site root and the GitHub Pages subpath:
 
 ```bash
 pnpm run test:e2e:production
 ```
 
-产物与隔离门禁：
+Run production isolation and bundle-size gates:
 
 ```bash
 pnpm run check:production
 pnpm run check:size
 ```
 
-生产依赖审计：
+Audit production dependencies:
 
 ```bash
 pnpm audit --prod
 ```
 
-`pnpm audit --prod` 会把公开依赖名称和版本发送给 npm advisory API；它在 Phase 11 实际执行并记录结果，但不是主 CI 强制门禁，避免外部 advisory 服务故障阻塞构建。
+`pnpm audit --prod` sends public dependency names and versions to the npm advisory API. It was run and recorded during Phase 11, but it is not a required main CI gate so an external advisory-service outage does not block builds.
 
-## 错误报告
+## Development Notes
 
-fatal 页面可复制的本地安全诊断只包含：
+The project uses React, TypeScript, Vite, Vitest, and Playwright. The formal game action reducer is `src/game/engine/reducer.ts`; presentation code must not bypass the reducer or the established session boundary.
 
-```text
-名称：反应域
-应用版本：0.13.0-alpha.3
-规则版本：MVP0-P10
-Commit：<短 SHA 或 dev/unknown>
-错误码：<稳定错误码>
-运行环境：<非敏感概要>
-```
+The fatal page exposes only a locally copyable diagnostic with the application name, application version, rules version, short commit or `dev/unknown`, a stable error code, and a non-sensitive environment summary. It excludes raw error messages, stacks, `GameState`, hands, logs, and user state, and it is not uploaded automatically.
 
-诊断不包含原始 `Error.message`、异常堆栈、`GameState`、手牌、日志或用户状态，也不会上传到外部服务。
+Release and rollback constraints are documented in [`docs/PHASE12_REACTION_FIELD_WEB_PLAYTEST_FREEZE.md`](docs/PHASE12_REACTION_FIELD_WEB_PLAYTEST_FREEZE.md). Rules remain frozen by [`docs/MVP0_RULE_FREEZE.md`](docs/MVP0_RULE_FREEZE.md), [`docs/PHASE8_CHARACTER_RULE_FREEZE.md`](docs/PHASE8_CHARACTER_RULE_FREEZE.md), [`docs/PHASE9_DEBUG_UI_RULE_FREEZE.md`](docs/PHASE9_DEBUG_UI_RULE_FREEZE.md), and [`docs/PHASE10_REACTION_EVENT_RULE_FREEZE.md`](docs/PHASE10_REACTION_EVENT_RULE_FREEZE.md). See [`docs/MVP_PLAN.md`](docs/MVP_PLAN.md) for the phase overview.
 
-## 当前限制与发布状态
+## Roadmap
 
-- 仅本地同屏双人公开试玩，无私密手牌和持久化；刷新即丢失进度。
-- 真实金属卡池及实验反击金属选项、方程式、沉淀、响应 DIY、多人、联网、账号、存档和回放均延期。
-- 当前公开发布使用 GitHub Pages；本地开发与验证不执行部署。
-- Tauri、Electron、PWA、service worker、APP / DMG / EXE / MSI、签名、公证和自动更新均未实现，也不在本阶段范围。
-- 已知兼容性边界：在 iOS 27 beta 的 Firefox 中，打开帮助或重开确认框可能进入 `ROOT_RUNTIME_FAILED`。此前的 `requestAnimationFrame` 聚焦实验未解决该问题，未进入稳定分支；Safari 与已测试的 Edge 路径正常只是已有真机/浏览器记录，不构成所有版本的普遍保证。本次 alpha.3 发布不修复也不声称修复 iOS Firefox beta；失败热修复分支 `fix/ios-firefox-modal-focus-alpha2` 不复制、不合并、不修改。
+Real metal cards and experiment-counterattack metal options, equations, precipitation, response DIY, multiplayer, networking, accounts, saves, and replays are deferred. Tauri, Electron, PWA, service workers, native installers, signing, notarization, and automatic updates are not implemented and are outside the current phase.
 
-发布、标签、回滚与停止公开试玩说明见 [`docs/PHASE12_REACTION_FIELD_WEB_PLAYTEST_FREEZE.md`](docs/PHASE12_REACTION_FIELD_WEB_PLAYTEST_FREEZE.md)。Phase 11 是历史稳定性基线；规则边界继续由 [`docs/MVP0_RULE_FREEZE.md`](docs/MVP0_RULE_FREEZE.md)、[`docs/PHASE8_CHARACTER_RULE_FREEZE.md`](docs/PHASE8_CHARACTER_RULE_FREEZE.md)、[`docs/PHASE9_DEBUG_UI_RULE_FREEZE.md`](docs/PHASE9_DEBUG_UI_RULE_FREEZE.md) 和 [`docs/PHASE10_REACTION_EVENT_RULE_FREEZE.md`](docs/PHASE10_REACTION_EVENT_RULE_FREEZE.md) 冻结；阶段总览见 [`docs/MVP_PLAN.md`](docs/MVP_PLAN.md)。
+## Known Limitations
 
-## 许可证
+- This is a same-screen two-player playtest with public hands and no persistence. Refreshing loses the current match.
+- In Firefox on iOS 27 beta, opening some modals such as Help or restart confirmation may enter `ROOT_RUNTIME_FAILED`. A previous `requestAnimationFrame` focus experiment did not resolve the issue and was not merged into the stable branch. The issue remains unresolved.
+- Safari and tested Edge paths have existing device/browser test records only; they are not a general compatibility guarantee for all versions.
+- The current public build is hosted on GitHub Pages. Local development and verification do not deploy it.
 
-- Source code: [Apache-2.0](LICENSE)，版权归 `Copyright 2026 Nulledge and Reaction Field contributors` 所有；归属说明见 [NOTICE](NOTICE)。
-- Brand assets: 由 [品牌资产说明](docs/REACTION_FIELD_BRAND_ASSETS.md) 单独管理，不属于 Apache-2.0 源代码授权范围。
-- Third-party dependencies and assets: 继续受各自许可证约束。
+## License
+
+Source code is licensed under [Apache-2.0](LICENSE), with attribution in [NOTICE](NOTICE). Third-party dependencies and assets remain subject to their respective licenses.
+
+## Brand Assets
+
+Files under `public/brand/**` are not included in the Apache-2.0 source-code license. Their use is governed by the existing [Reaction Field brand asset guidance](docs/REACTION_FIELD_BRAND_ASSETS.md), including the restrictions against implying official status, approval, or endorsement.
+
+## Credits
+
+Copyright 2026 Nulledge and Reaction Field contributors. See [NOTICE](NOTICE) for attribution.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Web Playtest Alpha 公开双方手牌、牌堆数量、状态与完整日志。�
 
 公开试玩入口为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)，GitHub Release 为 [web-playtest-v0.13.0-alpha.3](https://github.com/9947447-alt/Chemistry-online-Card-Game/releases/tag/web-playtest-v0.13.0-alpha.3)。当前公开发布事实为：对外阶段 Reaction Field Alpha 2，技术版本 `0.13.0-alpha.3`，规则版本 `MVP0-P10`，标签 `web-playtest-v0.13.0-alpha.3`，peeled commit `0f50b2c8011ee108bc4b6ab3178ad4aa0acbe6cd`。`main` 已包含完整稳定历史；Pages workflow、部署和简略公开页面验收均已成功，但这不等同于广泛跨浏览器兼容性验收。`web-playtest-v0.13.0-alpha.2` 已存在并保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 对旧 commit 的固定断言失败，alpha.2 未成功部署。`web-playtest-v0.13.0-alpha.1` 与 alpha.2 标签均保持不可变。
 
+## Feedback / 反馈
+
+<a href="https://forms.cloud.microsoft/r/QG8PACUnsa" target="_blank" rel="noopener noreferrer">Feedback / 反馈 — opens Microsoft Forms in a new tab / 将在新标签页打开 Microsoft Forms</a>
+
+点击反馈会离开游戏，提交内容由 Microsoft Forms 处理。游戏不会向该表单传递手牌、日志、角色、浏览器信息、错误诊断、语言偏好或任何 `GameState` 内容。 / Clicking Feedback leaves the game and Microsoft Forms handles submitted content. The game sends the form no hand, log, character, browser information, error diagnostic, language preference, or `GameState` content.
+
 ## 固定工具链
 
 - Node.js `24.18.0`，见 `.node-version`。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,132 @@
+[English](./README.md) | 简体中文
+
+# 反应域
+
+**反应域（REACTION FIELD）** 已公开发布 Web Playtest Alpha，技术版本为 `0.13.0-alpha.3`，规则版本严格为 `MVP0-P10`，对外阶段名为 Reaction Field Alpha 2。本次发布不增加任何游戏功能或规则。这是一个基于 React、TypeScript、Vite、Vitest 与 Playwright 的本地同屏双人公开试玩版本，不是正式发行版。
+
+## 当前能力
+
+- 7 个正式角色及 49 种有序双人阵容，允许镜像角色；默认预选实验室老师与化工厂 CEO。
+- 68 张普通实体卡池；`event_lab_fire` 初始普通 `CardInstance` 数量为 0。
+- 本地开局、备课、周期、轮次、行动、响应、状态处理、牌堆重洗、淘汰、胜负和公开日志。
+- 关联出牌与 `tableReference`，主动 DIY、角色技能、统一伤害管线和实验反击的已实现部分。
+- 三类结构化成功反应事件：酸碱中和、酸与碳酸盐、SO2 碱性吸收；虚拟 H2O / CO2 不创建卡牌实例。
+- fatal 会话边界：初始化、重开或引擎操作发生未处理异常时停止旧对局，移除旧 `GameState`，只允许全新恢复或返回角色选择。
+- React ErrorBoundary、根级 React 回调与浏览器 `error` / `unhandledrejection` 最后保护。
+- 对局进行中重开和返回角色选择使用可访问的页面内二次确认；`gameOver` 后直接执行。
+- 角色选择、playing 和 `gameOver` 均可打开同一个“关于与帮助”界面，查看版本、能力、操作、安全和延期边界。
+
+Web Playtest Alpha 公开双方手牌、牌堆数量、状态与完整日志。没有联网、账号、房间、存档、遥测或远程错误上报；刷新会丢失当前对局并回到默认角色预选。
+
+## 公开试玩地址与本轮状态
+
+公开试玩入口为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)，GitHub Release 为 [web-playtest-v0.13.0-alpha.3](https://github.com/9947447-alt/Chemistry-online-Card-Game/releases/tag/web-playtest-v0.13.0-alpha.3)。当前公开发布事实为：对外阶段 Reaction Field Alpha 2，技术版本 `0.13.0-alpha.3`，规则版本 `MVP0-P10`，标签 `web-playtest-v0.13.0-alpha.3`，peeled commit `0f50b2c8011ee108bc4b6ab3178ad4aa0acbe6cd`。`main` 已包含完整稳定历史；Pages workflow、部署和简略公开页面验收均已成功，但这不等同于广泛跨浏览器兼容性验收。`web-playtest-v0.13.0-alpha.2` 已存在并保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 对旧 commit 的固定断言失败，alpha.2 未成功部署。`web-playtest-v0.13.0-alpha.1` 与 alpha.2 标签均保持不可变。
+
+## Alpha 4 国际试玩状态
+
+Alpha 4 国际试玩功能已在当前分支实现，但尚未合并、发布或部署。Alpha 4 提供简体中文和英文展示层，不改变游戏状态或规则。
+
+- 展示语言根据浏览器语言偏好给出建议，也可以在页面内切换。
+- 语言选择仅保存在当前 React 页面生命周期，不做持久化；刷新后会重新根据浏览器语言建议。
+- 英文模式下，普通正式游戏日志仍保持简体中文。部分结构化反应展示已本地化，但不能据此宣称游戏已有完整英文日志。
+
+## Feedback / 反馈
+
+<a href="https://forms.cloud.microsoft/r/QG8PACUnsa" target="_blank" rel="noopener noreferrer">Feedback / 反馈 — opens Microsoft Forms in a new tab / 将在新标签页打开 Microsoft Forms</a>
+
+点击反馈会离开游戏，提交内容由 Microsoft Forms 处理。游戏不会向该表单传递手牌、日志、角色、浏览器信息、错误诊断、语言偏好或任何 `GameState` 内容。 / Clicking Feedback leaves the game and Microsoft Forms handles submitted content. The game sends the form no hand, log, character, browser information, error diagnostic, language preference, or `GameState` content.
+
+游戏不会在用户点击反馈链接前访问 Microsoft Forms。点击后由 Microsoft Forms 处理用户填写的内容。本项目不声称该表单匿名、无需登录或不收集身份信息。
+
+## 固定工具链
+
+- Node.js `24.18.0`，见 `.node-version`。
+- pnpm `11.9.0`，见 `package.json#packageManager`。
+- 只为 E2E 安装 Playwright Chromium。
+
+安装依赖：
+
+```bash
+pnpm install --frozen-lockfile
+pnpm exec playwright install chromium
+```
+
+## 本地运行与验证
+
+开发服务器：
+
+```bash
+pnpm run dev
+```
+
+正式构建和 production preview：
+
+```bash
+pnpm run build
+pnpm run preview
+```
+
+常规和固定 seed Vitest：
+
+```bash
+pnpm run test:run
+pnpm run test:shuffle
+```
+
+production-mode 独立 fixture 构建和 Chromium E2E：
+
+```bash
+pnpm run test:e2e
+```
+
+正式 `src/main.tsx` / `dist/index.html` 试玩路径（同时覆盖根路径和 GitHub Pages 子路径）：
+
+```bash
+pnpm run test:e2e:production
+```
+
+产物与隔离门禁：
+
+```bash
+pnpm run check:production
+pnpm run check:size
+```
+
+生产依赖审计：
+
+```bash
+pnpm audit --prod
+```
+
+`pnpm audit --prod` 会把公开依赖名称和版本发送给 npm advisory API；它在 Phase 11 实际执行并记录结果，但不是主 CI 强制门禁，避免外部 advisory 服务故障阻塞构建。
+
+## 错误报告
+
+fatal 页面可复制的本地安全诊断只包含：
+
+```text
+名称：反应域
+应用版本：0.13.0-alpha.3
+规则版本：MVP0-P10
+Commit：<短 SHA 或 dev/unknown>
+错误码：<稳定错误码>
+运行环境：<非敏感概要>
+```
+
+诊断不包含原始 `Error.message`、异常堆栈、`GameState`、手牌、日志或用户状态，也不会上传到外部服务。
+
+## 当前限制与发布状态
+
+- 仅本地同屏双人公开试玩，无私密手牌和持久化；刷新即丢失进度。
+- 真实金属卡池及实验反击金属选项、方程式、沉淀、响应 DIY、多人、联网、账号、存档和回放均延期。
+- 当前公开发布使用 GitHub Pages；本地开发与验证不执行部署。
+- Tauri、Electron、PWA、service worker、APP / DMG / EXE / MSI、签名、公证和自动更新均未实现，也不在本阶段范围。
+- 已知兼容性边界：在 iOS 27 beta 的 Firefox 中，打开帮助或重开确认框可能进入 `ROOT_RUNTIME_FAILED`。此前的 `requestAnimationFrame` 聚焦实验未解决该问题，未进入稳定分支；Safari 与已测试的 Edge 路径正常只是已有真机/浏览器记录，不构成所有版本的普遍保证。本次 alpha.3 发布不修复也不声称修复 iOS Firefox beta；失败热修复分支 `fix/ios-firefox-modal-focus-alpha2` 不复制、不合并、不修改。
+
+发布、标签、回滚与停止公开试玩说明见 [`docs/PHASE12_REACTION_FIELD_WEB_PLAYTEST_FREEZE.md`](docs/PHASE12_REACTION_FIELD_WEB_PLAYTEST_FREEZE.md)。Phase 11 是历史稳定性基线；规则边界继续由 [`docs/MVP0_RULE_FREEZE.md`](docs/MVP0_RULE_FREEZE.md)、[`docs/PHASE8_CHARACTER_RULE_FREEZE.md`](docs/PHASE8_CHARACTER_RULE_FREEZE.md)、[`docs/PHASE9_DEBUG_UI_RULE_FREEZE.md`](docs/PHASE9_DEBUG_UI_RULE_FREEZE.md) 和 [`docs/PHASE10_REACTION_EVENT_RULE_FREEZE.md`](docs/PHASE10_REACTION_EVENT_RULE_FREEZE.md) 冻结；阶段总览见 [`docs/MVP_PLAN.md`](docs/MVP_PLAN.md)。
+
+## 许可证
+
+- Source code: [Apache-2.0](LICENSE)，版权归 `Copyright 2026 Nulledge and Reaction Field contributors` 所有；归属说明见 [NOTICE](NOTICE)。
+- Brand assets: `public/brand/**` 由 [品牌资产说明](docs/REACTION_FIELD_BRAND_ASSETS.md) 单独管理，不属于 Apache-2.0 源代码授权范围。
+- Third-party dependencies and assets: 继续受各自许可证约束。

--- a/docs/ALPHA4_INTERNATIONAL_PLAYTEST_FREEZE.md
+++ b/docs/ALPHA4_INTERNATIONAL_PLAYTEST_FREEZE.md
@@ -1,0 +1,24 @@
+# Alpha 4 国际试玩展示层冻结
+
+本文件仅冻结 Reaction Field Alpha 4 的展示层与反馈入口边界；不修改 MVP0–P10、Phase 8–13 的游戏规则、引擎、数据、卡池或发布身份。
+
+## 展示语言
+
+- 既有完整简体中文界面继续保留。
+- React 页面生命周期内可手动切换简体中文和 English；初始建议只读取 `navigator.languages` / `navigator.language`，任一首选语言以 `en` 开头时建议 English，否则建议简体中文。
+- 手动选择不使用浏览器存储、URL、cookie、网络 API 或遥测；刷新后重新采用浏览器语言建议。
+- `<html lang>` 随当前展示语言更新为 `zh-CN` 或 `en`。
+- 英文名称只能由稳定角色、卡牌定义、技能、DIY、状态或 reaction ID，以及既有结构化展示模型导出；不得解析中文字符串、普通日志或 `rulesText`，也不得复制 reducer 逻辑。
+- 普通 engine 正式日志、debug `rulesText`、技术 ID、错误码、应用版本和规则版本继续保持原有合同。英文模式必须明确普通正式日志目前仍为简体中文。
+
+## Forms 反馈入口
+
+- 唯一 Forms 配置位于 `src/app/feedback.tsx`；它只渲染静态普通 `<a>`，并以 `target="_blank" rel="noopener noreferrer"` 打开。
+- 入口位于全局页头，README 也提供同一填写者链接。不会使用 `window.open`、fetch、XHR、sendBeacon、自动提交、预填 query 参数、运行时数据拼接或遥测。
+- 游戏不向 Forms 传递手牌、日志、角色、浏览器信息、错误诊断、语言偏好或任何 `GameState` 内容；About 仅保留双语隐私说明，不重复反馈链接。
+- 缺少配置时不渲染可点击入口；不得使用 `#` 或备用站点。
+
+## 保留边界
+
+- 不修改 `src/game/engine/**`、`src/game/data/**`、`src/game/tests/**`、`ModalDialog` 焦点逻辑、版本、锁文件、发布元数据、Vite/Playwright 配置、品牌资源、CI、标签、Release、Pages 或 GitHub 设置。
+- 不声称已修复 iOS 27 beta Firefox 的已知 modal/root failure；该问题不在 Alpha 4 范围。

--- a/e2e/fixtureApp.tsx
+++ b/e2e/fixtureApp.tsx
@@ -2,6 +2,7 @@ import { StrictMode, useSyncExternalStore } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "../src/app/App";
 import { installBrowserFatalHandlers } from "../src/app/browserFatalHandlers";
+import { LocaleProvider } from "../src/app/locale";
 import { RootErrorBoundary } from "../src/app/RootErrorBoundary";
 import { RootFailurePage } from "../src/app/RootFailurePage";
 import "../src/styles.css";
@@ -54,25 +55,31 @@ if (!rootElement) {
       return;
     }
     rootFailed = true;
-    root.render(<RootFailurePage code="ROOT_RUNTIME_FAILED" />);
+    root.render(
+      <LocaleProvider>
+        <RootFailurePage code="ROOT_RUNTIME_FAILED" />
+      </LocaleProvider>,
+    );
   };
   installBrowserFatalHandlers(renderRootFailure);
 
   root.render(
     <StrictMode>
-      <RootErrorBoundary>
-        {scenario === "render-error" ? (
-          <ThrowingFixture />
-        ) : (
-          <>
-            <FixtureDiagnostics />
-            <App
-              createGame={deterministicFixtureFactory}
-              createSession={getFixtureInitializer(readFixtureScenario())}
-            />
-          </>
-        )}
-      </RootErrorBoundary>
+      <LocaleProvider>
+        <RootErrorBoundary>
+          {scenario === "render-error" ? (
+            <ThrowingFixture />
+          ) : (
+            <>
+              <FixtureDiagnostics />
+              <App
+                createGame={deterministicFixtureFactory}
+                createSession={getFixtureInitializer(readFixtureScenario())}
+              />
+            </>
+          )}
+        </RootErrorBoundary>
+      </LocaleProvider>
     </StrictMode>,
   );
 }

--- a/e2e/production/reaction-field.spec.ts
+++ b/e2e/production/reaction-field.spec.ts
@@ -58,6 +58,19 @@ const test = base.extend<{
   },
 });
 
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(Navigator.prototype, "language", {
+      configurable: true,
+      get: () => "zh-CN",
+    });
+    Object.defineProperty(Navigator.prototype, "languages", {
+      configurable: true,
+      get: () => ["zh-CN"],
+    });
+  });
+});
+
 async function expectNoHorizontalOverflow(page: Page) {
   const widths = await page.evaluate(() => ({
     bodyClient: document.body.clientWidth,
@@ -123,6 +136,10 @@ for (const [path, assetPrefix, brandPrefix] of [["/", "/assets/", "/"], ["/playt
     await expect(page.getByRole("heading", { name: "反应域 · 本地双人角色选择" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "新手引导：配置" })).toBeVisible();
     await expect(page.locator(".release-bar .secondary-brand")).toHaveText("REACTION FIELD");
+    const feedback = page.getByRole("link", { name: "在新标签页打开 Microsoft Forms 反馈表" });
+    await expect(feedback).toHaveAttribute("href", "https://forms.cloud.microsoft/r/QG8PACUnsa");
+    await expect(feedback).toHaveAttribute("target", "_blank");
+    await expect(feedback).toHaveAttribute("rel", "noopener noreferrer");
     await expect(page.locator(".character-selection-hero__icon")).toBeVisible();
     await expect(page.locator(".character-selection-hero__icon")).toHaveAttribute("alt", "");
     await expect(page.locator(".character-selection-hero__icon")).toHaveAttribute("aria-hidden", "true");

--- a/e2e/tests/debug-alpha.spec.ts
+++ b/e2e/tests/debug-alpha.spec.ts
@@ -18,6 +18,19 @@ const test = base.extend<{ runtimeErrors: string[] }>({
   },
 });
 
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(Navigator.prototype, "language", {
+      configurable: true,
+      get: () => "zh-CN",
+    });
+    Object.defineProperty(Navigator.prototype, "languages", {
+      configurable: true,
+      get: () => ["zh-CN"],
+    });
+  });
+});
+
 async function startNoTeacherGame(page: Page) {
   await page.goto("/");
   await page.getByLabel("player_1 角色").selectOption("chemical_factory_ceo");
@@ -114,6 +127,117 @@ async function openAndCloseAbout(page: Page) {
   await expect(dialog).toBeHidden();
   await expect(aboutTrigger).toBeFocused();
 }
+
+test("Alpha 4 language layer changes only presentation and keeps feedback static", async ({ page, runtimeErrors }) => {
+  void runtimeErrors;
+  await startNoTeacherGame(page);
+
+  const beforeLanguageSwitch = await page.evaluate(() => ({
+    cards: document.querySelectorAll(".debug-card").length,
+    detailText: document.querySelector(".debug-detail-list")?.textContent ?? "",
+    logEntries: Array.from(document.querySelectorAll(".game-log li")).map((entry) => entry.textContent),
+    phase: Array.from(document.querySelectorAll(".debug-detail-list > div")).find(
+      (row) => row.querySelector("dt")?.textContent === "phase",
+    )?.querySelector("dd")?.textContent ?? null,
+  }));
+
+  await page.getByRole("button", { name: "English" }).click();
+  await expect(page.locator("html")).toHaveAttribute("lang", "en");
+  await expect(page.getByRole("heading", { exact: true, name: "Main action" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "New player guidance: Main action" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Full game log" })).toBeVisible();
+  await expect(page.getByText("The formal game record currently remains in Simplified Chinese.", { exact: false })).toBeVisible();
+
+  const feedback = page.getByRole("link", { name: "Open Microsoft Forms feedback in a new tab" });
+  await expect(feedback).toHaveAttribute("href", "https://forms.cloud.microsoft/r/QG8PACUnsa");
+  await expect(feedback).toHaveAttribute("target", "_blank");
+  await expect(feedback).toHaveAttribute("rel", "noopener noreferrer");
+
+  expect(await page.evaluate(() => ({
+    cookie: document.cookie,
+    localStorage: window.localStorage.length,
+    sessionStorage: window.sessionStorage.length,
+    formsRequests: performance.getEntriesByType("resource").filter((entry) =>
+      entry.name.includes("forms.cloud.microsoft"),
+    ).length,
+  }))).toEqual({ cookie: "", localStorage: 0, sessionStorage: 0, formsRequests: 0 });
+
+  await page.getByRole("button", { name: "中文" }).click();
+  await expect(page.locator("html")).toHaveAttribute("lang", "zh-CN");
+  expect(await page.evaluate(() => ({
+    cards: document.querySelectorAll(".debug-card").length,
+    detailText: document.querySelector(".debug-detail-list")?.textContent ?? "",
+    logEntries: Array.from(document.querySelectorAll(".game-log li")).map((entry) => entry.textContent),
+    phase: Array.from(document.querySelectorAll(".debug-detail-list > div")).find(
+      (row) => row.querySelector("dt")?.textContent === "phase",
+    )?.querySelector("dd")?.textContent ?? null,
+  }))).toEqual(beforeLanguageSwitch);
+
+  await page.getByRole("button", { name: "English" }).click();
+  await page.reload();
+  await expect(page.locator("html")).toHaveAttribute("lang", "zh-CN");
+  await expect(page.getByRole("heading", { name: "反应域 · 本地双人角色选择" })).toBeVisible();
+});
+
+test("Alpha 4 suggests English from an English browser preference", async ({ page, runtimeErrors }) => {
+  void runtimeErrors;
+  await page.addInitScript(() => {
+    Object.defineProperty(Navigator.prototype, "language", {
+      configurable: true,
+      get: () => "en-US",
+    });
+    Object.defineProperty(Navigator.prototype, "languages", {
+      configurable: true,
+      get: () => ["zh-CN", "en-US"],
+    });
+  });
+  await page.goto("/");
+
+  await expect(page.locator("html")).toHaveAttribute("lang", "en");
+  await expect(page.getByRole("heading", {
+    name: "REACTION FIELD · Local two-player character selection",
+  })).toBeVisible();
+  await expect(page.getByLabel("player_1 character")).toHaveValue("laboratory_teacher");
+});
+
+test("Alpha 4 English display covers setup, all public phases, dialogs, and fatal fallback", async ({ page, runtimeErrors }) => {
+  void runtimeErrors;
+  const switchToEnglish = async (path: string) => {
+    await page.goto(path);
+    await page.getByRole("button", { name: "English" }).click();
+    await expect(page.locator("html")).toHaveAttribute("lang", "en");
+  };
+
+  await switchToEnglish("/");
+  await expect(page.getByRole("heading", { name: "REACTION FIELD · Local two-player character selection" })).toBeVisible();
+  await page.getByRole("button", { name: "About & help" }).click();
+  await expect(page.getByRole("dialog", { name: "About & help" })).toBeVisible();
+  await page.getByRole("button", { name: "Close help" }).click();
+
+  await page.getByRole("button", { name: "Start game" }).click();
+  await expect(page.getByRole("heading", { name: "Laboratory Teacher · Preparation" })).toBeVisible();
+
+  await startNoTeacherGame(page);
+  await page.getByRole("button", { name: "English" }).click();
+  await expect(page.getByRole("heading", { name: "Main action", exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "End this action" }).click();
+  await page.getByRole("button", { name: "Restart with current lineup" }).click();
+  await expect(page.getByRole("alertdialog", { name: "Restart with the current lineup?" })).toBeVisible();
+  await page.getByRole("button", { name: "Cancel" }).click();
+
+  await switchToEnglish("/?scenario=response-window");
+  await expect(page.getByRole("heading", { name: "Response window" })).toBeVisible();
+  await switchToEnglish("/?scenario=status-window");
+  await expect(page.getByRole("heading", { name: "Status handling window" })).toBeVisible();
+  await switchToEnglish("/?scenario=experiment-counterattack-window");
+  await expect(page.getByRole("heading", { name: "Experiment Counterattack selection" })).toBeVisible();
+  await switchToEnglish("/?scenario=reaction-h2o");
+  await expect(page.getByText("Successful reaction · Acid-base neutralization", { exact: true })).toBeVisible();
+  await switchToEnglish("/?scenario=game-over");
+  await expect(page.getByRole("heading", { name: "Game over", exact: true })).toBeVisible();
+  await switchToEnglish("/?scenario=fatal");
+  await expect(page.getByRole("heading", { name: "The current game stopped safely" })).toBeVisible();
+});
 
 test("默认配置、正式元数据与 configuring 帮助界面", async ({ page, runtimeErrors }) => {
   void runtimeErrors;

--- a/src/app/RootErrorBoundary.test.tsx
+++ b/src/app/RootErrorBoundary.test.tsx
@@ -28,7 +28,7 @@ describe("Phase 11 React ErrorBoundary", () => {
       expect(container.textContent).toContain("页面遇到无法继续处理的错误");
       expect(container.textContent).toContain("UI_RENDER_FAILED");
       expect(container.textContent).not.toContain("PRIVATE_STACK_AND_GAME_STATE");
-      expect(container.querySelector("button")?.textContent).toBe("重新加载页面");
+      expect(container.querySelector(".root-failure-card button")?.textContent).toBe("重新加载页面");
     } finally {
       await act(async () => root.unmount());
       container.remove();

--- a/src/app/RootFailurePage.tsx
+++ b/src/app/RootFailurePage.tsx
@@ -1,3 +1,5 @@
+import { FeedbackLink } from "./feedback";
+import { LocaleSwitch, useLocale } from "./locale";
 import { releaseMetadata } from "./releaseMetadata";
 
 export type RootFailureCode = "UI_RENDER_FAILED" | "ROOT_RUNTIME_FAILED";
@@ -7,27 +9,44 @@ type RootFailurePageProps = Readonly<{
 }>;
 
 export function RootFailurePage({ code }: RootFailurePageProps) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
+
   return (
     <main className="root-failure-page">
+      <header className="release-bar">
+        <div>
+          <strong>{releaseMetadata.displayName} · {releaseMetadata.secondaryName}</strong>
+          <span>{releaseMetadata.channel} · v{releaseMetadata.version} · {releaseMetadata.rulesVersion}</span>
+        </div>
+        <div className="release-bar__actions">
+          <LocaleSwitch />
+          <FeedbackLink />
+        </div>
+      </header>
       <section className="root-failure-card" role="alert" aria-labelledby="root-failure-title">
-        <p className="debug-kicker">{releaseMetadata.channel} · 安全兜底</p>
-        <h1 id="root-failure-title">页面遇到无法继续处理的错误</h1>
+        <p className="debug-kicker">{releaseMetadata.channel} · {isEnglish ? "Safe fallback" : "安全兜底"}</p>
+        <h1 id="root-failure-title">
+          {isEnglish ? "The page encountered an unrecoverable error" : "页面遇到无法继续处理的错误"}
+        </h1>
         <p>
-          为避免继续运行不确定状态，当前界面已经停止。不会上传对局、手牌、日志或异常详情。
+          {isEnglish
+            ? "The interface stopped to avoid continuing with uncertain state. No game, hand, log, or error detail is uploaded."
+            : "为避免继续运行不确定状态，当前界面已经停止。不会上传对局、手牌、日志或异常详情。"}
         </p>
         <dl className="failure-diagnostics">
-          <div><dt>名称</dt><dd>{releaseMetadata.displayName}</dd></div>
-          <div><dt>应用版本</dt><dd>{releaseMetadata.version}</dd></div>
-          <div><dt>规则版本</dt><dd>{releaseMetadata.rulesVersion}</dd></div>
+          <div><dt>{isEnglish ? "Name" : "名称"}</dt><dd>{releaseMetadata.displayName}</dd></div>
+          <div><dt>{isEnglish ? "App version" : "应用版本"}</dt><dd>{releaseMetadata.version}</dd></div>
+          <div><dt>{isEnglish ? "Rules version" : "规则版本"}</dt><dd>{releaseMetadata.rulesVersion}</dd></div>
           <div><dt>Commit</dt><dd>{releaseMetadata.commit}</dd></div>
-          <div><dt>错误码</dt><dd>{code}</dd></div>
+          <div><dt>{isEnglish ? "Error code" : "错误码"}</dt><dd>{code}</dd></div>
         </dl>
         <button
           className="primary-button"
           onClick={() => window.location.reload()}
           type="button"
         >
-          重新加载页面
+          {isEnglish ? "Reload page" : "重新加载页面"}
         </button>
       </section>
     </main>

--- a/src/app/feedback.test.tsx
+++ b/src/app/feedback.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it } from "vitest";
+import { FeedbackLink, feedbackFormUrl } from "./feedback";
+
+describe("Alpha 4 feedback link", () => {
+  it("uses only the approved static Forms endpoint and safe new-tab attributes", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => root.render(createElement(FeedbackLink)));
+      const link = container.querySelector("a");
+
+      expect(feedbackFormUrl).toBe("https://forms.cloud.microsoft/r/QG8PACUnsa");
+      expect(link?.getAttribute("href")).toBe(feedbackFormUrl);
+      expect(link?.getAttribute("target")).toBe("_blank");
+      expect(link?.getAttribute("rel")).toBe("noopener noreferrer");
+      expect(link?.getAttribute("aria-label")).toContain("Microsoft Forms");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+});

--- a/src/app/feedback.tsx
+++ b/src/app/feedback.tsx
@@ -1,0 +1,28 @@
+import { useLocale } from "./locale";
+
+// This is the sole Forms endpoint. It intentionally carries no game or browser data.
+export const feedbackFormUrl: string | undefined = "https://forms.cloud.microsoft/r/QG8PACUnsa";
+
+export function FeedbackLink() {
+  const { locale } = useLocale();
+
+  if (!feedbackFormUrl) {
+    return null;
+  }
+
+  const label = locale === "en"
+    ? "Open Microsoft Forms feedback in a new tab"
+    : "在新标签页打开 Microsoft Forms 反馈表";
+
+  return (
+    <a
+      aria-label={label}
+      className="feedback-link"
+      href={feedbackFormUrl}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      {locale === "en" ? "Feedback (opens Microsoft Forms in a new tab)" : "反馈（将在新标签页打开 Microsoft Forms）"}
+    </a>
+  );
+}

--- a/src/app/locale.test.tsx
+++ b/src/app/locale.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it } from "vitest";
+import {
+  getSuggestedDisplayLocale,
+  LocaleProvider,
+  LocaleSwitch,
+  useLocale,
+} from "./locale";
+
+function LocaleProbe() {
+  const { locale } = useLocale();
+  return <output>{locale}</output>;
+}
+
+describe("Alpha 4 display locale", () => {
+  it("suggests English when any browser language preference begins with en", () => {
+    expect(getSuggestedDisplayLocale(["zh-CN", "en-GB"], "zh-CN")).toBe("en");
+    expect(getSuggestedDisplayLocale(undefined, "en-US")).toBe("en");
+  });
+
+  it("otherwise suggests Simplified Chinese", () => {
+    expect(getSuggestedDisplayLocale(["zh-CN", "ja-JP"], "en-US")).toBe("zh-CN");
+    expect(getSuggestedDisplayLocale(undefined, undefined)).toBe("zh-CN");
+  });
+
+  it("switches display language in React state and updates html lang", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <LocaleProvider>
+            <LocaleProbe />
+            <LocaleSwitch />
+          </LocaleProvider>,
+        );
+      });
+
+      await act(async () => {
+        (Array.from(container.querySelectorAll("button")).find(
+          (button) => button.textContent === "English",
+        ) as HTMLButtonElement).click();
+      });
+
+      expect(container.querySelector("output")?.textContent).toBe("en");
+      expect(document.documentElement.lang).toBe("en");
+      expect(container.querySelector('button[aria-pressed="true"]')?.textContent).toBe("English");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+});

--- a/src/app/locale.tsx
+++ b/src/app/locale.tsx
@@ -1,0 +1,86 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type DisplayLocale = "zh-CN" | "en";
+
+type LocaleContextValue = Readonly<{
+  locale: DisplayLocale;
+  setLocale: (locale: DisplayLocale) => void;
+}>;
+
+const defaultLocaleContext: LocaleContextValue = {
+  locale: "zh-CN",
+  setLocale: () => undefined,
+};
+
+const LocaleContext = createContext<LocaleContextValue>(defaultLocaleContext);
+
+export function getSuggestedDisplayLocale(
+  languages: readonly string[] | undefined,
+  language: string | undefined,
+): DisplayLocale {
+  const preferences = languages && languages.length > 0 ? languages : [language ?? ""];
+
+  return preferences.some((preference) => preference.toLowerCase().startsWith("en"))
+    ? "en"
+    : "zh-CN";
+}
+
+export function getBrowserSuggestedDisplayLocale(): DisplayLocale {
+  if (typeof navigator === "undefined") {
+    return "zh-CN";
+  }
+
+  return getSuggestedDisplayLocale(navigator.languages, navigator.language);
+}
+
+export function LocaleProvider({ children }: Readonly<{ children: ReactNode }>) {
+  const [locale, setLocale] = useState<DisplayLocale>(getBrowserSuggestedDisplayLocale);
+  const value = useMemo(() => ({ locale, setLocale }), [locale]);
+
+  useEffect(() => {
+    document.documentElement.lang = locale;
+  }, [locale]);
+
+  return <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>;
+}
+
+export function useLocale(): LocaleContextValue {
+  return useContext(LocaleContext);
+}
+
+export function LocaleSwitch() {
+  const { locale, setLocale } = useLocale();
+  const isEnglish = locale === "en";
+
+  return (
+    <div
+      aria-label={isEnglish ? "Display language" : "展示语言"}
+      className="locale-switch"
+      role="group"
+    >
+      <button
+        aria-pressed={!isEnglish}
+        className="locale-switch__button"
+        onClick={() => setLocale("zh-CN")}
+        type="button"
+      >
+        中文
+      </button>
+      <button
+        aria-pressed={isEnglish}
+        className="locale-switch__button"
+        onClick={() => setLocale("en")}
+        type="button"
+      >
+        English
+      </button>
+    </div>
+  );
+}

--- a/src/features/local-game/LocalGamePage.tsx
+++ b/src/features/local-game/LocalGamePage.tsx
@@ -1,5 +1,7 @@
 import "./local-game.css";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { FeedbackLink } from "../../app/feedback";
+import { LocaleSwitch, useLocale } from "../../app/locale";
 import { releaseMetadata } from "../../app/releaseMetadata";
 import type { GameAction } from "../../game/engine/actions";
 import type { CardInstanceId } from "../../game/engine/types";
@@ -53,6 +55,8 @@ function PlayingGame({
   onRequestSessionExit,
 }: PlayingGameProps) {
   const { game, error } = session;
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
   const [selectedCardId, setSelectedCardId] = useState<CardInstanceId | undefined>();
 
   useEffect(() => {
@@ -89,7 +93,7 @@ function PlayingGame({
           </div>
           <GameLog game={game} />
         </div>
-        <aside className="debug-sidebar" aria-label="操作面板">
+        <aside className="debug-sidebar" aria-label={isEnglish ? "Action panels" : "操作面板"}>
           <NewPlayerGuidance
             collapsed={guidanceCollapsed}
             game={game}
@@ -120,9 +124,9 @@ function PlayingGame({
           )}
           {game.phase === "gameOver" ? (
             <section className="debug-section">
-              <h2>对局结束</h2>
+              <h2>{isEnglish ? "Game over" : "对局结束"}</h2>
               <p className="panel-note">
-                可以查看完整日志，或使用顶部“按当前阵容重开”“返回角色选择”。
+                {isEnglish ? "Review the full log, or use the header to restart with the current lineup or return to character selection." : "可以查看完整日志，或使用顶部“按当前阵容重开”“返回角色选择”。"}
               </p>
             </section>
           ) : null}
@@ -148,6 +152,8 @@ export function LocalGamePage({
   reduceGame,
   createSession,
 }: LocalGamePageProps = {}) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
   const [session, dispatch] = useLocalGameDebug(createGame, reduceGame, createSession);
   const [aboutOpen, setAboutOpen] = useState(false);
   const [confirmation, setConfirmation] = useState<PendingSessionConfirmation | null>(null);
@@ -247,14 +253,18 @@ export function LocalGamePage({
               {releaseMetadata.channel} · v{releaseMetadata.version} · {releaseMetadata.rulesVersion}
             </span>
           </div>
-          <button
-            className="secondary-button"
-            onClick={openAbout}
-            ref={aboutTriggerRef}
-            type="button"
-          >
-            关于与帮助
-          </button>
+          <div className="release-bar__actions">
+            <LocaleSwitch />
+            <FeedbackLink />
+            <button
+              className="secondary-button"
+              onClick={openAbout}
+              ref={aboutTriggerRef}
+              type="button"
+            >
+              {isEnglish ? "About & help" : "关于与帮助"}
+            </button>
+          </div>
         </header>
 
         {session.mode === "configuring" ? (

--- a/src/features/local-game/characterPresentation.ts
+++ b/src/features/local-game/characterPresentation.ts
@@ -3,6 +3,13 @@ import type {
   CharacterSkillImplementationStatus,
   CharacterSkillType,
 } from "../../game/engine/types";
+import type { DisplayLocale } from "../../app/locale";
+import {
+  getImplementationStatusDisplayName,
+  getSkillAvailabilityDisplayName,
+  getSkillDisplayName,
+  getSkillTypeDisplayName,
+} from "./presentationLocale";
 
 export const skillTypeLabels: Record<CharacterSkillType, string> = {
   active: "主动",
@@ -32,16 +39,13 @@ export type PublicCharacterSkill = Readonly<{
   availability: string;
 }>;
 
-function publicAvailability(status: CharacterSkillImplementationStatus) {
-  if (status === "implemented-8c-4-partial") return "当前试玩部分可用";
-  if (status.startsWith("implemented")) return "当前试玩可用";
-  return "当前试玩为说明项";
-}
-
-export function getPublicCharacterSkills(character: CharacterDefinition): readonly PublicCharacterSkill[] {
+export function getPublicCharacterSkills(
+  character: CharacterDefinition,
+  locale: DisplayLocale = "zh-CN",
+): readonly PublicCharacterSkill[] {
   return character.skills.map((skill) => ({
-    name: skill.name,
-    type: skillTypeLabels[skill.type],
-    availability: publicAvailability(skill.implementationStatus),
+    name: getSkillDisplayName(skill.id, locale),
+    type: getSkillTypeDisplayName(skill.type, locale),
+    availability: getSkillAvailabilityDisplayName(skill.implementationStatus, locale),
   }));
 }

--- a/src/features/local-game/components/AboutDialog.tsx
+++ b/src/features/local-game/components/AboutDialog.tsx
@@ -1,11 +1,15 @@
 import { useRef } from "react";
+import { useLocale } from "../../../app/locale";
 import { releaseMetadata } from "../../../app/releaseMetadata";
 import { characterDefinitions } from "../../../game/data/characterDefinitions";
 import {
   getPublicCharacterSkills,
-  implementationStatusLabels,
-  skillTypeLabels,
 } from "../characterPresentation";
+import {
+  getCharacterDisplayName,
+  getImplementationStatusDisplayName,
+  getSkillTypeDisplayName,
+} from "../presentationLocale";
 import { ModalDialog } from "./ModalDialog";
 
 type AboutDialogProps = Readonly<{
@@ -14,6 +18,8 @@ type AboutDialogProps = Readonly<{
 
 export function AboutDialog({ onClose }: AboutDialogProps) {
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
 
   return (
     <ModalDialog
@@ -27,7 +33,7 @@ export function AboutDialog({ onClose }: AboutDialogProps) {
         <div className="modal-heading">
           <div>
             <p className="debug-kicker">{releaseMetadata.channel}</p>
-            <h2 id="about-title">关于与帮助</h2>
+            <h2 id="about-title">{isEnglish ? "About & help" : "关于与帮助"}</h2>
           </div>
           <button
             className="secondary-button"
@@ -35,53 +41,53 @@ export function AboutDialog({ onClose }: AboutDialogProps) {
             ref={closeButtonRef}
             type="button"
           >
-            关闭帮助
+            {isEnglish ? "Close help" : "关闭帮助"}
           </button>
         </div>
 
         <p id="about-description">
-          查看当前试玩版的发布身份、操作方式、角色实现状态与安全边界。
+          {isEnglish ? "Review this playtest's release identity, controls, character implementation status, and safety boundaries." : "查看当前试玩版的发布身份、操作方式、角色实现状态与安全边界。"}
         </p>
 
         <section className="about-section" aria-labelledby="about-release-title">
           <h3 id="about-release-title">{releaseMetadata.displayName} <span className="secondary-brand">{releaseMetadata.secondaryName}</span></h3>
           <dl className="about-metadata">
-            <div><dt>发布渠道</dt><dd>{releaseMetadata.channel}</dd></div>
-            <div><dt>应用版本</dt><dd>{releaseMetadata.version}</dd></div>
-            <div><dt>规则版本</dt><dd>{releaseMetadata.rulesVersion}</dd></div>
+            <div><dt>{isEnglish ? "Release channel" : "发布渠道"}</dt><dd>{releaseMetadata.channel}</dd></div>
+            <div><dt>{isEnglish ? "App version" : "应用版本"}</dt><dd>{releaseMetadata.version}</dd></div>
+            <div><dt>{isEnglish ? "Rules version" : "规则版本"}</dt><dd>{releaseMetadata.rulesVersion}</dd></div>
             <div><dt>Commit</dt><dd>{releaseMetadata.commit}</dd></div>
           </dl>
         </section>
 
         <section className="about-section">
-          <h3>当前能力与基本操作</h3>
+          <h3>{isEnglish ? "Current capabilities and basic controls" : "当前能力与基本操作"}</h3>
           <ul>
-            <li>本地同屏双人公开对局；双方手牌、牌堆数量、状态与完整日志均公开。</li>
-            <li>选择双方角色后开始；按当前阶段完成备课、主行动、响应、状态处理与角色技能。</li>
-            <li>酸碱响应可取消伤害；酸与碳酸盐可生成虚拟 CO2；碱性牌可处理即时或待处理效果。</li>
-            <li>主动 DIY 每名玩家每周期一次；角色技能与成功反应事件按正式定义和日志展示。</li>
-            <li>对局进行中重开或返回角色选择需要二次确认；对局结束后可直接执行。</li>
+            <li>{isEnglish ? "A local shared-screen public two-player game; both hands, deck counts, statuses, and the full log are public." : "本地同屏双人公开对局；双方手牌、牌堆数量、状态与完整日志均公开。"}</li>
+            <li>{isEnglish ? "Choose both characters, then complete preparation, main action, response, status handling, and character skills for the current phase." : "选择双方角色后开始；按当前阶段完成备课、主行动、响应、状态处理与角色技能。"}</li>
+            <li>{isEnglish ? "Acid-base responses can cancel damage; acid and carbonate can produce virtual CO2; alkaline cards can handle immediate or pending effects." : "酸碱响应可取消伤害；酸与碳酸盐可生成虚拟 CO2；碱性牌可处理即时或待处理效果。"}</li>
+            <li>{isEnglish ? "Each player may use active DIY once per cycle; character skills and successful reaction events follow their formal definitions and log display." : "主动 DIY 每名玩家每周期一次；角色技能与成功反应事件按正式定义和日志展示。"}</li>
+            <li>{isEnglish ? "Restarting or returning during a game needs confirmation; after game over these actions run directly." : "对局进行中重开或返回角色选择需要二次确认；对局结束后可直接执行。"}</li>
           </ul>
         </section>
 
         <section className="about-section">
-          <h3>首局速查</h3>
+          <h3>{isEnglish ? "First-game quick guide" : "首局速查"}</h3>
           <ul>
-            <li>先在角色选择页确认本地同屏双人阵容；双方手牌始终公开。</li>
-            <li>按当前阶段面板完成备课、主行动、响应、状态处理或实验反击；完整规则以帮助与冻结文档为准。</li>
-            <li>响应 DIY 关闭。酸碱中和产生虚拟 H2O；酸与碳酸盐产生虚拟 CO2；两者只记录结果，不创建 CardInstance。</li>
-            <li>普通实体卡池固定为 68 张；真实金属、方程式、沉淀与通用反应链仍延期。</li>
+            <li>{isEnglish ? "Confirm a local shared-screen two-player lineup on the character selection page; both hands remain public." : "先在角色选择页确认本地同屏双人阵容；双方手牌始终公开。"}</li>
+            <li>{isEnglish ? "Use the panel for the current phase to complete preparation, main action, response, status handling, or Experiment Counterattack. The help and freeze documents remain authoritative." : "按当前阶段面板完成备课、主行动、响应、状态处理或实验反击；完整规则以帮助与冻结文档为准。"}</li>
+            <li>{isEnglish ? "Response DIY is disabled. Acid-base neutralization produces virtual H2O and acid-carbonate produces virtual CO2; both only record results and create no CardInstance." : "响应 DIY 关闭。酸碱中和产生虚拟 H2O；酸与碳酸盐产生虚拟 CO2；两者只记录结果，不创建 CardInstance。"}</li>
+            <li>{isEnglish ? "The ordinary physical card pool is fixed at 68. Real metals, equations, precipitation, and general reaction chains remain deferred." : "普通实体卡池固定为 68 张；真实金属、方程式、沉淀与通用反应链仍延期。"}</li>
           </ul>
         </section>
 
         <section className="about-section">
-          <h3>七个角色与试玩能力</h3>
+          <h3>{isEnglish ? "Seven characters and playtest capabilities" : "七个角色与试玩能力"}</h3>
           <div className="about-character-grid">
             {characterDefinitions.map((character) => (
               <article key={character.id}>
-                <h4>{character.name} · {character.maxHp} HP</h4>
+                <h4>{getCharacterDisplayName(character.id, locale)} · {character.maxHp} HP</h4>
                 <ul>
-                  {getPublicCharacterSkills(character).map((skill) => (
+                  {getPublicCharacterSkills(character, locale).map((skill) => (
                     <li key={skill.name}>
                       {skill.name}：{skill.type} · {skill.availability}
                     </li>
@@ -91,24 +97,25 @@ export function AboutDialog({ onClose }: AboutDialogProps) {
             ))}
           </div>
           <p>
-            “实验反击”在当前试玩中提供部分选择；这里仅展示角色定义的公开摘要，不复制规则执行逻辑。
+            {isEnglish ? "Experiment Counterattack offers partial choices in this playtest. This area shows only public summaries from character definitions and does not copy rule execution logic." : "“实验反击”在当前试玩中提供部分选择；这里仅展示角色定义的公开摘要，不复制规则执行逻辑。"}
           </p>
           <details className="debug-details">
-            <summary>调试详情</summary>
+            <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
             {characterDefinitions.map((character) => character.skills.map((skill) => (
-              <p key={skill.id}>{character.id} · {skill.id} · {skillTypeLabels[skill.type]} · {implementationStatusLabels[skill.implementationStatus]} · {skill.rulesText}{"implementationNote" in skill && skill.implementationNote ? ` · ${skill.implementationNote}` : ""}</p>
+              <p key={skill.id}>{character.id} · {skill.id} · {getSkillTypeDisplayName(skill.type, locale)} · {getImplementationStatusDisplayName(skill.implementationStatus, locale)} · {skill.rulesText}{"implementationNote" in skill && skill.implementationNote ? ` · ${skill.implementationNote}` : ""}</p>
             )))}
           </details>
         </section>
 
         <section className="about-section">
-          <h3>数据、安全与内容边界</h3>
+          <h3>{isEnglish ? "Data, safety, and content boundaries" : "数据、安全与内容边界"}</h3>
           <ul>
-            <li>零网络遥测，无账号、无联网、无存档；刷新会丢失当前对局并回到默认角色预选。</li>
-            <li>普通实体卡池固定为 68 张；虚拟 H2O、CO2 与技能结果不会创建额外普通 CardInstance。</li>
-            <li>金属反击、方程式、沉淀、响应 DIY、多人、房间、回放和桌面安装均延期。</li>
-            <li>本地安全错误报告只包含名称、应用版本、规则版本、commit、稳定错误码和非敏感运行环境概要。</li>
+            <li>{isEnglish ? "No game telemetry, accounts, online play, or saves; refreshing discards the current game and returns to the default selections." : "零网络遥测，无账号、无联网、无存档；刷新会丢失当前对局并回到默认角色预选。"}</li>
+            <li>{isEnglish ? "The ordinary physical card pool is fixed at 68; virtual H2O, CO2, and skill results never create extra ordinary CardInstances." : "普通实体卡池固定为 68 张；虚拟 H2O、CO2 与技能结果不会创建额外普通 CardInstance。"}</li>
+            <li>{isEnglish ? "Metal counterattacks, equations, precipitation, response DIY, multiplayer, rooms, replays, and desktop installation are deferred." : "金属反击、方程式、沉淀、响应 DIY、多人、房间、回放和桌面安装均延期。"}</li>
+            <li>{isEnglish ? "Local safe diagnostics contain only the name, app version, rules version, commit, stable error code, and a non-sensitive environment summary." : "本地安全错误报告只包含名称、应用版本、规则版本、commit、稳定错误码和非敏感运行环境概要。"}</li>
           </ul>
+          <p className="panel-note">反馈 / Feedback：点击反馈将离开游戏，提交内容由 Microsoft Forms 处理。 / Clicking Feedback leaves the game and Microsoft Forms handles submitted content.</p>
         </section>
     </ModalDialog>
   );

--- a/src/features/local-game/components/ActionPanel.tsx
+++ b/src/features/local-game/components/ActionPanel.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { useLocale } from "../../../app/locale";
 import type { GameAction } from "../../../game/engine/actions";
 import type {
   CardInstanceId,
@@ -15,8 +16,12 @@ import {
   getAlkaliRecoveryCards,
   getCardDefinition,
   getOpponentTargets,
-  getPlayerName,
 } from "../localGameView";
+import {
+  getCardDisplayName,
+  getPlayerDisplayName,
+  getSkillDisplayName,
+} from "../presentationLocale";
 
 type ActionPanelProps = {
   game: GameState;
@@ -36,6 +41,8 @@ function CharacterSkillActions({
   activePlayer: NonNullable<ReturnType<typeof getActivePlayer>>;
   dispatchGameAction: (action: GameAction) => void;
 }) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
   const targets = getOpponentTargets(game, activePlayer.id);
 
   if (activePlayer.characterId === "caustic_soda_captain") {
@@ -46,8 +53,8 @@ function CharacterSkillActions({
     return (
       <div className="character-active-skill">
         <div>
-          <strong>碱液回收</strong>
-          <span>弃置一张实体强碱物质牌，回复 2 HP · 每周期一次</span>
+          <strong>{getSkillDisplayName("alkali_recovery", locale)}</strong>
+          <span>{isEnglish ? "Discard a physical strong-alkali substance card to recover 2 HP · once per cycle" : "弃置一张实体强碱物质牌，回复 2 HP · 每周期一次"}</span>
         </div>
         <div className="candidate-grid">
           {cards.length > 0 ? cards.map((cardInstanceId) => (
@@ -62,11 +69,16 @@ function CharacterSkillActions({
               })}
               type="button"
             >
-              使用 {getCardDefinition(game, cardInstanceId)?.name ?? cardInstanceId}
+              {isEnglish ? "Use" : "使用"} {(() => {
+                const definition = getCardDefinition(game, cardInstanceId);
+                return definition
+                  ? getCardDisplayName(definition.id, definition.name, locale)
+                  : cardInstanceId;
+              })()}
             </button>
           )) : (
             <button className="primary-button" disabled type="button">
-              {used ? "本周期已用" : "当前不可发动"}
+              {used ? (isEnglish ? "Used this cycle" : "本周期已用") : (isEnglish ? "Currently unavailable" : "当前不可发动")}
             </button>
           )}
         </div>
@@ -81,8 +93,8 @@ function CharacterSkillActions({
     return (
       <div className="character-active-skill">
         <div>
-          <strong>排放尾气</strong>
-          <span>使一名其他存活玩家获得尾气泄漏状态 · 每周期一次</span>
+          <strong>{getSkillDisplayName("exhaust_discharge", locale)}</strong>
+          <span>{isEnglish ? "Give one other living player the Exhaust Leak status · once per cycle" : "使一名其他存活玩家获得尾气泄漏状态 · 每周期一次"}</span>
         </div>
         <div className="candidate-grid">
           {targets.map((target) => (
@@ -98,7 +110,7 @@ function CharacterSkillActions({
               })}
               type="button"
             >
-              对 {target.name} 发动
+              {isEnglish ? "Activate against" : "对"} {getPlayerDisplayName(target, locale)} {isEnglish ? "" : "发动"}
             </button>
           ))}
         </div>
@@ -111,18 +123,18 @@ function CharacterSkillActions({
       activePlayer.characterUsage.perCycle.clumsy_party_secretary_shared_active,
     );
     const skills = [
-      ["exhaust_leak", "尾气泄漏"],
-      ["lab_fire", "实验台起火"],
-      ["exothermic_accident", "强放热事故"],
+      "exhaust_leak",
+      "lab_fire",
+      "exothermic_accident",
     ] as const;
     return (
       <div className="character-active-skill">
         <div>
-          <strong>书记共享主动技能</strong>
-          <span>三项技能共享每周期一次 · 当前：{used ? "已用" : "可用"}</span>
+          <strong>{isEnglish ? "Secretary shared active skills" : "书记共享主动技能"}</strong>
+          <span>{isEnglish ? "Three skills share once per cycle · current:" : "三项技能共享每周期一次 · 当前："}{used ? (isEnglish ? "used" : "已用") : (isEnglish ? "available" : "可用")}</span>
         </div>
         <div className="candidate-grid">
-          {skills.map(([skillId, name]) => (
+          {skills.map((skillId) => (
             <button
               className="primary-button"
               disabled={used || targets.length === 0}
@@ -134,7 +146,7 @@ function CharacterSkillActions({
               })}
               type="button"
             >
-              发动{name}
+              {isEnglish ? "Activate " : "发动"}{getSkillDisplayName(skillId, locale)}
             </button>
           ))}
         </div>
@@ -151,23 +163,22 @@ export function ActionPanel({
   onSelectCard,
   dispatchGameAction,
 }: ActionPanelProps) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
   const activePlayer = getActivePlayer(game);
   const targets = activePlayer ? getOpponentTargets(game, activePlayer.id) : [];
   const [targetByCardId, setTargetByCardId] = useState<Record<CardInstanceId, PlayerId>>({});
   const activeCharacterSkill: {
     id: DrawSkillId;
-    name: string;
     usageKey: CharacterUsageKey;
   } | undefined = activePlayer?.characterId === "laboratory_teacher"
     ? {
         id: "extra_lesson",
-        name: "补课",
         usageKey: "laboratory_teacher_extra_lesson",
       }
     : activePlayer?.characterId === "chemical_factory_ceo"
       ? {
           id: "emergency_supply",
-          name: "紧急调货",
           usageKey: "chemical_factory_ceo_emergency_supply",
         }
       : undefined;
@@ -191,24 +202,24 @@ export function ActionPanel({
     <section className="debug-section action-panel" aria-labelledby="main-action-title">
       <div className="panel-heading">
         <div>
-          <p className="debug-kicker">轮到当前玩家进行主行动</p>
-          <h2 id="main-action-title">主行动</h2>
+          <p className="debug-kicker">{isEnglish ? "It is the active player's main action" : "轮到当前玩家进行主行动"}</p>
+          <h2 id="main-action-title">{isEnglish ? "Main action" : "主行动"}</h2>
         </div>
         <button
           className="secondary-button"
           onClick={() => dispatchGameAction({ type: "PASS_ACTION", playerId: activePlayer.id })}
           type="button"
         >
-          结束本次行动
+          {isEnglish ? "End this action" : "结束本次行动"}
         </button>
       </div>
-      <p className="panel-note">当前行动玩家：{activePlayer.name}</p>
-      <details className="debug-details"><summary>调试详情</summary><p>PLAY_CARD / PLAY_REFERENCE_CARD / PASS_ACTION</p></details>
+      <p className="panel-note">{isEnglish ? "Active player" : "当前行动玩家"}：{getPlayerDisplayName(activePlayer, locale)}</p>
+      <details className="debug-details"><summary>{isEnglish ? "Debug details" : "调试详情"}</summary><p>PLAY_CARD / PLAY_REFERENCE_CARD / PASS_ACTION</p></details>
       {activeCharacterSkill ? (
         <div className="character-active-skill">
           <div>
-            <strong>{activeCharacterSkill.name}</strong>
-            <span>手牌不超过 4 张 · 每周期一次 · 发动后结束行动</span>
+            <strong>{getSkillDisplayName(activeCharacterSkill.id, locale)}</strong>
+            <span>{isEnglish ? "Hand of 4 or fewer · once per cycle · activation ends this action" : "手牌不超过 4 张 · 每周期一次 · 发动后结束行动"}</span>
           </div>
           <button
             className="primary-button"
@@ -226,7 +237,7 @@ export function ActionPanel({
             }
             type="button"
           >
-            发动{activeCharacterSkill.name}
+            {isEnglish ? "Activate " : "发动"}{getSkillDisplayName(activeCharacterSkill.id, locale)}
           </button>
         </div>
       ) : null}
@@ -235,7 +246,7 @@ export function ActionPanel({
         dispatchGameAction={dispatchGameAction}
         game={game}
       />
-      <p className="empty-note">普通出牌不需要目标，不触发原有效果，只更新场面基准并推进一次行动。</p>
+      <p className="empty-note">{isEnglish ? "A normal play needs no target and triggers no original effect; it only updates the table reference and advances one action." : "普通出牌不需要目标，不触发原有效果，只更新场面基准并推进一次行动。"}</p>
       <div className="action-card-list">
         {activePlayer.hand.map((cardInstanceId) => {
           const definition = getCardDefinition(game, cardInstanceId);
@@ -248,6 +259,7 @@ export function ActionPanel({
             game,
             activePlayer,
             cardInstanceId,
+            locale,
           );
           const canExecute = executableCardIds.has(cardInstanceId);
           const isOxygen = definition?.id === "substance_o2";
@@ -262,20 +274,20 @@ export function ActionPanel({
               onClick={() => onSelectCard(cardInstanceId)}
             >
               <div>
-                <strong>{definition?.name ?? "未知卡牌"}</strong>
+                <strong>{definition ? getCardDisplayName(definition.id, definition.name, locale) : (isEnglish ? "Unknown card" : "未知卡牌")}</strong>
                 <span className={`association-line${canAssociate ? " is-allowed" : " is-blocked"}`}>
                   {associationLabel}
                 </span>
                 <details className="debug-details" onClick={(event) => event.stopPropagation()}>
-                  <summary>调试详情</summary>
+                  <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
                   <span>{definition?.type ?? "unknown"} · {cardInstanceId}</span>
-                  <span>标签：{formatList(definition?.tags ?? [])}</span>
-                  <span>时机：{formatList(definition?.allowedTimings ?? [])}</span>
+                  <span>{isEnglish ? "Tags" : "标签"}：{formatList(definition?.tags ?? [])}</span>
+                  <span>{isEnglish ? "Timing" : "时机"}：{formatList(definition?.allowedTimings ?? [])}</span>
                 </details>
               </div>
               {canExecute && !isOxygen ? (
                 <label className="field-row compact-field">
-                  <span>执行效果目标</span>
+                  <span>{isEnglish ? "Effect target" : "执行效果目标"}</span>
                   <select
                     onChange={(event) =>
                       setTargetByCardId((current) => ({
@@ -288,7 +300,7 @@ export function ActionPanel({
                   >
                     {targets.map((target) => (
                       <option key={target.id} value={target.id}>
-                        {getPlayerName(game, target.id)}
+                        {getPlayerDisplayName(target, locale)}
                       </option>
                     ))}
                   </select>
@@ -309,7 +321,7 @@ export function ActionPanel({
                     }}
                     type="button"
                   >
-                    执行效果
+                    {isEnglish ? "Run effect" : "执行效果"}
                   </button>
                 ) : null}
                 {canAssociate ? (
@@ -325,11 +337,11 @@ export function ActionPanel({
                     }}
                     type="button"
                   >
-                    普通出牌
+                    {isEnglish ? "Normal play" : "普通出牌"}
                   </button>
                 ) : (
                   <button className="secondary-button" disabled type="button">
-                    不可出牌
+                    {isEnglish ? "Cannot play" : "不可出牌"}
                   </button>
                 )}
               </div>

--- a/src/features/local-game/components/CardDebugCard.tsx
+++ b/src/features/local-game/components/CardDebugCard.tsx
@@ -1,6 +1,8 @@
 import type { CardInstanceId } from "../../../game/engine/types";
+import { useLocale } from "../../../app/locale";
 import { formatList, getCardDefinition } from "../localGameView";
 import type { GameState } from "../../../game/engine/types";
+import { getCardDisplayName } from "../presentationLocale";
 
 type CardDebugCardProps = {
   cardInstanceId: CardInstanceId;
@@ -18,12 +20,14 @@ export function CardDebugCard({
   onSelect,
 }: CardDebugCardProps) {
   const definition = getCardDefinition(game, cardInstanceId);
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
 
   if (!definition) {
     return (
       <article className="debug-card is-missing">
         <button className="debug-card__select" disabled type="button">
-          未知卡牌 {cardInstanceId}
+          {isEnglish ? "Unknown card" : "未知卡牌"} {cardInstanceId}
         </button>
       </article>
     );
@@ -39,14 +43,14 @@ export function CardDebugCard({
         onClick={() => onSelect?.(cardInstanceId)}
         type="button"
       >
-        <span className="debug-card__name">{definition.name}</span>
-        <span className="debug-card__line">可在当前对局中选择</span>
+        <span className="debug-card__name">{getCardDisplayName(definition.id, definition.name, locale)}</span>
+        <span className="debug-card__line">{isEnglish ? "Selectable in this game" : "可在当前对局中选择"}</span>
       </button>
       <details className="debug-details debug-card__details">
-        <summary>调试详情</summary>
+        <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
         <span className="debug-card__meta">{definition.type} · {cardInstanceId}</span>
-        <span className="debug-card__line">标签：{formatList(definition.tags)}</span>
-        <span className="debug-card__line">时机：{formatList(definition.allowedTimings)}</span>
+        <span className="debug-card__line">{isEnglish ? "Tags" : "标签"}：{formatList(definition.tags)}</span>
+        <span className="debug-card__line">{isEnglish ? "Timing" : "时机"}：{formatList(definition.allowedTimings)}</span>
       </details>
     </article>
   );

--- a/src/features/local-game/components/CharacterSelectionPanel.tsx
+++ b/src/features/local-game/components/CharacterSelectionPanel.tsx
@@ -1,9 +1,8 @@
 import { characterDefinitions, getCharacterDefinition } from "../../../game/data/characterDefinitions";
+import { useLocale } from "../../../app/locale";
 import type { CharacterId } from "../../../game/engine/types";
 import {
   getPublicCharacterSkills,
-  implementationStatusLabels,
-  skillTypeLabels,
 } from "../characterPresentation";
 import {
   isCharacterSelection,
@@ -11,6 +10,11 @@ import {
   type LocalGameSessionCommand,
 } from "../localGameSession";
 import { NewPlayerGuidance } from "./NewPlayerGuidance";
+import {
+  getCharacterDisplayName,
+  getImplementationStatusDisplayName,
+  getSkillTypeDisplayName,
+} from "../presentationLocale";
 
 type CharacterSelectionPanelProps = {
   session: ConfiguringLocalGameSession;
@@ -29,6 +33,8 @@ export function CharacterSelectionPanel({
   onGuidanceVisibleChange,
   onGuidanceCollapsedChange,
 }: CharacterSelectionPanelProps) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
   const canStart = isCharacterSelection(session.characterIds);
   const selectedCharacters = session.characterIds.map((characterId) =>
     getCharacterDefinition(characterId),
@@ -54,29 +60,29 @@ export function CharacterSelectionPanel({
             width="72"
           />
           <div>
-            <p className="debug-kicker">反应域 · Web Playtest Alpha · MVP0-P10</p>
-            <h1 id="character-selection-title">反应域 · 本地双人角色选择</h1>
+            <p className="debug-kicker">{isEnglish ? "REACTION FIELD · Web Playtest Alpha · MVP0-P10" : "反应域 · Web Playtest Alpha · MVP0-P10"}</p>
+            <h1 id="character-selection-title">{isEnglish ? "REACTION FIELD · Local two-player character selection" : "反应域 · 本地双人角色选择"}</h1>
           </div>
         </div>
         <p className="panel-note">
-          选择两名玩家的角色后开始本地同屏对局；双方手牌公开。刷新页面会丢失本局进度。
+          {isEnglish ? "Choose two characters to start a local shared-screen game. Both hands are public. Refreshing loses this game." : "选择两名玩家的角色后开始本地同屏对局；双方手牌公开。刷新页面会丢失本局进度。"}
         </p>
-        <p className="mirror-note">试玩版允许镜像角色；该能力不预先冻结未来正式实体角色牌模式。</p>
+        <p className="mirror-note">{isEnglish ? "This playtest allows mirrored characters; it does not predefine a future physical character-card mode." : "试玩版允许镜像角色；该能力不预先冻结未来正式实体角色牌模式。"}</p>
       </section>
 
       <section className="debug-section character-config" aria-labelledby="lineup-title">
         <div className="panel-heading">
           <div>
-            <p className="debug-kicker">本地同屏 · 2 名玩家 · 7 个角色</p>
-            <h2 id="lineup-title">当前阵容</h2>
+            <p className="debug-kicker">{isEnglish ? "Local shared screen · 2 players · 7 characters" : "本地同屏 · 2 名玩家 · 7 个角色"}</p>
+            <h2 id="lineup-title">{isEnglish ? "Current lineup" : "当前阵容"}</h2>
           </div>
         </div>
         <div className="character-select-grid">
           {([0, 1] as const).map((playerIndex) => (
             <label className="field-row character-select-field" key={playerIndex}>
-                <span>玩家 {playerIndex === 0 ? "A" : "B"}</span>
+                <span>{isEnglish ? "Player" : "玩家"} {playerIndex === 0 ? "A" : "B"}</span>
               <select
-                aria-label={`player_${playerIndex + 1} 角色`}
+                aria-label={isEnglish ? `player_${playerIndex + 1} character` : `player_${playerIndex + 1} 角色`}
                 onChange={(event) => dispatch({
                   type: "SELECT_CHARACTER",
                   playerIndex,
@@ -86,7 +92,7 @@ export function CharacterSelectionPanel({
               >
                 {characterDefinitions.map((character) => (
                   <option key={character.id} value={character.id}>
-                    {character.name} · {character.maxHp} HP
+                    {getCharacterDisplayName(character.id, locale)} · {character.maxHp} HP
                   </option>
                 ))}
               </select>
@@ -94,11 +100,11 @@ export function CharacterSelectionPanel({
           ))}
         </div>
         <div className="lineup-summary" aria-live="polite">
-          <strong>阵容确认</strong>
-          <span>玩家 A：{selectedCharacters[0].name}</span>
-          <span>玩家 B：{selectedCharacters[1].name}</span>
+          <strong>{isEnglish ? "Lineup confirmed" : "阵容确认"}</strong>
+          <span>{isEnglish ? "Player A" : "玩家 A"}：{getCharacterDisplayName(selectedCharacters[0].id, locale)}</span>
+          <span>{isEnglish ? "Player B" : "玩家 B"}：{getCharacterDisplayName(selectedCharacters[1].id, locale)}</span>
           {session.characterIds[0] === session.characterIds[1] ? (
-            <span className="ok-pill">镜像阵容合法</span>
+            <span className="ok-pill">{isEnglish ? "Mirrored lineup is valid" : "镜像阵容合法"}</span>
           ) : null}
         </div>
         {session.error ? <p className="error-banner">{session.error}</p> : null}
@@ -108,30 +114,30 @@ export function CharacterSelectionPanel({
           onClick={() => dispatch({ type: "START_LOCAL_GAME" })}
           type="button"
         >
-          开始游戏
+          {isEnglish ? "Start game" : "开始游戏"}
         </button>
       </section>
 
       <section className="character-catalog" aria-labelledby="character-catalog-title">
         <div className="character-catalog__heading">
           <div>
-          <p className="debug-kicker">角色资料</p>
-            <h2 id="character-catalog-title">7 个正式角色资料</h2>
+          <p className="debug-kicker">{isEnglish ? "Character profiles" : "角色资料"}</p>
+            <h2 id="character-catalog-title">{isEnglish ? "7 official character profiles" : "7 个正式角色资料"}</h2>
           </div>
-          <p className="panel-note">技能摘要来自角色定义；具体实现说明可在调试详情中查看。</p>
+          <p className="panel-note">{isEnglish ? "Skill summaries come from character definitions; implementation notes remain in Debug details." : "技能摘要来自角色定义；具体实现说明可在调试详情中查看。"}</p>
         </div>
         <div className="character-catalog-grid">
           {characterDefinitions.map((character) => (
             <article className="debug-section character-option-card" key={character.id}>
               <div className="character-option-card__heading">
                 <div>
-                  <h2>{character.name}</h2>
+                  <h2>{getCharacterDisplayName(character.id, locale)}</h2>
                   <p>{character.maxHp} HP</p>
                 </div>
                 <span className="active-pill">{character.maxHp} HP</span>
               </div>
               <ul className="character-skill-list">
-                {getPublicCharacterSkills(character).map((skill) => (
+              {getPublicCharacterSkills(character, locale).map((skill) => (
                   <li key={skill.name}>
                     <div className="character-skill-list__heading">
                       <strong>{skill.name}</strong>
@@ -143,16 +149,16 @@ export function CharacterSelectionPanel({
                 ))}
               </ul>
               <details className="debug-details">
-                <summary>调试详情</summary>
+                <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
                 {character.skills.map((skill) => (
-                  <p key={skill.id}>{skill.id} · {skillTypeLabels[skill.type]} · {implementationStatusLabels[skill.implementationStatus]} · {skill.rulesText}{"implementationNote" in skill && skill.implementationNote ? ` · ${skill.implementationNote}` : ""}</p>
+                  <p key={skill.id}>{skill.id} · {getSkillTypeDisplayName(skill.type, locale)} · {getImplementationStatusDisplayName(skill.implementationStatus, locale)} · {skill.rulesText}{"implementationNote" in skill && skill.implementationNote ? ` · ${skill.implementationNote}` : ""}</p>
                 ))}
               </details>
             </article>
           ))}
         </div>
         <p className="deferred-note">
-          不可用或部分实现：实验反击的金属选项等待真实金属卡池；硫酸盐副产已在 Phase 10 通过结构化成功反应事件启用。延期能力不提供虚假执行入口。
+          {isEnglish ? "Unavailable or partial: Experiment Counterattack's metal option awaits a real metal card pool. Sulfate Byproduct is enabled by Phase 10 structured successful reactions. Deferred abilities have no false action entry point." : "不可用或部分实现：实验反击的金属选项等待真实金属卡池；硫酸盐副产已在 Phase 10 通过结构化成功反应事件启用。延期能力不提供虚假执行入口。"}
         </p>
       </section>
     </main>

--- a/src/features/local-game/components/ConfirmationDialog.tsx
+++ b/src/features/local-game/components/ConfirmationDialog.tsx
@@ -1,4 +1,5 @@
 import { useRef } from "react";
+import { useLocale } from "../../../app/locale";
 import { ModalDialog } from "./ModalDialog";
 
 export type SessionConfirmationKind = "restart" | "return";
@@ -26,13 +27,27 @@ const confirmationCopy: Readonly<Record<SessionConfirmationKind, Readonly<{
   },
 };
 
+const englishConfirmationCopy: typeof confirmationCopy = {
+  restart: {
+    title: "Restart with the current lineup?",
+    description: "The current game, both hands, statuses, and log will be discarded. A completely new game will be created with the current lineup.",
+    confirmLabel: "Confirm restart",
+  },
+  return: {
+    title: "Return to character selection?",
+    description: "The current game, both hands, statuses, and log will be discarded. The current lineup remains available for adjustment.",
+    confirmLabel: "Confirm return",
+  },
+};
+
 export function ConfirmationDialog({
   kind,
   onCancel,
   onConfirm,
 }: ConfirmationDialogProps) {
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
-  const copy = confirmationCopy[kind];
+  const { locale } = useLocale();
+  const copy = (locale === "en" ? englishConfirmationCopy : confirmationCopy)[kind];
 
   return (
     <ModalDialog
@@ -52,7 +67,7 @@ export function ConfirmationDialog({
             ref={cancelButtonRef}
             type="button"
           >
-            取消
+            {locale === "en" ? "Cancel" : "取消"}
           </button>
           <button className="danger-button" onClick={onConfirm} type="button">
             {copy.confirmLabel}

--- a/src/features/local-game/components/DiyPanel.tsx
+++ b/src/features/local-game/components/DiyPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useLocale } from "../../../app/locale";
 import type { GameAction } from "../../../game/engine/actions";
 import type { CardInstanceId, GameState, PlayerId } from "../../../game/engine/types";
 import {
@@ -11,6 +12,11 @@ import {
   getRecipeById,
   getRequiredComponentSlots,
 } from "../localGameView";
+import {
+  getCardDisplayName,
+  getDiyRecipeDisplayName,
+  getPlayerDisplayName,
+} from "../presentationLocale";
 
 type DiyPanelProps = {
   game: GameState;
@@ -18,6 +24,8 @@ type DiyPanelProps = {
 };
 
 export function DiyPanel({ game, dispatchGameAction }: DiyPanelProps) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
   const activePlayer = getActivePlayer(game);
   const recipes = getPlayableDiyRecipes();
   const [recipeId, setRecipeId] = useState(recipes[0]?.id);
@@ -50,25 +58,25 @@ export function DiyPanel({ game, dispatchGameAction }: DiyPanelProps) {
     <section className="debug-section diy-panel" aria-labelledby="diy-title">
       <div className="panel-heading">
         <div>
-          <p className="debug-kicker">选择配方和组件后执行</p>
-          <h2 id="diy-title">主动 DIY</h2>
+          <p className="debug-kicker">{isEnglish ? "Choose a recipe and components, then run it" : "选择配方和组件后执行"}</p>
+          <h2 id="diy-title">{isEnglish ? "Active DIY" : "主动 DIY"}</h2>
         </div>
         <span className={activePlayer.usedDIYThisCycle ? "warn-pill" : "ok-pill"}>
-          {activePlayer.usedDIYThisCycle ? "本周期已用" : "本周期可用"}
+          {activePlayer.usedDIYThisCycle ? (isEnglish ? "Used this cycle" : "本周期已用") : (isEnglish ? "Available this cycle" : "本周期可用")}
         </span>
       </div>
-      <details className="debug-details"><summary>调试详情</summary><p>START_ACTIVE_DIY</p></details>
+      <details className="debug-details"><summary>{isEnglish ? "Debug details" : "调试详情"}</summary><p>START_ACTIVE_DIY</p></details>
       <label className="field-row">
-        <span>配方</span>
+        <span>{isEnglish ? "Recipe" : "配方"}</span>
         <select value={recipe.id} onChange={(event) => setRecipeId(event.target.value)}>
           {recipes.map((candidate) => (
             <option key={candidate.id} value={candidate.id}>
-              {candidate.name}
+              {getDiyRecipeDisplayName(candidate.id, candidate.name, locale)}
             </option>
           ))}
         </select>
       </label>
-      <div className="recipe-list" aria-label="全部 MVP 0 主动 DIY 配方">
+      <div className="recipe-list" aria-label={isEnglish ? "All MVP 0 active DIY recipes" : "全部 MVP 0 主动 DIY 配方"}>
         {recipes.map((candidate) => (
           <button
             className={`recipe-chip${candidate.id === recipe.id ? " is-selected" : ""}`}
@@ -76,7 +84,7 @@ export function DiyPanel({ game, dispatchGameAction }: DiyPanelProps) {
             onClick={() => setRecipeId(candidate.id)}
             type="button"
           >
-            {candidate.name}
+            {getDiyRecipeDisplayName(candidate.id, candidate.name, locale)}
           </button>
         ))}
       </div>
@@ -91,11 +99,14 @@ export function DiyPanel({ game, dispatchGameAction }: DiyPanelProps) {
             slot.definitionId,
             selectedForOtherSlots,
           );
-          const definitionName = cardDefinitionById.get(slot.definitionId)?.name ?? slot.definitionId;
+          const definition = cardDefinitionById.get(slot.definitionId);
+          const definitionName = definition
+            ? getCardDisplayName(definition.id, definition.name, locale)
+            : slot.definitionId;
 
           return (
             <label className="field-row" key={slot.slotId}>
-              <span>{slot.label}</span>
+              <span>{definitionName}</span>
               <select
                 onChange={(event) =>
                   setComponentIds((current) => ({
@@ -105,12 +116,14 @@ export function DiyPanel({ game, dispatchGameAction }: DiyPanelProps) {
                 }
                 value={componentIds[slot.slotId] ?? ""}
               >
-                <option value="">选择 {definitionName}</option>
+                <option value="">{isEnglish ? "Select" : "选择"} {definitionName}</option>
                 {options.map((cardInstanceId) => {
                   const cardDefinition = getCardDefinition(game, cardInstanceId);
                   return (
                     <option key={cardInstanceId} value={cardInstanceId}>
-                      {cardDefinition?.name ?? "未知卡牌"}
+                      {cardDefinition
+                        ? getCardDisplayName(cardDefinition.id, cardDefinition.name, locale)
+                        : (isEnglish ? "Unknown card" : "未知卡牌")}
                     </option>
                   );
                 })}
@@ -121,24 +134,24 @@ export function DiyPanel({ game, dispatchGameAction }: DiyPanelProps) {
       </div>
       {recipe.requiresTarget ? (
         <label className="field-row">
-          <span>DIY 目标</span>
+          <span>{isEnglish ? "DIY target" : "DIY 目标"}</span>
           <select
             onChange={(event) => setTargetPlayerId(event.target.value)}
             value={targetPlayerId ?? ""}
           >
             {targets.map((target) => (
               <option key={target.id} value={target.id}>
-                {target.name}
+                {getPlayerDisplayName(target, locale)}
               </option>
             ))}
           </select>
         </label>
       ) : (
-        <p className="empty-note">此配方不需要选择目标。</p>
+        <p className="empty-note">{isEnglish ? "This recipe does not require a target." : "此配方不需要选择目标。"}</p>
       )}
       <details className="debug-details">
-        <summary>调试详情</summary>
-        <p>targetPlayerId：{recipe.requiresTarget ? targetPlayerId ?? "未选择" : "未设置"}</p>
+        <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
+        <p>targetPlayerId：{recipe.requiresTarget ? targetPlayerId ?? (isEnglish ? "not selected" : "未选择") : (isEnglish ? "not set" : "未设置")}</p>
       </details>
       <button
         className="primary-button"
@@ -154,7 +167,7 @@ export function DiyPanel({ game, dispatchGameAction }: DiyPanelProps) {
         }
         type="button"
       >
-        执行主动 DIY
+        {isEnglish ? "Run active DIY" : "执行主动 DIY"}
       </button>
     </section>
   );

--- a/src/features/local-game/components/ExperimentCounterattackPanel.tsx
+++ b/src/features/local-game/components/ExperimentCounterattackPanel.tsx
@@ -1,4 +1,5 @@
 import type { GameAction } from "../../../game/engine/actions";
+import { useLocale } from "../../../app/locale";
 import type { GameState } from "../../../game/engine/types";
 import {
   describePendingExperimentCounterattack,
@@ -8,6 +9,7 @@ import {
   getPlayer,
   getPlayerName,
 } from "../localGameView";
+import { getCardDisplayName, getPlayerDisplayName } from "../presentationLocale";
 
 type ExperimentCounterattackPanelProps = {
   game: GameState;
@@ -18,6 +20,8 @@ export function ExperimentCounterattackPanel({
   game,
   dispatchGameAction,
 }: ExperimentCounterattackPanelProps) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
   const pending = game.pendingExperimentCounterattack;
   const responder = pending ? getPlayer(game, pending.responderPlayerId) : undefined;
 
@@ -43,26 +47,28 @@ export function ExperimentCounterattackPanel({
     >
       <div className="panel-heading">
         <div>
-          <p className="debug-kicker">请选择一个当前合法的反击选项</p>
-          <h2 id="experiment-counterattack-title">实验反击选择</h2>
+          <p className="debug-kicker">{isEnglish ? "Choose a currently legal counterattack option" : "请选择一个当前合法的反击选项"}</p>
+          <h2 id="experiment-counterattack-title">{isEnglish ? "Experiment Counterattack selection" : "实验反击选择"}</h2>
         </div>
         <span className={used ? "warn-pill" : "ok-pill"}>
-          {used ? "本周期已用" : "本周期可用"}
+          {used ? (isEnglish ? "Used this cycle" : "本周期已用") : (isEnglish ? "Available this cycle" : "本周期可用")}
         </span>
       </div>
       <p className="panel-note">
-        {responder.name} 已成功响应 {getPlayerName(game, pending.attackerPlayerId)} 的攻击，请选择一个合法反击选项。
+        {isEnglish
+          ? `${getPlayerDisplayName(responder, locale)} successfully responded to ${getPlayerDisplayName(getPlayer(game, pending.attackerPlayerId), locale)}'s attack. Choose one legal counterattack option.`
+          : `${responder.name} 已成功响应 ${getPlayerName(game, pending.attackerPlayerId)} 的攻击，请选择一个合法反击选项。`}
       </p>
       <details className="debug-details">
-        <summary>调试详情</summary>
+        <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
         <p>{describePendingExperimentCounterattack(game)}</p>
         <p>RESOLVE_EXPERIMENT_COUNTERATTACK</p>
       </details>
 
       <div className="character-active-skill">
         <div>
-          <strong>回复 1 HP</strong>
-          <span>满 HP、火情或尾气泄漏时不可选</span>
+          <strong>{isEnglish ? "Recover 1 HP" : "回复 1 HP"}</strong>
+          <span>{isEnglish ? "Unavailable at full HP or with Fire or SO2 leak" : "满 HP、火情或尾气泄漏时不可选"}</span>
         </div>
         <button
           className="primary-button"
@@ -76,24 +82,24 @@ export function ExperimentCounterattackPanel({
           }
           type="button"
         >
-          {canRecover ? "选择回复" : "当前不可回复"}
+          {canRecover ? (isEnglish ? "Choose recovery" : "选择回复") : (isEnglish ? "Recovery unavailable" : "当前不可回复")}
         </button>
       </div>
 
       <div className="character-active-skill">
         <div>
-          <strong>金属元素反击</strong>
-          <span>弃置金属元素牌，对原攻击者造成 1 点伤害</span>
+          <strong>{isEnglish ? "Metal element counterattack" : "金属元素反击"}</strong>
+          <span>{isEnglish ? "Discard a metal element card to deal 1 damage to the original attacker" : "弃置金属元素牌，对原攻击者造成 1 点伤害"}</span>
         </div>
         {metalCards.length === 0 ? (
-          <p className="empty-note">当前 68 张卡池暂无合法金属元素牌，等待后续真实金属卡池阶段启用。</p>
+          <p className="empty-note">{isEnglish ? "The current 68-card pool has no legal metal element card. This awaits a future real-metal card-pool phase." : "当前 68 张卡池暂无合法金属元素牌，等待后续真实金属卡池阶段启用。"}</p>
         ) : null}
       </div>
 
       <div className="character-active-skill">
         <div>
-          <strong>实体酸碱追击</strong>
-          <span>基础伤害按实体定义，increase 阶段 +1，且不再打开响应</span>
+          <strong>{isEnglish ? "Physical acid-base pursuit" : "实体酸碱追击"}</strong>
+          <span>{isEnglish ? "Base damage follows the physical definition, receives +1 at increase, and does not open another response" : "基础伤害按实体定义，increase 阶段 +1，且不再打开响应"}</span>
         </div>
         <div className="candidate-grid">
           {pursuitCards.map((cardInstanceId) => (
@@ -110,7 +116,12 @@ export function ExperimentCounterattackPanel({
               }
               type="button"
             >
-              使用 {getCardDefinition(game, cardInstanceId)?.name ?? "未知卡牌"}
+              {isEnglish ? "Use" : "使用"} {(() => {
+                const definition = getCardDefinition(game, cardInstanceId);
+                return definition
+                  ? getCardDisplayName(definition.id, definition.name, locale)
+                  : (isEnglish ? "Unknown card" : "未知卡牌");
+              })()}
             </button>
           ))}
         </div>

--- a/src/features/local-game/components/FatalSessionPage.tsx
+++ b/src/features/local-game/components/FatalSessionPage.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
+import { useLocale } from "../../../app/locale";
 import {
   formatFatalDiagnostics,
   type FatalLocalGameSession,
   type LocalGameSessionCommand,
 } from "../localGameSession";
+import { getFatalMessageDisplayName } from "../presentationLocale";
 
 type FatalSessionPageProps = Readonly<{
   session: FatalLocalGameSession;
@@ -12,6 +14,8 @@ type FatalSessionPageProps = Readonly<{
 
 export function FatalSessionPage({ session, dispatch }: FatalSessionPageProps) {
   const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "failed">("idle");
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
 
   async function copyDiagnostics() {
     try {
@@ -26,20 +30,20 @@ export function FatalSessionPage({ session, dispatch }: FatalSessionPageProps) {
     <main className="local-game-page fatal-session-page">
       <section className="debug-section fatal-session-card" role="alert" aria-labelledby="fatal-session-title">
           <div>
-          <p className="debug-kicker">反应域 · 会话安全边界</p>
-          <h1 id="fatal-session-title">当前对局已安全停止</h1>
+          <p className="debug-kicker">{isEnglish ? "REACTION FIELD · Session safety boundary" : "反应域 · 会话安全边界"}</p>
+          <h1 id="fatal-session-title">{isEnglish ? "The current game stopped safely" : "当前对局已安全停止"}</h1>
         </div>
-        <p>{session.error.userMessage}</p>
+        <p>{getFatalMessageDisplayName(session.error.code, session.error.userMessage, locale)}</p>
         <p className="panel-note">
-          旧对局状态已从本地会话中移除，任何旧对局操作都会被拒绝。恢复会重新创建完整的新对局。
+          {isEnglish ? "The old game state was removed from the local session and every old game action is rejected. Recovery creates a complete new game." : "旧对局状态已从本地会话中移除，任何旧对局操作都会被拒绝。恢复会重新创建完整的新对局。"}
         </p>
         <dl className="failure-diagnostics">
-          <div><dt>名称</dt><dd>{session.error.diagnostics.displayName}</dd></div>
-          <div><dt>错误码</dt><dd>{session.error.code}</dd></div>
-          <div><dt>应用版本</dt><dd>{session.error.diagnostics.version}</dd></div>
-          <div><dt>规则版本</dt><dd>{session.error.diagnostics.rulesVersion}</dd></div>
+          <div><dt>{isEnglish ? "Name" : "名称"}</dt><dd>{session.error.diagnostics.displayName}</dd></div>
+          <div><dt>{isEnglish ? "Error code" : "错误码"}</dt><dd>{session.error.code}</dd></div>
+          <div><dt>{isEnglish ? "App version" : "应用版本"}</dt><dd>{session.error.diagnostics.version}</dd></div>
+          <div><dt>{isEnglish ? "Rules version" : "规则版本"}</dt><dd>{session.error.diagnostics.rulesVersion}</dd></div>
           <div><dt>Commit</dt><dd>{session.error.diagnostics.commit}</dd></div>
-          <div><dt>运行环境</dt><dd>{session.error.diagnostics.environment}</dd></div>
+          <div><dt>{isEnglish ? "Environment" : "运行环境"}</dt><dd>{session.error.diagnostics.environment}</dd></div>
         </dl>
         <div className="fatal-actions">
           <button
@@ -47,25 +51,25 @@ export function FatalSessionPage({ session, dispatch }: FatalSessionPageProps) {
             onClick={() => dispatch({ type: "RECOVER_FATAL_WITH_CURRENT_LINEUP" })}
             type="button"
           >
-            按原阵容创建全新对局
+            {isEnglish ? "Create a new game with the same lineup" : "按原阵容创建全新对局"}
           </button>
           <button
             className="secondary-button"
             onClick={() => dispatch({ type: "RETURN_TO_CHARACTER_SELECTION" })}
             type="button"
           >
-            返回角色选择
+            {isEnglish ? "Return to character selection" : "返回角色选择"}
           </button>
           <button className="secondary-button" onClick={copyDiagnostics} type="button">
-            复制安全诊断
+            {isEnglish ? "Copy safe diagnostics" : "复制安全诊断"}
           </button>
         </div>
         <p aria-live="polite" className="panel-note">
           {copyStatus === "copied"
-            ? "安全诊断已复制。"
+            ? (isEnglish ? "Safe diagnostics copied." : "安全诊断已复制。")
             : copyStatus === "failed"
-              ? "浏览器未允许复制；页面未上传任何信息。"
-              : "诊断不包含异常原文、堆栈或任何对局内容。"}
+              ? (isEnglish ? "The browser did not allow copying; the page uploaded no information." : "浏览器未允许复制；页面未上传任何信息。")
+              : (isEnglish ? "Diagnostics contain no original error text, stack, or game content." : "诊断不包含异常原文、堆栈或任何对局内容。")}
         </p>
       </section>
     </main>

--- a/src/features/local-game/components/GameLog.tsx
+++ b/src/features/local-game/components/GameLog.tsx
@@ -1,4 +1,5 @@
 import type { GameState } from "../../../game/engine/types";
+import { useLocale } from "../../../app/locale";
 import { getPublicReactionLogView } from "../localGameView";
 
 type GameLogProps = {
@@ -6,31 +7,39 @@ type GameLogProps = {
 };
 
 export function GameLog({ game }: GameLogProps) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
+
   return (
     <section className="debug-section game-log" aria-labelledby="game-log-title">
-      <h2 id="game-log-title">完整游戏日志</h2>
+      <h2 id="game-log-title">{isEnglish ? "Full game log" : "完整游戏日志"}</h2>
+      {isEnglish ? (
+        <p className="panel-note">
+          The formal game record currently remains in Simplified Chinese. This display layer does not translate log messages.
+        </p>
+      ) : null}
       <ol>
         {game.log.map((entry) => {
-          const reaction = getPublicReactionLogView(game, entry);
+          const reaction = getPublicReactionLogView(game, entry, locale);
 
           return (
             <li key={entry.id}>
               <div className="game-log__message">
-                {reaction ? "已记录一项成功反应。" : entry.message}
+                {reaction ? (isEnglish ? "A successful reaction was recorded." : "已记录一项成功反应。") : entry.message}
                 <details className="debug-details game-log__details">
-                  <summary>调试详情</summary>
-                  <span className="game-log__entry-id">日志编号：{entry.id}</span>
+                  <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
+                  <span className="game-log__entry-id">{isEnglish ? "Log ID" : "日志编号"}：{entry.id}</span>
                   {reaction ? <span className="game-log__entry-id">{JSON.stringify(entry.reaction)}</span> : null}
                 </details>
               </div>
               {reaction ? (
-                <div className="game-log__reaction" aria-label={`成功反应：${reaction.name}`}>
-                  <strong>成功反应 · {reaction.name}</strong>
-                  <span>入口：{reaction.trigger}</span>
+                <div className="game-log__reaction" aria-label={`${isEnglish ? "Successful reaction" : "成功反应"}：${reaction.name}`}>
+                  <strong>{isEnglish ? "Successful reaction" : "成功反应"} · {reaction.name}</strong>
+                  <span>{isEnglish ? "Entry" : "入口"}：{reaction.trigger}</span>
                   {reaction.participants.map((participant) => (
                     <span key={participant}>{participant}</span>
                   ))}
-                  <span>结果：{reaction.outcome}</span>
+                  <span>{isEnglish ? "Result" : "结果"}：{reaction.outcome}</span>
                 </div>
               ) : null}
             </li>

--- a/src/features/local-game/components/GameSummary.tsx
+++ b/src/features/local-game/components/GameSummary.tsx
@@ -1,12 +1,13 @@
 import type { GameState } from "../../../game/engine/types";
+import { useLocale } from "../../../app/locale";
 import { releaseMetadata } from "../../../app/releaseMetadata";
 import {
   describePendingResponse,
   describePendingStatusHandling,
   describeTableReference,
-  getPlayerName,
   getTotalCardCount,
 } from "../localGameView";
+import { getPlayerDisplayName } from "../presentationLocale";
 
 type GameSummaryProps = {
   game: GameState;
@@ -21,58 +22,62 @@ export function GameSummary({
   onRestart,
   onReturnToCharacterSelection,
 }: GameSummaryProps) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
   const winnerText = game.phase === "gameOver"
     ? game.isDraw
-      ? "平局"
-      : `胜者：${game.winnerPlayerId ? getPlayerName(game, game.winnerPlayerId) : "未定"}`
-    : "未结束";
+      ? (isEnglish ? "Draw" : "平局")
+      : `${isEnglish ? "Winner" : "胜者"}：${game.winnerPlayerId
+        ? getPlayerDisplayName(game.players.find((player) => player.id === game.winnerPlayerId), locale)
+        : (isEnglish ? "Undetermined" : "未定")}`
+    : (isEnglish ? "Not finished" : "未结束");
 
   return (
     <section className="debug-section debug-summary" aria-labelledby="summary-title">
       <div>
         <p className="debug-kicker">{releaseMetadata.displayName}</p>
-        <h1 id="summary-title">本地双人公开对局</h1>
+        <h1 id="summary-title">{isEnglish ? "Local public two-player game" : "本地双人公开对局"}</h1>
       </div>
       <dl className="summary-grid">
         <div>
-          <dt>实验周期</dt>
+          <dt>{isEnglish ? "Experiment cycle" : "实验周期"}</dt>
           <dd>{game.cycleNumber}</dd>
         </div>
         <div>
-          <dt>本周期轮次</dt>
+          <dt>{isEnglish ? "Round in cycle" : "本周期轮次"}</dt>
           <dd>{game.roundInCycle}</dd>
         </div>
         <div>
-          <dt>当前阶段</dt>
-          <dd>{game.phase === "mainAction" ? "主行动" : game.phase === "gameOver" ? "对局结束" : "等待处理"}</dd>
+          <dt>{isEnglish ? "Current phase" : "当前阶段"}</dt>
+          <dd>{game.phase === "mainAction" ? (isEnglish ? "Main action" : "主行动") : game.phase === "gameOver" ? (isEnglish ? "Game over" : "对局结束") : (isEnglish ? "Waiting for handling" : "等待处理")}</dd>
         </div>
         <div>
-          <dt>当前行动玩家</dt>
-          <dd>{getPlayerName(game, game.activePlayerId)}</dd>
+          <dt>{isEnglish ? "Active player" : "当前行动玩家"}</dt>
+          <dd>{getPlayerDisplayName(game.players.find((player) => player.id === game.activePlayerId), locale)}</dd>
         </div>
         <div>
-          <dt>牌堆</dt>
+          <dt>{isEnglish ? "Deck" : "牌堆"}</dt>
           <dd>{game.deck.length}</dd>
         </div>
         <div>
-          <dt>弃牌堆</dt>
+          <dt>{isEnglish ? "Discard pile" : "弃牌堆"}</dt>
           <dd>{game.discardPile.length}</dd>
         </div>
         <div>
-          <dt>公开对局</dt>
-          <dd>双方手牌可见</dd>
+          <dt>{isEnglish ? "Public game" : "公开对局"}</dt>
+          <dd>{isEnglish ? "Both hands visible" : "双方手牌可见"}</dd>
         </div>
         <div>
-          <dt>胜负</dt>
+          <dt>{isEnglish ? "Outcome" : "胜负"}</dt>
           <dd>{winnerText}</dd>
         </div>
       </dl>
       <details className="debug-details">
-        <summary>调试详情</summary>
+        <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
         <dl className="debug-detail-list">
-          <div><dt>发布渠道</dt><dd>{releaseMetadata.channel}</dd></div>
-          <div><dt>应用版本</dt><dd>{releaseMetadata.version}</dd></div>
-          <div><dt>规则版本</dt><dd>{releaseMetadata.rulesVersion}</dd></div>
+          <div><dt>{isEnglish ? "Release channel" : "发布渠道"}</dt><dd>{releaseMetadata.channel}</dd></div>
+          <div><dt>{isEnglish ? "App version" : "应用版本"}</dt><dd>{releaseMetadata.version}</dd></div>
+          <div><dt>{isEnglish ? "Rules version" : "规则版本"}</dt><dd>{releaseMetadata.rulesVersion}</dd></div>
           <div><dt>Commit</dt><dd>{releaseMetadata.commit}</dd></div>
           <div><dt>phase</dt><dd>{game.phase}</dd></div>
           <div><dt>CardInstance</dt><dd>{getTotalCardCount(game)}</dd></div>
@@ -82,21 +87,21 @@ export function GameSummary({
         </dl>
       </details>
       <div className="summary-actions">
-        {error ? <p className="error-banner">{error}</p> : <p className="quiet-banner">等待操作</p>}
+        {error ? <p className="error-banner">{error}</p> : <p className="quiet-banner">{isEnglish ? "Awaiting action" : "等待操作"}</p>}
         <div className="session-actions">
           <button
             className="secondary-button"
             onClick={(event) => onRestart(event.currentTarget)}
             type="button"
           >
-            按当前阵容重开
+            {isEnglish ? "Restart with current lineup" : "按当前阵容重开"}
           </button>
           <button
             className="secondary-button"
             onClick={(event) => onReturnToCharacterSelection(event.currentTarget)}
             type="button"
           >
-            返回角色选择
+            {isEnglish ? "Return to character selection" : "返回角色选择"}
           </button>
         </div>
       </div>

--- a/src/features/local-game/components/NewPlayerGuidance.tsx
+++ b/src/features/local-game/components/NewPlayerGuidance.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { useLocale } from "../../../app/locale";
 import type { GameState } from "../../../game/engine/types";
 import {
   getConfiguringGuidance,
@@ -22,14 +23,16 @@ export function NewPlayerGuidance({
   onVisibleChange,
   onCollapsedChange,
 }: NewPlayerGuidanceProps) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
   const showControlRef = useRef<HTMLButtonElement>(null);
   const collapseControlRef = useRef<HTMLButtonElement>(null);
   const previousVisibleRef = useRef(visible);
   const previousCollapsedRef = useRef(collapsed);
   const guidance = mode === "configuring"
-    ? getConfiguringGuidance()
+    ? getConfiguringGuidance(locale)
     : game
-      ? getPlayingGuidance(game)
+      ? getPlayingGuidance(game, locale)
       : undefined;
 
   useEffect(() => {
@@ -55,14 +58,14 @@ export function NewPlayerGuidance({
 
   if (!visible) {
     return (
-      <section className="new-player-guidance new-player-guidance--hidden" aria-label="新手引导">
+      <section className="new-player-guidance new-player-guidance--hidden" aria-label={isEnglish ? "New player guidance" : "新手引导"}>
         <button
           className="secondary-button new-player-guidance__show"
           onClick={() => onVisibleChange(true)}
           ref={showControlRef}
           type="button"
         >
-          重新显示新手引导
+          {isEnglish ? "Show new player guidance again" : "重新显示新手引导"}
         </button>
       </section>
     );
@@ -74,8 +77,8 @@ export function NewPlayerGuidance({
     <section className="debug-section new-player-guidance" aria-labelledby={`${contentId}-title`}>
       <div className="panel-heading new-player-guidance__heading">
         <div>
-          <p className="debug-kicker">首局提示 · 当前阶段</p>
-          <h2 id={`${contentId}-title`}>新手引导：{guidance.title}</h2>
+          <p className="debug-kicker">{isEnglish ? "First-game guidance · Current phase" : "首局提示 · 当前阶段"}</p>
+          <h2 id={`${contentId}-title`}>{isEnglish ? "New player guidance: " : "新手引导："}{guidance.title}</h2>
         </div>
         <button
           aria-controls={contentId}
@@ -85,24 +88,24 @@ export function NewPlayerGuidance({
           ref={collapseControlRef}
           type="button"
         >
-          {collapsed ? "展开新手引导" : "折叠新手引导"}
+          {collapsed ? (isEnglish ? "Expand guidance" : "展开新手引导") : (isEnglish ? "Collapse guidance" : "折叠新手引导")}
         </button>
       </div>
       {!collapsed ? (
         <div className="new-player-guidance__content" id={contentId}>
           <p className="new-player-guidance__actor">{guidance.actor}</p>
           <dl className="new-player-guidance__facts">
-            <div><dt>本阶段目标</dt><dd>{guidance.goal}</dd></div>
-            <div><dt>操作入口</dt><dd>{guidance.entry}</dd></div>
-            <div><dt>相关概念</dt><dd>{guidance.concept}</dd></div>
+            <div><dt>{isEnglish ? "Goal" : "本阶段目标"}</dt><dd>{guidance.goal}</dd></div>
+            <div><dt>{isEnglish ? "Action entry" : "操作入口"}</dt><dd>{guidance.entry}</dd></div>
+            <div><dt>{isEnglish ? "Concept" : "相关概念"}</dt><dd>{guidance.concept}</dd></div>
           </dl>
-          <p className="panel-note">需要完整规则说明时，请使用页面顶部“关于与帮助”。</p>
+          <p className="panel-note">{isEnglish ? "For complete rules guidance, use About & help in the header." : "需要完整规则说明时，请使用页面顶部“关于与帮助”。"}</p>
           <button
             className="secondary-button new-player-guidance__skip"
             onClick={() => onVisibleChange(false)}
             type="button"
           >
-            跳过新手引导
+            {isEnglish ? "Hide new player guidance" : "跳过新手引导"}
           </button>
         </div>
       ) : null}

--- a/src/features/local-game/components/PlayerPanel.tsx
+++ b/src/features/local-game/components/PlayerPanel.tsx
@@ -1,4 +1,5 @@
 import { getCharacterDefinition } from "../../../game/data/characterDefinitions";
+import { useLocale } from "../../../app/locale";
 import type {
   CardInstanceId,
   GameState,
@@ -6,10 +7,14 @@ import type {
 } from "../../../game/engine/types";
 import {
   getPublicCharacterSkills,
-  implementationStatusLabels,
-  skillTypeLabels,
 } from "../characterPresentation";
 import { CardDebugCard } from "./CardDebugCard";
+import {
+  getCharacterDisplayName,
+  getImplementationStatusDisplayName,
+  getPlayerDisplayName,
+  getSkillTypeDisplayName,
+} from "../presentationLocale";
 
 type PlayerPanelProps = {
   game: GameState;
@@ -29,6 +34,8 @@ export function PlayerPanel({
   showActivePlayerIndicator = true,
 }: PlayerPanelProps) {
   const character = getCharacterDefinition(player.characterId);
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
   const statusText = player.statuses.length > 0
     ? player.statuses.map((status) => `${status.statusId} (${status.id})`).join(", ")
     : "无";
@@ -37,50 +44,50 @@ export function PlayerPanel({
     <section className="debug-section player-panel" aria-labelledby={`${player.id}-title`}>
       <div className="player-panel__header">
         <div>
-          <h2 id={`${player.id}-title`}>{player.name}</h2>
-          <p>{character.name}</p>
+          <h2 id={`${player.id}-title`}>{getPlayerDisplayName(player, locale)}</h2>
+          <p>{getCharacterDisplayName(character.id, locale)}</p>
         </div>
         {showActivePlayerIndicator && game.activePlayerId === player.id ? (
-          <span className="active-pill">当前行动</span>
+          <span className="active-pill">{isEnglish ? "Active" : "当前行动"}</span>
         ) : null}
       </div>
       <dl className="player-stats">
         <div>
-          <dt>生命值</dt>
+          <dt>{isEnglish ? "HP" : "生命值"}</dt>
           <dd>
             {player.hp} / {player.maxHp}
           </dd>
         </div>
         <div>
-          <dt>淘汰</dt>
-          <dd>{player.eliminated ? "是" : "否"}</dd>
+          <dt>{isEnglish ? "Eliminated" : "淘汰"}</dt>
+          <dd>{player.eliminated ? (isEnglish ? "Yes" : "是") : (isEnglish ? "No" : "否")}</dd>
         </div>
         <div>
-          <dt>待处理状态</dt>
-          <dd>{player.statuses.length > 0 ? "有" : "无"}</dd>
+          <dt>{isEnglish ? "Pending status" : "待处理状态"}</dt>
+          <dd>{player.statuses.length > 0 ? (isEnglish ? "Yes" : "有") : (isEnglish ? "No" : "无")}</dd>
         </div>
         <div>
-          <dt>本周期 DIY</dt>
-          <dd>{player.usedDIYThisCycle ? "已用" : "未用"}</dd>
+          <dt>{isEnglish ? "DIY this cycle" : "本周期 DIY"}</dt>
+          <dd>{player.usedDIYThisCycle ? (isEnglish ? "Used" : "已用") : (isEnglish ? "Unused" : "未用")}</dd>
         </div>
         <div>
-          <dt>手牌</dt>
+          <dt>{isEnglish ? "Hand" : "手牌"}</dt>
           <dd>{player.hand.length}</dd>
         </div>
       </dl>
-      <p className="status-line">当前状态：{player.statuses.length > 0 ? "有待处理状态" : "正常"}</p>
+      <p className="status-line">{isEnglish ? "Current status" : "当前状态"}：{player.statuses.length > 0 ? (isEnglish ? "Pending status" : "有待处理状态") : (isEnglish ? "Normal" : "正常")}</p>
       <details className="debug-details">
-        <summary>调试详情</summary>
+        <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
         <p className="status-line">playerId：{player.id}</p>
-        <p className="status-line">状态：{statusText}</p>
+        <p className="status-line">{isEnglish ? "Status" : "状态"}：{statusText}</p>
       </details>
       <div className="character-readout">
         <div className="character-readout__heading">
-          <h3>角色技能</h3>
-          <span>{character.name}</span>
+          <h3>{isEnglish ? "Character skills" : "角色技能"}</h3>
+          <span>{getCharacterDisplayName(character.id, locale)}</span>
         </div>
         <ul className="character-skill-list">
-          {getPublicCharacterSkills(character).map((skill) => (
+          {getPublicCharacterSkills(character, locale).map((skill) => (
             <li key={skill.name}>
               <div className="character-skill-list__heading">
                 <strong>{skill.name}</strong>
@@ -92,9 +99,9 @@ export function PlayerPanel({
           ))}
         </ul>
         <details className="debug-details">
-          <summary>调试详情</summary>
+          <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
           {character.skills.map((skill) => (
-            <p key={skill.id}>{skill.id} · {skillTypeLabels[skill.type]} · {implementationStatusLabels[skill.implementationStatus]} · {skill.rulesText}{skill.implementationNote ? ` · ${skill.implementationNote}` : ""}</p>
+            <p key={skill.id}>{skill.id} · {getSkillTypeDisplayName(skill.type, locale)} · {getImplementationStatusDisplayName(skill.implementationStatus, locale)} · {skill.rulesText}{skill.implementationNote ? ` · ${skill.implementationNote}` : ""}</p>
           ))}
         </details>
       </div>

--- a/src/features/local-game/components/PreparationPanel.tsx
+++ b/src/features/local-game/components/PreparationPanel.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
+import { useLocale } from "../../../app/locale";
 import type { GameAction } from "../../../game/engine/actions";
 import type { CardInstanceId, GameState } from "../../../game/engine/types";
-import { getPlayerName } from "../localGameView";
 import { CardDebugCard } from "./CardDebugCard";
+import { getPlayerDisplayName } from "../presentationLocale";
 
 type PreparationPanelProps = {
   game: GameState;
@@ -10,6 +11,8 @@ type PreparationPanelProps = {
 };
 
 export function PreparationPanel({ game, dispatchGameAction }: PreparationPanelProps) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
   const pending = game.pendingLaboratoryPreparation;
   const [selectedIds, setSelectedIds] = useState<CardInstanceId[]>([]);
   const currentPlayer = game.players.find((player) => player.id === pending?.playerId);
@@ -50,15 +53,15 @@ export function PreparationPanel({ game, dispatchGameAction }: PreparationPanelP
     <section className="debug-section preparation-panel" aria-labelledby="preparation-title">
       <div className="panel-heading">
         <div>
-          <p className="debug-kicker">请保留指定数量的手牌</p>
-          <h2 id="preparation-title">实验室老师 · 备课</h2>
+          <p className="debug-kicker">{isEnglish ? "Keep the required number of cards" : "请保留指定数量的手牌"}</p>
+          <h2 id="preparation-title">{isEnglish ? "Laboratory Teacher · Preparation" : "实验室老师 · 备课"}</h2>
         </div>
         <strong className="selection-count">
-          已选 {validSelectedIds.length} / {pending.keepCount}
+          {isEnglish ? "Selected" : "已选"} {validSelectedIds.length} / {pending.keepCount}
         </strong>
       </div>
-      <p className="panel-note">当前选择玩家：{getPlayerName(game, pending.playerId)}</p>
-      <details className="debug-details"><summary>调试详情</summary><p>LABORATORY_PREPARATION</p></details>
+      <p className="panel-note">{isEnglish ? "Current selector" : "当前选择玩家"}：{getPlayerDisplayName(currentPlayer, locale)}</p>
+      <details className="debug-details"><summary>{isEnglish ? "Debug details" : "调试详情"}</summary><p>LABORATORY_PREPARATION</p></details>
       <div className="preparation-candidate-grid">
         {validCandidateIds.map((cardInstanceId) => (
           <CardDebugCard
@@ -83,7 +86,7 @@ export function PreparationPanel({ game, dispatchGameAction }: PreparationPanelP
         }}
         type="button"
       >
-        确认备课选择
+        {isEnglish ? "Confirm preparation selection" : "确认备课选择"}
       </button>
     </section>
   );

--- a/src/features/local-game/components/ResponsePanel.tsx
+++ b/src/features/local-game/components/ResponsePanel.tsx
@@ -1,4 +1,5 @@
 import type { GameAction } from "../../../game/engine/actions";
+import { useLocale } from "../../../app/locale";
 import type { GameState } from "../../../game/engine/types";
 import {
   describePendingResponse,
@@ -6,6 +7,7 @@ import {
   getResponseCards,
 } from "../localGameView";
 import { CardDebugCard } from "./CardDebugCard";
+import { getPlayerDisplayName } from "../presentationLocale";
 
 type ResponsePanelProps = {
   game: GameState;
@@ -13,6 +15,8 @@ type ResponsePanelProps = {
 };
 
 export function ResponsePanel({ game, dispatchGameAction }: ResponsePanelProps) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
   const pendingResponse = game.pendingResponse;
   const responder = pendingResponse ? getPlayer(game, pendingResponse.responderId) : undefined;
   const responseCards = responder ? getResponseCards(game, responder) : [];
@@ -25,20 +29,20 @@ export function ResponsePanel({ game, dispatchGameAction }: ResponsePanelProps) 
     <section className="debug-section response-panel" aria-labelledby="response-title">
       <div className="panel-heading">
         <div>
-          <p className="debug-kicker">当前响应者可选择合法响应牌</p>
-          <h2 id="response-title">响应窗口</h2>
+          <p className="debug-kicker">{isEnglish ? "The current responder may choose a legal response card" : "当前响应者可选择合法响应牌"}</p>
+          <h2 id="response-title">{isEnglish ? "Response window" : "响应窗口"}</h2>
         </div>
         <button
           className="secondary-button"
           onClick={() => dispatchGameAction({ type: "PASS_RESPONSE", playerId: responder.id })}
           type="button"
         >
-          放弃响应
+          {isEnglish ? "Pass response" : "放弃响应"}
         </button>
       </div>
-      <p className="panel-note">轮到 {responder.name} 决定是否响应当前效果。</p>
+      <p className="panel-note">{isEnglish ? `${getPlayerDisplayName(responder, locale)} decides whether to respond to the current effect.` : `轮到 ${responder.name} 决定是否响应当前效果。`}</p>
       <details className="debug-details">
-        <summary>调试详情</summary>
+        <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
         <p>{describePendingResponse(game)}</p>
         <p>RESPOND_WITH_CARD / PASS_RESPONSE</p>
       </details>
@@ -59,7 +63,7 @@ export function ResponsePanel({ game, dispatchGameAction }: ResponsePanelProps) 
             />
           ))
         ) : (
-          <p className="empty-note">当前响应者没有 UI 判定可用的响应牌。</p>
+          <p className="empty-note">{isEnglish ? "The current responder has no response card available according to the UI's existing check." : "当前响应者没有 UI 判定可用的响应牌。"}</p>
         )}
       </div>
     </section>

--- a/src/features/local-game/components/StatusPanel.tsx
+++ b/src/features/local-game/components/StatusPanel.tsx
@@ -1,4 +1,5 @@
 import type { GameAction } from "../../../game/engine/actions";
+import { useLocale } from "../../../app/locale";
 import type { GameState } from "../../../game/engine/types";
 import {
   getPlayer,
@@ -6,6 +7,7 @@ import {
   getStatusHandlingCards,
 } from "../localGameView";
 import { CardDebugCard } from "./CardDebugCard";
+import { getPlayerDisplayName, getStatusDisplayName } from "../presentationLocale";
 
 type StatusPanelProps = {
   game: GameState;
@@ -13,6 +15,8 @@ type StatusPanelProps = {
 };
 
 export function StatusPanel({ game, dispatchGameAction }: StatusPanelProps) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
   const pendingStatusHandling = game.pendingStatusHandling;
   const player = pendingStatusHandling ? getPlayer(game, pendingStatusHandling.playerId) : undefined;
   const status = getPlayerStatusById(player, pendingStatusHandling?.statusInstanceId);
@@ -26,8 +30,8 @@ export function StatusPanel({ game, dispatchGameAction }: StatusPanelProps) {
     <section className="debug-section status-panel" aria-labelledby="status-title">
       <div className="panel-heading">
         <div>
-          <p className="debug-kicker">请处理当前状态，或放弃处理</p>
-          <h2 id="status-title">状态处理窗口</h2>
+          <p className="debug-kicker">{isEnglish ? "Handle the current status or pass" : "请处理当前状态，或放弃处理"}</p>
+          <h2 id="status-title">{isEnglish ? "Status handling window" : "状态处理窗口"}</h2>
         </div>
         <button
           className="secondary-button"
@@ -40,13 +44,13 @@ export function StatusPanel({ game, dispatchGameAction }: StatusPanelProps) {
           }
           type="button"
         >
-          放弃处理
+          {isEnglish ? "Pass handling" : "放弃处理"}
         </button>
       </div>
       <p className="panel-note">
-        {player.name} 正在处理一项状态
+        {isEnglish ? `${getPlayerDisplayName(player, locale)} is handling ${getStatusDisplayName(status.statusId, locale)}.` : `${player.name} 正在处理一项状态`}
       </p>
-      <details className="debug-details"><summary>调试详情</summary><p>HANDLE_STATUS_WITH_CARD / PASS_STATUS_HANDLING · {status.statusId} ({status.id})</p></details>
+      <details className="debug-details"><summary>{isEnglish ? "Debug details" : "调试详情"}</summary><p>HANDLE_STATUS_WITH_CARD / PASS_STATUS_HANDLING · {status.statusId} ({status.id})</p></details>
       <div className="candidate-grid">
         {handlingCards.length > 0 ? (
           handlingCards.map((cardInstanceId) => (
@@ -65,7 +69,7 @@ export function StatusPanel({ game, dispatchGameAction }: StatusPanelProps) {
             />
           ))
         ) : (
-          <p className="empty-note">当前玩家没有 UI 判定可用的状态处理牌。</p>
+          <p className="empty-note">{isEnglish ? "The current player has no status-handling card available according to the UI's existing check." : "当前玩家没有 UI 判定可用的状态处理牌。"}</p>
         )}
       </div>
     </section>

--- a/src/features/local-game/local-game.css
+++ b/src/features/local-game/local-game.css
@@ -15,10 +15,62 @@
   padding: 12px 24px;
 }
 
-.release-bar > div {
+.release-bar > :first-child {
   display: grid;
   gap: 3px;
   min-width: 0;
+}
+
+.release-bar__actions {
+  align-items: center;
+  display: flex;
+  flex: 0 1 auto;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+  min-width: 0;
+}
+
+.locale-switch {
+  border: 1px solid #bdd0dd;
+  border-radius: 6px;
+  display: inline-flex;
+  overflow: hidden;
+}
+
+.locale-switch__button {
+  background: #f7f9fb;
+  border: 0;
+  color: #17384d;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  min-height: 32px;
+  padding: 5px 9px;
+}
+
+.locale-switch__button + .locale-switch__button {
+  border-left: 1px solid #bdd0dd;
+}
+
+.locale-switch__button[aria-pressed="true"] {
+  background: #d9edf6;
+  color: #102f40;
+}
+
+.feedback-link {
+  color: #ffffff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.feedback-link:focus-visible,
+.locale-switch__button:focus-visible {
+  outline: 3px solid #f9ca70;
+  outline-offset: 2px;
 }
 
 .release-bar strong,
@@ -1046,6 +1098,26 @@ select {
 
   .release-bar .secondary-button {
     width: 100%;
+  }
+
+  .release-bar__actions {
+    align-items: stretch;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    justify-content: stretch;
+  }
+
+  .locale-switch {
+    width: 100%;
+  }
+
+  .locale-switch__button {
+    flex: 1 1 0;
+  }
+
+  .feedback-link {
+    display: block;
+    text-align: center;
   }
 
   .local-game-page {

--- a/src/features/local-game/localGameView.ts
+++ b/src/features/local-game/localGameView.ts
@@ -2,6 +2,7 @@ import { cardDefinitions } from "../../game/data/cardDefinitions";
 import { characterDefinitions } from "../../game/data/characterDefinitions";
 import { diyRecipes, type DIYRecipe } from "../../game/data/diyRecipes";
 import { getReactionDefinition } from "../../game/data/reactions";
+import type { DisplayLocale } from "../../app/locale";
 import { canPlayCardAgainstTableReference } from "../../game/engine/cardAssociation";
 import { getAcidBaseDamageTag } from "../../game/engine/damageContext";
 import { isAlkalineAbsorptionDefinition } from "../../game/engine/multiTargetResponse";
@@ -24,6 +25,13 @@ import type {
   ReactionParticipant,
   SuccessfulReactionEvent,
 } from "../../game/engine/reactions";
+import {
+  getCardDisplayName,
+  getDiyRecipeDisplayName,
+  getReactionDisplayName,
+  getSkillDisplayName,
+  getPlayerDisplayName,
+} from "./presentationLocale";
 
 export const cardDefinitionById = new Map<string, CardDefinition>(
   cardDefinitions.map((definition) => [definition.id, definition]),
@@ -52,17 +60,35 @@ const reactionParticipantRoleLabels: Record<ReactionParticipant["role"], string>
 function describePublicReactionParticipant(
   state: GameState,
   participant: ReactionParticipant,
+  locale: DisplayLocale,
 ): string {
-  const role = reactionParticipantRoleLabels[participant.role];
+  const role = locale === "en"
+    ? {
+        attacker: "Attack source",
+        responder: "Response card",
+        "status-handler": "Status handler card",
+        "affected-status": "Status being handled",
+      }[participant.role]
+    : reactionParticipantRoleLabels[participant.role];
 
   if (participant.kind === "card") {
     const definition = cardDefinitionById.get(participant.cardDefinitionId);
-    return `${role}：${getPlayerName(state, participant.playerId)} · ${definition?.name ?? participant.cardDefinitionId}`;
+    const name = definition
+      ? getCardDisplayName(definition.id, definition.name, locale)
+      : participant.cardDefinitionId;
+    return locale === "en"
+      ? `${role}: ${getPlayerDisplayName(getPlayer(state, participant.playerId), locale)} · ${name}`
+      : `${role}：${getPlayerName(state, participant.playerId)} · ${name}`;
   }
 
   if (participant.kind === "diy") {
     const recipe = diyRecipes.find((candidate) => candidate.id === participant.recipeId);
-    return `${role}：${getPlayerName(state, participant.playerId)} · 虚拟 DIY ${recipe?.name ?? participant.recipeId}`;
+    const name = recipe
+      ? getDiyRecipeDisplayName(recipe.id, recipe.name, locale)
+      : participant.recipeId;
+    return locale === "en"
+      ? `${role}: ${getPlayerDisplayName(getPlayer(state, participant.playerId), locale)} · Virtual DIY ${name}`
+      : `${role}：${getPlayerName(state, participant.playerId)} · 虚拟 DIY ${name}`;
   }
 
   if (participant.kind === "character-skill") {
@@ -72,20 +98,25 @@ function describePublicReactionParticipant(
     const skill = characterDefinitions
       .find((definition) => definition.id === character?.characterId)
       ?.skills.find((candidate) => candidate.id === participant.skillId);
-    return `${role}：${getPlayerName(state, participant.sourcePlayerId)} · ${skill?.name ?? participant.skillId}`;
+    const name = skill ? getSkillDisplayName(skill.id, locale) : participant.skillId;
+    return locale === "en"
+      ? `${role}: ${getPlayerDisplayName(getPlayer(state, participant.sourcePlayerId), locale)} · ${name}`
+      : `${role}：${getPlayerName(state, participant.sourcePlayerId)} · ${name}`;
   }
 
-  return `${role}：${getPlayerName(state, participant.targetPlayerId)} · 待处理状态`;
+  return locale === "en"
+    ? `${role}: ${getPlayerDisplayName(getPlayer(state, participant.targetPlayerId), locale)} · Status being handled`
+    : `${role}：${getPlayerName(state, participant.targetPlayerId)} · 待处理状态`;
 }
 
-function describePublicReactionTrigger(event: SuccessfulReactionEvent): string {
+function describePublicReactionTrigger(event: SuccessfulReactionEvent, locale: DisplayLocale): string {
   switch (event.trigger.kind) {
     case "single-damage-response":
-      return "单目标伤害响应";
+      return locale === "en" ? "Single-target damage response" : "单目标伤害响应";
     case "multi-target-damage-response":
-      return "即时多目标响应";
+      return locale === "en" ? "Immediate multi-target response" : "即时多目标响应";
     case "status-handling":
-      return "状态处理响应";
+      return locale === "en" ? "Status-handling response" : "状态处理响应";
     default: {
       const exhaustiveTrigger: never = event.trigger;
       return exhaustiveTrigger;
@@ -93,14 +124,16 @@ function describePublicReactionTrigger(event: SuccessfulReactionEvent): string {
   }
 }
 
-function describePublicReactionOutcome(event: SuccessfulReactionEvent): string {
+function describePublicReactionOutcome(event: SuccessfulReactionEvent, locale: DisplayLocale): string {
   switch (event.outcome.kind) {
     case "virtual-product":
-      return `伤害已完全抵消；生成虚拟结果 ${event.outcome.product}`;
+      return locale === "en"
+        ? `Damage was fully cancelled; virtual result ${event.outcome.product} was produced`
+        : `伤害已完全抵消；生成虚拟结果 ${event.outcome.product}`;
     case "damage-cancelled":
-      return "伤害已完全抵消";
+      return locale === "en" ? "Damage was fully cancelled" : "伤害已完全抵消";
     case "status-removed":
-      return "待处理状态已移除";
+      return locale === "en" ? "The pending status was removed" : "待处理状态已移除";
     default: {
       const exhaustiveOutcome: never = event.outcome;
       return exhaustiveOutcome;
@@ -140,7 +173,7 @@ function describeReactionParticipant(
   if (participant.kind === "status") {
     return `${reactionParticipantRoleLabels[participant.role]}：${getPlayerName(state, participant.targetPlayerId)} · ${participant.statusId} (${participant.statusInstanceId})`;
   }
-  return describePublicReactionParticipant(state, participant);
+  return describePublicReactionParticipant(state, participant, "zh-CN");
 }
 
 function describeReactionTrigger(event: SuccessfulReactionEvent): string {
@@ -170,15 +203,19 @@ function describeReactionOutcome(event: SuccessfulReactionEvent): string {
 export function getPublicReactionLogView(
   state: GameState,
   entry: GameLogEntry,
+  locale: DisplayLocale = "zh-CN",
 ): ReactionLogView | undefined {
   if (!entry.reaction) return undefined;
   return {
-    name: getReactionDefinition(entry.reaction.definitionId).name,
-    trigger: describePublicReactionTrigger(entry.reaction),
-    participants: entry.reaction.participants.map((participant) =>
-      describePublicReactionParticipant(state, participant),
+    name: getReactionDisplayName(
+      entry.reaction.definitionId,
+      locale,
     ),
-    outcome: describePublicReactionOutcome(entry.reaction),
+    trigger: describePublicReactionTrigger(entry.reaction, locale),
+    participants: entry.reaction.participants.map((participant) =>
+      describePublicReactionParticipant(state, participant, locale),
+    ),
+    outcome: describePublicReactionOutcome(entry.reaction, locale),
   };
 }
 
@@ -310,14 +347,15 @@ export function describeTableReferenceAssociation(
   state: GameState,
   player: Player,
   cardInstanceId: CardInstanceId,
+  locale: DisplayLocale = "zh-CN",
 ) {
   if (!state.tableReference) {
-    return "可建立首张基准牌";
+    return locale === "en" ? "Can establish the first reference card" : "可建立首张基准牌";
   }
 
   return canPlayAgainstCurrentTableReference(state, player, cardInstanceId)
-    ? "可关联出牌"
-    : "与当前基准牌不关联";
+    ? (locale === "en" ? "Can play as associated" : "可关联出牌")
+    : (locale === "en" ? "Not associated with the current reference card" : "与当前基准牌不关联");
 }
 
 export function getMainActionCards(state: GameState, player: Player) {

--- a/src/features/local-game/newPlayerGuidance.ts
+++ b/src/features/local-game/newPlayerGuidance.ts
@@ -1,4 +1,6 @@
 import type { GamePhase, GameState, PlayerId } from "../../game/engine/types";
+import type { DisplayLocale } from "../../app/locale";
+import { getPlayerDisplayName } from "./presentationLocale";
 
 export type NewPlayerGuidancePhase =
   | "configuring"
@@ -18,8 +20,12 @@ export type NewPlayerGuidanceView = Readonly<{
   concept: string;
 }>;
 
-function getPlayerName(game: GameState, playerId: PlayerId | undefined): string {
-  return game.players.find((player) => player.id === playerId)?.name ?? "当前玩家";
+function getPlayerName(
+  game: GameState,
+  playerId: PlayerId | undefined,
+  locale: DisplayLocale,
+): string {
+  return getPlayerDisplayName(game.players.find((player) => player.id === playerId), locale);
 }
 
 const phaseCopy: Readonly<Record<Exclude<NewPlayerGuidancePhase, "configuring">, Omit<
@@ -64,7 +70,57 @@ const phaseCopy: Readonly<Record<Exclude<NewPlayerGuidancePhase, "configuring">,
   },
 };
 
-export function getConfiguringGuidance(): NewPlayerGuidanceView {
+const englishPhaseCopy: typeof phaseCopy = {
+  preparationSelection: {
+    title: "Preparation",
+    goal: "Use the existing preparation panel to choose and confirm this hand's kept cards.",
+    entry: "Use the cards and Confirm preparation selection in the Laboratory Teacher · Preparation panel below.",
+    concept: "The existing panel determines the keep count and eligible cards; guidance does not make a second decision.",
+  },
+  mainAction: {
+    title: "Main action",
+    goal: "The active player completes one main action or ends this action.",
+    entry: "Use Main action, Active DIY, character-skill entries, or End this action below.",
+    concept: "The table reference only describes the current reference; use the existing action-panel notice to determine association.",
+  },
+  responseWindow: {
+    title: "Response",
+    goal: "The current responder uses an existing response entry or passes.",
+    entry: "Use the options in Response window below, or Pass response.",
+    concept: "Response DIY is disabled in MVP0-P10; guidance does not judge whether any card is legal.",
+  },
+  statusWindow: {
+    title: "Status handling",
+    goal: "The current handler handles the pending status or uses the existing continue entry.",
+    entry: "Use the options in Status handling window below, or Pass handling.",
+    concept: "The existing status panel determines usable cards; guidance does not create or judge handling options.",
+  },
+  experimentCounterattackWindow: {
+    title: "Experiment Counterattack",
+    goal: "The current counterattacker completes this Experiment Counterattack with an implemented option.",
+    entry: "Use the currently displayed options in Experiment Counterattack selection below.",
+    concept: "The real metal option remains deferred; no missing card or option is added here.",
+  },
+  gameOver: {
+    title: "Game over",
+    goal: "Review the public log and result, then decide whether to start the next game.",
+    entry: "Review the public log and use Restart with current lineup or Return to character selection in the header.",
+    concept: "Existing resolution determined the outcome; guidance does not change the outcome or restart behavior.",
+  },
+};
+
+export function getConfiguringGuidance(locale: DisplayLocale = "zh-CN"): NewPlayerGuidanceView {
+  if (locale === "en") {
+    return {
+      phase: "configuring",
+      title: "Setup",
+      actor: "Both players",
+      goal: "Confirm the local shared-screen two-player lineup before starting this public game.",
+      entry: "Use Player A and Player B character selection and Start game below.",
+      concept: "Both hands are public; refreshing returns to the default character selections and does not save this game.",
+    };
+  }
+
   return {
     phase: "configuring",
     title: "配置",
@@ -75,50 +131,69 @@ export function getConfiguringGuidance(): NewPlayerGuidanceView {
   };
 }
 
-export function getPlayingGuidance(game: GameState): NewPlayerGuidanceView | undefined {
+export function getPlayingGuidance(
+  game: GameState,
+  locale: DisplayLocale = "zh-CN",
+): NewPlayerGuidanceView | undefined {
   const phase: GamePhase = game.phase;
+  const copy = locale === "en" ? englishPhaseCopy : phaseCopy;
 
   switch (phase) {
     case "preparationSelection":
       return {
-        ...phaseCopy.preparationSelection,
+        ...copy.preparationSelection,
         phase,
-        actor: `当前选择者：${getPlayerName(game, game.pendingLaboratoryPreparation?.playerId)}`,
+        actor: locale === "en"
+          ? `Current selector: ${getPlayerName(game, game.pendingLaboratoryPreparation?.playerId, locale)}`
+          : `当前选择者：${getPlayerName(game, game.pendingLaboratoryPreparation?.playerId, locale)}`,
       };
     case "mainAction":
       return {
-        ...phaseCopy.mainAction,
+        ...copy.mainAction,
         phase,
-        actor: `当前行动者：${getPlayerName(game, game.activePlayerId)}`,
+        actor: locale === "en"
+          ? `Active player: ${getPlayerName(game, game.activePlayerId, locale)}`
+          : `当前行动者：${getPlayerName(game, game.activePlayerId, locale)}`,
       };
     case "responseWindow":
       return {
-        ...phaseCopy.responseWindow,
+        ...copy.responseWindow,
         phase,
-        actor: `当前响应者：${getPlayerName(game, game.pendingResponse?.responderId)}`,
+        actor: locale === "en"
+          ? `Current responder: ${getPlayerName(game, game.pendingResponse?.responderId, locale)}`
+          : `当前响应者：${getPlayerName(game, game.pendingResponse?.responderId, locale)}`,
       };
     case "statusWindow":
       return {
-        ...phaseCopy.statusWindow,
+        ...copy.statusWindow,
         phase,
-        actor: `当前处理者：${getPlayerName(game, game.pendingStatusHandling?.playerId)}`,
+        actor: locale === "en"
+          ? `Current handler: ${getPlayerName(game, game.pendingStatusHandling?.playerId, locale)}`
+          : `当前处理者：${getPlayerName(game, game.pendingStatusHandling?.playerId, locale)}`,
       };
     case "experimentCounterattackWindow":
       return {
-        ...phaseCopy.experimentCounterattackWindow,
+        ...copy.experimentCounterattackWindow,
         phase,
-        actor: `当前反击者：${getPlayerName(
+        actor: locale === "en" ? `Current counterattacker: ${getPlayerName(
           game,
           game.pendingExperimentCounterattack?.responderPlayerId,
+          locale,
+        )}` : `当前反击者：${getPlayerName(
+          game,
+          game.pendingExperimentCounterattack?.responderPlayerId,
+          locale,
         )}`,
       };
     case "gameOver":
       return {
-        ...phaseCopy.gameOver,
+        ...copy.gameOver,
         phase,
         actor: game.isDraw
-          ? "本局结果：平局"
-          : `本局结果：${getPlayerName(game, game.winnerPlayerId)} 获胜`,
+          ? (locale === "en" ? "Game result: Draw" : "本局结果：平局")
+          : locale === "en"
+            ? `Game result: ${getPlayerName(game, game.winnerPlayerId, locale)} wins`
+            : `本局结果：${getPlayerName(game, game.winnerPlayerId, locale)} 获胜`,
       };
     case "setup":
     case "cycleStart":

--- a/src/features/local-game/presentationLocale.ts
+++ b/src/features/local-game/presentationLocale.ts
@@ -1,0 +1,210 @@
+import type {
+  CharacterId,
+  CharacterSkillImplementationStatus,
+  CharacterSkillType,
+  Player,
+} from "../../game/engine/types";
+import type { DisplayLocale } from "../../app/locale";
+
+type LocalizedLabel = Readonly<Record<DisplayLocale, string>>;
+
+function label(value: LocalizedLabel, locale: DisplayLocale): string {
+  return value[locale];
+}
+
+const characterNames: Readonly<Record<CharacterId, LocalizedLabel>> = {
+  laboratory_teacher: { "zh-CN": "实验室老师", en: "Laboratory Teacher" },
+  chemical_factory_ceo: { "zh-CN": "化工厂 CEO", en: "Chemical Factory CEO" },
+  clumsy_party_secretary: { "zh-CN": "手残党党委书记", en: "Clumsy Party Secretary" },
+  caustic_soda_captain: { "zh-CN": "烧碱大队队长", en: "Caustic Soda Captain" },
+  acid_king: { "zh-CN": "酸王", en: "Acid King" },
+  chemistry_enthusiast: { "zh-CN": "化学爱好者", en: "Chemistry Enthusiast" },
+  sulfuric_acid_factory_director: { "zh-CN": "硫酸厂厂长", en: "Sulfuric Acid Factory Director" },
+};
+
+const skillNames: Readonly<Record<string, LocalizedLabel>> = {
+  lesson_preparation: { "zh-CN": "备课", en: "Lesson Preparation" },
+  extra_lesson: { "zh-CN": "补课", en: "Extra Lesson" },
+  capital_reserve: { "zh-CN": "资金储备", en: "Capital Reserve" },
+  emergency_supply: { "zh-CN": "紧急调货", en: "Emergency Supply" },
+  exhaust_leak: { "zh-CN": "尾气泄漏", en: "Exhaust Leak" },
+  lab_fire: { "zh-CN": "实验台起火", en: "Laboratory Bench Fire" },
+  exothermic_accident: { "zh-CN": "强放热事故", en: "Exothermic Accident" },
+  strong_alkali_protection: { "zh-CN": "强碱防护", en: "Strong Alkali Protection" },
+  alkali_recovery: { "zh-CN": "碱液回收", en: "Alkali Recovery" },
+  strong_alkali_mastery: { "zh-CN": "强碱专精", en: "Strong Alkali Mastery" },
+  acid_corrosion: { "zh-CN": "酸性侵蚀", en: "Acid Corrosion" },
+  acid_resistant_layer: { "zh-CN": "耐酸层", en: "Acid-resistant Layer" },
+  diy_experiment: { "zh-CN": "DIY 实验", en: "DIY Experiment" },
+  experiment_counterattack: { "zh-CN": "实验反击", en: "Experiment Counterattack" },
+  exhaust_discharge: { "zh-CN": "排放尾气", en: "Exhaust Discharge" },
+  sulfuric_acid_process: { "zh-CN": "硫酸工艺", en: "Sulfuric Acid Process" },
+  sulfate_byproduct: { "zh-CN": "硫酸盐副产", en: "Sulfate Byproduct" },
+};
+
+const cardNames: Readonly<Record<string, LocalizedLabel>> = {
+  element_o: { "zh-CN": "O", en: "O" },
+  element_c: { "zh-CN": "C", en: "C" },
+  element_s: { "zh-CN": "S", en: "S" },
+  ion_h: { "zh-CN": "H+", en: "H+" },
+  ion_oh: { "zh-CN": "OH-", en: "OH-" },
+  ion_co3: { "zh-CN": "CO3^2-", en: "CO3^2-" },
+  ion_cl: { "zh-CN": "Cl-", en: "Cl-" },
+  ion_so4: { "zh-CN": "SO4^2-", en: "SO4^2-" },
+  ion_na: { "zh-CN": "Na+", en: "Na+" },
+  ion_k: { "zh-CN": "K+", en: "K+" },
+  ion_ca: { "zh-CN": "Ca2+", en: "Ca2+" },
+  substance_h2o: { "zh-CN": "H2O", en: "H2O" },
+  substance_co2: { "zh-CN": "CO2", en: "CO2" },
+  substance_o2: { "zh-CN": "O2", en: "O2" },
+  substance_so2: { "zh-CN": "SO2", en: "SO2" },
+  substance_hcl_dilute: { "zh-CN": "稀 HCl", en: "Dilute HCl" },
+  substance_h2so4_dilute: { "zh-CN": "稀 H2SO4", en: "Dilute H2SO4" },
+  substance_naoh_dilute: { "zh-CN": "稀 NaOH", en: "Dilute NaOH" },
+  substance_koh_dilute: { "zh-CN": "稀 KOH", en: "Dilute KOH" },
+  substance_caoh2_limewater: { "zh-CN": "石灰水 Ca(OH)2", en: "Limewater Ca(OH)2" },
+  substance_na2co3: { "zh-CN": "Na2CO3", en: "Na2CO3" },
+  event_lab_fire: { "zh-CN": "实验台起火", en: "Laboratory Bench Fire" },
+};
+
+const diyRecipeNames: Readonly<Record<string, LocalizedLabel>> = {
+  diy_co2_from_c_o_o: { "zh-CN": "C + O + O -> CO2", en: "C + O + O -> CO2" },
+  diy_h2o_from_h_oh: { "zh-CN": "H+ + OH- -> H2O", en: "H+ + OH- -> H2O" },
+  diy_hcl_from_h_cl: { "zh-CN": "H+ + Cl- -> 稀 HCl", en: "H+ + Cl- -> dilute HCl" },
+  diy_h2so4_from_2h_so4: { "zh-CN": "2H+ + SO4^2- -> 稀 H2SO4", en: "2H+ + SO4^2- -> dilute H2SO4" },
+  diy_naoh_from_na_oh: { "zh-CN": "Na+ + OH- -> 稀 NaOH", en: "Na+ + OH- -> dilute NaOH" },
+  diy_koh_from_k_oh: { "zh-CN": "K+ + OH- -> 稀 KOH", en: "K+ + OH- -> dilute KOH" },
+  diy_limewater_from_ca_2oh: { "zh-CN": "Ca2+ + 2OH- -> 石灰水 Ca(OH)2", en: "Ca2+ + 2OH- -> limewater Ca(OH)2" },
+  diy_so2_from_s_o_o: { "zh-CN": "S + O + O -> SO2", en: "S + O + O -> SO2" },
+};
+
+const statusNames: Readonly<Record<string, LocalizedLabel>> = {
+  SO2_LEAK: { "zh-CN": "SO2 泄漏", en: "SO2 leak" },
+  FIRE: { "zh-CN": "火情", en: "Fire" },
+};
+
+const reactionNames: Readonly<Record<string, LocalizedLabel>> = {
+  acid_base_neutralization: { "zh-CN": "酸碱中和", en: "Acid-base neutralization" },
+  acid_carbonate_co2: { "zh-CN": "酸与碳酸盐", en: "Acid and carbonate" },
+  so2_alkaline_absorption: { "zh-CN": "SO2 碱性吸收", en: "SO2 alkaline absorption" },
+};
+
+const skillTypeNames: Readonly<Record<CharacterSkillType, LocalizedLabel>> = {
+  active: { "zh-CN": "主动", en: "Active" },
+  passive: { "zh-CN": "被动", en: "Passive" },
+  response: { "zh-CN": "响应", en: "Response" },
+};
+
+const implementationStatusNames: Readonly<Record<CharacterSkillImplementationStatus, LocalizedLabel>> = {
+  "display-only-8a": { "zh-CN": "8A 仅展示", en: "8A display only" },
+  "implemented-8b-1": { "zh-CN": "8B-1 已实现", en: "8B-1 implemented" },
+  "implemented-8b-2": { "zh-CN": "8B-2 已实现", en: "8B-2 implemented" },
+  "implemented-8c-2": { "zh-CN": "8C-2 已实现", en: "8C-2 implemented" },
+  "implemented-8c-3": { "zh-CN": "8C-3 已实现", en: "8C-3 implemented" },
+  "implemented-8c-4-partial": { "zh-CN": "8C-4 部分实现", en: "8C-4 partially implemented" },
+  "implemented-phase10": { "zh-CN": "Phase 10 已实现", en: "Phase 10 implemented" },
+  "planned-8b": { "zh-CN": "8B 计划实现", en: "8B planned" },
+  "planned-8c": { "zh-CN": "8C 计划实现", en: "8C planned" },
+  deferred: { "zh-CN": "延期", en: "Deferred" },
+};
+
+export function getCharacterDisplayName(characterId: CharacterId, locale: DisplayLocale): string {
+  return label(characterNames[characterId], locale);
+}
+
+export function getSkillDisplayName(skillId: string, locale: DisplayLocale): string {
+  return skillNames[skillId] ? label(skillNames[skillId], locale) : skillId;
+}
+
+export function getCardDisplayName(definitionId: string, fallback: string, locale: DisplayLocale): string {
+  return cardNames[definitionId] ? label(cardNames[definitionId], locale) : fallback;
+}
+
+export function getDiyRecipeDisplayName(recipeId: string, fallback: string, locale: DisplayLocale): string {
+  return diyRecipeNames[recipeId] ? label(diyRecipeNames[recipeId], locale) : fallback;
+}
+
+export function getStatusDisplayName(statusId: string, locale: DisplayLocale): string {
+  return statusNames[statusId] ? label(statusNames[statusId], locale) : statusId;
+}
+
+export function getReactionDisplayName(reactionId: string, locale: DisplayLocale): string {
+  return reactionNames[reactionId] ? label(reactionNames[reactionId], locale) : reactionId;
+}
+
+export function getSkillTypeDisplayName(type: CharacterSkillType, locale: DisplayLocale): string {
+  return label(skillTypeNames[type], locale);
+}
+
+export function getImplementationStatusDisplayName(
+  status: CharacterSkillImplementationStatus,
+  locale: DisplayLocale,
+): string {
+  return label(implementationStatusNames[status], locale);
+}
+
+export function getSkillAvailabilityDisplayName(
+  status: CharacterSkillImplementationStatus,
+  locale: DisplayLocale,
+): string {
+  if (status === "implemented-8c-4-partial") {
+    return locale === "en" ? "Partially available in this playtest" : "当前试玩部分可用";
+  }
+
+  if (status.startsWith("implemented")) {
+    return locale === "en" ? "Available in this playtest" : "当前试玩可用";
+  }
+
+  return locale === "en" ? "Information only in this playtest" : "当前试玩为说明项";
+}
+
+export function getPlayerDisplayName(player: Player | undefined, locale: DisplayLocale): string {
+  if (!player) {
+    return locale === "en" ? "Current player" : "当前玩家";
+  }
+
+  if (player.id === "player_1") {
+    return locale === "en" ? "Player A" : "玩家 A";
+  }
+
+  if (player.id === "player_2") {
+    return locale === "en" ? "Player B" : "玩家 B";
+  }
+
+  return player.name;
+}
+
+const fatalMessages: Readonly<Record<string, LocalizedLabel>> = {
+  SESSION_INITIALIZATION_FAILED: {
+    "zh-CN": "本地会话初始化失败。旧状态已被隔离，请重新开始。",
+    en: "Local session initialization failed. The old state was isolated; please start again.",
+  },
+  GAME_START_FAILED: {
+    "zh-CN": "无法创建本地对局。未保留不完整的游戏状态。",
+    en: "A local game could not be created. No incomplete game state was kept.",
+  },
+  GAME_RESTART_FAILED: {
+    "zh-CN": "无法重建本地对局。旧对局已被隔离。",
+    en: "The local game could not be rebuilt. The old game was isolated.",
+  },
+  GAME_ACTION_FAILED: {
+    "zh-CN": "处理本次操作时发生致命错误。旧对局已停止运行。",
+    en: "A fatal error occurred while handling this action. The old game stopped running.",
+  },
+  GAME_RECOVERY_FAILED: {
+    "zh-CN": "恢复操作未能创建全新对局。你可以重试或返回角色选择。",
+    en: "Recovery could not create a new game. You may retry or return to character selection.",
+  },
+  GAME_STATE_VALIDATION_FAILED: {
+    "zh-CN": "新建状态未通过会话边界校验，已阻止继续运行。",
+    en: "The new state did not pass session-boundary validation, so continued operation was blocked.",
+  },
+};
+
+export function getFatalMessageDisplayName(
+  code: string,
+  fallback: string,
+  locale: DisplayLocale,
+): string {
+  return fatalMessages[code] ? label(fatalMessages[code], locale) : fallback;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app/App";
 import { installBrowserFatalHandlers } from "./app/browserFatalHandlers";
+import { LocaleProvider } from "./app/locale";
 import { RootErrorBoundary } from "./app/RootErrorBoundary";
 import { RootFailurePage } from "./app/RootFailurePage";
 import "./styles.css";
@@ -25,7 +26,11 @@ if (!rootElement) {
     }
 
     rootFailed = true;
-    root.render(<RootFailurePage code="ROOT_RUNTIME_FAILED" />);
+    root.render(
+      <LocaleProvider>
+        <RootFailurePage code="ROOT_RUNTIME_FAILED" />
+      </LocaleProvider>,
+    );
   };
 
   const cleanupBrowserHandlers = installBrowserFatalHandlers(renderRootFailure);
@@ -35,9 +40,11 @@ if (!rootElement) {
 
   root.render(
     <StrictMode>
-      <RootErrorBoundary>
-        <App />
-      </RootErrorBoundary>
+      <LocaleProvider>
+        <RootErrorBoundary>
+          <App />
+        </RootErrorBoundary>
+      </LocaleProvider>
     </StrictMode>,
   );
 }


### PR DESCRIPTION
## Summary

- add an in-memory Simplified Chinese and English display-language layer
- suggest the initial language from the browser and allow manual switching without persistence
- translate player-facing UI, guidance, cards, roles, skills, DIY recipes, statuses, and structured reactions
- preserve ordinary engine logs as the original Chinese record and disclose that boundary in English mode
- add a privacy-preserving Microsoft Forms feedback link
- make the English README the default GitHub introduction and retain the Chinese README as README.zh-CN.md

## Validation

- TypeScript build passed
- Vitest: 37 files, 508 tests passed
- fixed-seed shuffled Vitest: 37 files, 508 tests passed
- fixture Playwright: 13/13 passed
- production Playwright: 2/2 passed
- production isolation and size checks passed
- Phase 11 Debug Alpha CI passed for commit 7fc94d17a06228559a48f05aebfb84fc92fa6312

## Boundaries

- no game rules, reducer, card pool, reaction definitions, package version, lockfile, workflow, or brand asset changes
- current published version remains 0.13.0-alpha.3
- Alpha 4 is not yet released or deployed
- the known iOS 27 beta Firefox modal/root failure is not fixed by this PR