### PR TITLE
docs: add bilingual rulebook links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ This is an alpha playtest, not a stable release.
 - Use linked card play and `tableReference`, active DIY actions, character skills, the shared damage pipeline, and the currently implemented part of experiment counterattacks.
 - Trigger three structured successful reaction events: acid-base neutralization, acid-carbonate reaction, and alkaline absorption of SO2. Virtual H2O and CO2 do not create card instances.
 
+## Rulebooks
+
+- [Rulebook I](https://1drv.ms/w/c/c8f765bca077d05c/IQARVQbFTILtQowJ0BLUq5V2AWHW1TuJcgOQwLIgWzi7qEo)
+- [Rulebook II](https://1drv.ms/w/c/c8f765bca077d05c/IQDsTmoal5SMQLobZjRCmYqAASqI_D2UADagxAimsvxbDHU)
+
+These rulebooks describe the intended game rules. The current build may contain unimplemented parts or implementation differences; in case of discrepancy, the behavior of the current game build takes precedence.
+
 ## Current Features
 
 - A 68-card ordinary physical card pool. `event_lab_fire` has zero ordinary `CardInstance` entries at initialization.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ English | [简体中文](./README.zh-CN.md)
 
 **Reaction Field** is an experimental, same-screen card game for two local players, built with React and TypeScript and currently distributed as a public Web Playtest Alpha.
 
+## Rulebooks
+
+- [Rulebook I](https://1drv.ms/w/c/c8f765bca077d05c/IQARVQbFTILtQowJ0BLUq5V2AWHW1TuJcgOQwLIgWzi7qEo)
+- [Rulebook II](https://1drv.ms/w/c/c8f765bca077d05c/IQDsTmoal5SMQLobZjRCmYqAASqI_D2UADagxAimsvxbDHU)
+
+These rulebooks describe the intended game rules. The current build may contain unimplemented parts or implementation differences; in case of discrepancy, the behavior of the current game build takes precedence.
+
 ## Try the Web Playtest
 
 - Play: [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)
@@ -27,13 +34,6 @@ This is an alpha playtest, not a stable release.
 - Play through setup, preparation, cycles, turns, actions, responses, status handling, deck reshuffles, elimination, and victory resolution.
 - Use linked card play and `tableReference`, active DIY actions, character skills, the shared damage pipeline, and the currently implemented part of experiment counterattacks.
 - Trigger three structured successful reaction events: acid-base neutralization, acid-carbonate reaction, and alkaline absorption of SO2. Virtual H2O and CO2 do not create card instances.
-
-## Rulebooks
-
-- [Rulebook I](https://1drv.ms/w/c/c8f765bca077d05c/IQARVQbFTILtQowJ0BLUq5V2AWHW1TuJcgOQwLIgWzi7qEo)
-- [Rulebook II](https://1drv.ms/w/c/c8f765bca077d05c/IQDsTmoal5SMQLobZjRCmYqAASqI_D2UADagxAimsvxbDHU)
-
-These rulebooks describe the intended game rules. The current build may contain unimplemented parts or implementation differences; in case of discrepancy, the behavior of the current game build takes precedence.
 
 ## Current Features
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,6 +4,13 @@
 
 **反应域（REACTION FIELD）** 当前公开版本仍是 Reaction Field Alpha 2 / `0.13.0-alpha.3`；Alpha 4 国际试玩功能已合入 `main`，本候选正在准备 `0.14.0-alpha.1`。规则版本严格保持 `MVP0-P10`，不增加任何游戏规则。这是一个基于 React、TypeScript、Vite、Vitest 与 Playwright 的本地同屏双人公开试玩版本，不是正式发行版。
 
+## 规则书
+
+- [规则书（一）](https://1drv.ms/w/c/c8f765bca077d05c/IQCSnB79Sf12Qr23WokLeoXFASUzet25LWZcJu6Lyr1pwZ0)
+- [规则书（二）](https://1drv.ms/w/c/c8f765bca077d05c/IQAmizLdNIPeR64VpWkG0ja5ASq7JOTM1CD2C5KupV6W4Nc)
+
+本规则书描述的是游戏的目标规则；当前游戏版本可能仍有未实现内容或实现差异，请以游戏内实际表现为准。
+
 ## 当前能力
 
 - 7 个正式角色及 49 种有序双人阵容，允许镜像角色；默认预选实验室老师与化工厂 CEO。
@@ -17,13 +24,6 @@
 - 角色选择、playing 和 `gameOver` 均可打开同一个“关于与帮助”界面，查看版本、能力、操作、安全和延期边界。
 
 Web Playtest Alpha 公开双方手牌、牌堆数量、状态与完整日志。没有联网、账号、房间、存档、遥测或远程错误上报；刷新会丢失当前对局并回到默认角色预选。
-
-## 规则书
-
-- [规则书（一）](https://1drv.ms/w/c/c8f765bca077d05c/IQCSnB79Sf12Qr23WokLeoXFASUzet25LWZcJu6Lyr1pwZ0)
-- [规则书（二）](https://1drv.ms/w/c/c8f765bca077d05c/IQAmizLdNIPeR64VpWkG0ja5ASq7JOTM1CD2C5KupV6W4Nc)
-
-本规则书描述的是游戏的目标规则；当前游戏版本可能仍有未实现内容或实现差异，请以游戏内实际表现为准。
 
 ## 公开试玩地址与本轮状态
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,6 +18,13 @@
 
 Web Playtest Alpha 公开双方手牌、牌堆数量、状态与完整日志。没有联网、账号、房间、存档、遥测或远程错误上报；刷新会丢失当前对局并回到默认角色预选。
 
+## 规则书
+
+- [规则书（一）](https://1drv.ms/w/c/c8f765bca077d05c/IQCSnB79Sf12Qr23WokLeoXFASUzet25LWZcJu6Lyr1pwZ0)
+- [规则书（二）](https://1drv.ms/w/c/c8f765bca077d05c/IQAmizLdNIPeR64VpWkG0ja5ASq7JOTM1CD2C5KupV6W4Nc)
+
+本规则书描述的是游戏的目标规则；当前游戏版本可能仍有未实现内容或实现差异，请以游戏内实际表现为准。
+
 ## 公开试玩地址与本轮状态
 
 公开试玩入口为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)，GitHub Release 为 [web-playtest-v0.13.0-alpha.3](https://github.com/9947447-alt/Chemistry-online-Card-Game/releases/tag/web-playtest-v0.13.0-alpha.3)。当前公开发布事实为：对外阶段 Reaction Field Alpha 2，技术版本 `0.13.0-alpha.3`，规则版本 `MVP0-P10`，标签 `web-playtest-v0.13.0-alpha.3`，peeled commit `0f50b2c8011ee108bc4b6ab3178ad4aa0acbe6cd`。`main` 已包含完整稳定历史；Pages workflow、部署和简略公开页面验收均已成功，但这不等同于广泛跨浏览器兼容性验收。`web-playtest-v0.13.0-alpha.2` 已存在并保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 对旧 commit 的固定断言失败，alpha.2 未成功部署。`web-playtest-v0.13.0-alpha.1` 与 alpha.2 标签均保持不可变。


### PR DESCRIPTION
Adds the two English rulebooks to `README.md` and the two Chinese rulebooks to `README.zh-CN.md`, positioned near the top of each README so new visitors can find the rules immediately.

Also adds a short disclaimer clarifying that the rulebooks describe the intended rules, while the current Alpha may still contain unimplemented parts or implementation differences; the current game build remains authoritative when behavior differs.

No gameplay, engine, version, release, or configuration changes.