### PR TITLE
feat: improve first-game guidance and reaction feedback

### DIFF
--- a/docs/MVP_PLAN.md
+++ b/docs/MVP_PLAN.md
@@ -16,6 +16,11 @@
 - `docs/PHASE11_DEBUG_ALPHA_STABILITY_PLAN.md`：Phase 11 稳定性、错误恢复、E2E、CI 与静态发布准备；不是规则冻结文档。
 - `docs/PHASE12_REACTION_FIELD_WEB_PLAYTEST_FREEZE.md`：Phase 12 反应域静态 Web 试玩发布边界、标签、回滚与停止公开说明；不是规则冻结文档。
 - `docs/PHASE13_NEW_PLAYER_GUIDANCE_FREEZE.md`：Phase 13 新玩家首局引导的展示、可访问性、测试与发布边界；不改写现有规则冻结。
+- `docs/PHASE15_FIRST_GAME_CONVERSION_FREEZE.md`：Phase 15 配置页信息层级、静态示例、非模态成功反应提示和 GitHub 入口边界；不改写现有规则冻结。
+
+## Phase 15 首局转化与玩法可理解性（未发布候选）
+
+Phase 15 只调整配置页信息层级、默认折叠的双语三步示例、消费既有 `GameLogEntry.reaction` 的约两秒非模态成功反应提示，以及 About / `gameOver` 的静态 GitHub 仓库链接。规则版本保持 `MVP0-P10`，默认实验室老师 / 化工厂 CEO 阵容不变，不新增媒体或外部请求，也不修改 engine、data、game tests、reaction definitions、Forms、版本、size gate 或发布状态。
 
 ## Phase 12 发布边界
 

--- a/docs/PHASE15_FIRST_GAME_CONVERSION_FREEZE.md
+++ b/docs/PHASE15_FIRST_GAME_CONVERSION_FREEZE.md
@@ -1,0 +1,47 @@
+# Phase 15 首局转化与玩法可理解性冻结
+
+## 结论与范围
+
+Phase 15 只调整 Reaction Field `0.14.0-alpha.1` 候选的展示层信息层级、静态玩法示例、成功反应即时提示和 GitHub 公共入口。规则版本继续为 `MVP0-P10`；本阶段不修改游戏规则、引擎、数据、卡池、默认阵容、版本或发布状态。
+
+本实现尚未提交、发布或部署。当前 Web Playtest 的规则权威继续是 `docs/MVP0_RULE_FREEZE.md` 及 Phase 8–13 冻结文档。
+
+## 配置页与引导
+
+配置页顺序冻结为：release bar；品牌与一句话玩法说明；玩家 A/B 角色选择、阵容摘要和开始按钮；一句话当前目标；默认折叠的详细引导；默认折叠的三步玩法示例；七角色资料。
+
+- `guidance.goal` 始终可见；actor、操作入口、相关概念和完整帮助入口默认折叠。
+- 折叠、展开、隐藏和重新显示继续使用普通按钮，保留 `aria-expanded`、`aria-controls` 与用户触发后的稳定焦点。
+- 引导不自动聚焦，不使用 modal、coach mark、storage、网络或 `GameAction`。
+- playing sidebar 仍先显示当前目标，再显示既有阶段操作面板；不改变面板顺序或合法性。
+- 三步示例只说明“出牌、响应、反应与记录”的界面流程，不判断卡牌合法性，不承诺每次出牌产生反应，不 dispatch action，也不提供策略建议。
+
+## 成功反应提示
+
+即时提示的唯一数据路径为：`GameState.log[]` → `GameLogEntry.reaction` → `SuccessfulReactionEvent` → `getPublicReactionLogView(...)`。
+
+- 只显示最新且尚未展示的结构化成功反应；不解析普通日志 `message`。
+- 覆盖 `acid_base_neutralization`、`acid_carbonate_co2` 和 `so2_alkaline_absorption`，包括 SO2 的即时多目标响应与状态处理两条正式 trigger。
+- `FIRE`、普通日志、pass、非法 action 和没有结构化事件的行为不触发。
+- 提示约 2000ms 后由 timer 清除；新事件重置 timer；卸载或没有 reaction 的新会话清理提示。
+- 提示使用 `role="status"` 与 polite announcement，不获取焦点、不遮挡控件、不阻断输入。永久记录仍保留在公开日志。
+- `prefers-reduced-motion: reduce` 下关闭非必要动画；内容和 timer 生命周期不依赖动画。
+
+## 公共入口与隐私
+
+- About 与 `gameOver` 各提供一个指向 `https://github.com/9947447-alt/Chemistry-online-Card-Game` 的普通 `<a>`，使用 `target="_blank" rel="noopener noreferrer"`。
+- 不使用 iframe、预取、preconnect、fetch、XHR、sendBeacon、`window.open`、跟踪参数或运行时数据拼接。
+- Microsoft Forms endpoint、页头入口、隐私说明和零自动数据传递边界保持不变；GitHub 与 Forms 不合并为数据组件。
+
+## 规则手册与默认阵容
+
+- Core Rulebook 只能作为 Extended tabletop reference；本阶段不接入页面。
+- Ion Reactions & DIY Manual 与当前 Web 规则冲突过多；本阶段不得公开链接。
+- 不宣称 OneDrive 在线内容已经验证。
+- 默认阵容保持玩家 A“实验室老师”、玩家 B“化工厂 CEO”；初始化、备课、HP、手牌、deck 和角色规则不变。
+
+## 媒体、体积与发布边界
+
+本阶段只使用 HTML/CSS 文本示例，不新增图片、GIF、MP4、WebM、poster 或字幕文件，不增加外部请求，不提高任何 size limit。
+
+本阶段不得修改 `src/game/engine/**`、`src/game/data/**`、`src/game/tests/**`、`ModalDialog.tsx`、Forms endpoint、依赖和锁文件、版本与发布元数据、品牌资源、Vite/Playwright 配置、CI、标签、Release、Pages 或 iOS Firefox 热修复。iOS 27 beta Firefox 的已知问题仍未验证修复。

--- a/e2e/production/reaction-field.spec.ts
+++ b/e2e/production/reaction-field.spec.ts
@@ -135,6 +135,15 @@ for (const [path, assetPrefix, brandPrefix] of [["/", "/assets/", "/"], ["/playt
     }
     await expect(page.getByRole("heading", { name: "反应域 · 本地双人角色选择" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "新手引导：配置" })).toBeVisible();
+    await expect(page.getByText(
+      "当前目标：确认本地同屏双人阵容后，再开始本局公开对局。",
+      { exact: true },
+    )).toBeVisible();
+    await expect(page.getByRole("button", { name: "展开新手引导" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    await expect(page.locator(".first-game-example details")).not.toHaveAttribute("open", "");
     await expect(page.locator(".release-bar .secondary-brand")).toHaveText("REACTION FIELD");
     const feedback = page.getByRole("link", { name: "在新标签页打开 Microsoft Forms 反馈表" });
     await expect(feedback).toHaveAttribute("href", "https://forms.cloud.microsoft/r/QG8PACUnsa");
@@ -146,10 +155,18 @@ for (const [path, assetPrefix, brandPrefix] of [["/", "/assets/", "/"], ["/playt
     await expect(page.getByLabel("player_1 角色")).toHaveValue("laboratory_teacher");
     await expect(page.getByLabel("player_2 角色")).toHaveValue("chemical_factory_ceo");
     await page.getByRole("button", { name: "关于与帮助" }).click();
-    await expect(page.getByRole("dialog", { name: "关于与帮助" })).toContainText("REACTION FIELD");
-    await expect(page.getByRole("dialog", { name: "关于与帮助" })).toContainText("0.14.0-alpha.1");
-    await expect(page.getByRole("dialog", { name: "关于与帮助" })).toContainText("MVP0-P10");
-    await expect(page.getByRole("dialog", { name: "关于与帮助" })).toContainText(expectedBuildCommit);
+    const about = page.getByRole("dialog", { name: "关于与帮助" });
+    await expect(about).toContainText("REACTION FIELD");
+    await expect(about).toContainText("0.14.0-alpha.1");
+    await expect(about).toContainText("MVP0-P10");
+    await expect(about).toContainText(expectedBuildCommit);
+    const repository = about.getByRole("link", { name: "在新标签页打开反应域 GitHub 仓库" });
+    await expect(repository).toHaveAttribute(
+      "href",
+      "https://github.com/9947447-alt/Chemistry-online-Card-Game",
+    );
+    await expect(repository).toHaveAttribute("target", "_blank");
+    await expect(repository).toHaveAttribute("rel", "noopener noreferrer");
     await page.keyboard.press("Escape");
     await page.getByLabel("player_1 角色").selectOption("chemical_factory_ceo");
     await page.getByLabel("player_2 角色").selectOption("acid_king");

--- a/e2e/tests/debug-alpha.spec.ts
+++ b/e2e/tests/debug-alpha.spec.ts
@@ -13,6 +13,9 @@ const test = base.extend<{ runtimeErrors: string[] }>({
       }
     });
     page.on("pageerror", (error) => errors.push(`pageerror: ${error.message}`));
+    page.on("requestfailed", (request) => errors.push(
+      `requestfailed: ${request.method()} ${request.url()} ${request.failure()?.errorText ?? "unknown"}`,
+    ));
     await use(errors);
     expect(errors).toEqual([]);
   },
@@ -64,6 +67,10 @@ async function expectGuidanceCopy(
   concept: string,
 ) {
   await expect(page.getByRole("heading", { name: heading })).toBeVisible();
+  const expand = page.getByRole("button", { name: "展开新手引导" });
+  if (await expand.isVisible().catch(() => false)) {
+    await expand.click();
+  }
   await expect(page.getByText(actor, { exact: true })).toBeVisible();
   await expect(page.getByText(entry, { exact: true })).toBeVisible();
   await expect(page.getByText(concept, { exact: true })).toBeVisible();
@@ -107,9 +114,12 @@ async function openAndCloseAbout(page: Page) {
   await expect(page.locator(".application-shell")).toHaveAttribute("inert", "");
   await expect(page.getByRole("alertdialog")).toHaveCount(0);
   const closeButton = page.getByRole("button", { name: "关闭帮助" });
+  const repositoryLink = dialog.getByRole("link", {
+    name: "在新标签页打开反应域 GitHub 仓库",
+  });
   await expect(closeButton).toBeFocused();
   await page.keyboard.press("Shift+Tab");
-  await expect(closeButton).toBeFocused();
+  await expect(repositoryLink).toBeFocused();
   await page.keyboard.press("Tab");
   await expect(closeButton).toBeFocused();
   await closeButton.click();
@@ -201,8 +211,44 @@ test("Alpha 4 English display covers setup, all public phases, dialogs, and fata
 
   await switchToEnglish("/");
   await expect(page.getByRole("heading", { name: "REACTION FIELD · Local two-player character selection" })).toBeVisible();
+  await expect(page.getByText(
+    "Current goal: Confirm the local shared-screen two-player lineup before starting this public game.",
+    { exact: true },
+  )).toBeVisible();
+  await expect(page.getByRole("button", { name: "Expand guidance" })).toHaveAttribute(
+    "aria-expanded",
+    "false",
+  );
+  await page.getByRole("button", { name: "Expand guidance" }).click();
+  await page.getByRole("button", { name: "Hide new player guidance" }).click();
+  const englishRestore = page.getByRole("button", { name: "Show new player guidance again" });
+  await expect(page.getByText(
+    "Current goal: Confirm the local shared-screen two-player lineup before starting this public game.",
+    { exact: true },
+  )).toBeVisible();
+  await expect(page.getByText("Both players", { exact: true })).toBeHidden();
+  await expect(page.getByText(
+    "Use Player A and Player B character selection and Start game below.",
+    { exact: true },
+  )).toBeHidden();
+  await expect(page.getByText(
+    "Both hands are public; refreshing returns to the default character selections and does not save this game.",
+    { exact: true },
+  )).toBeHidden();
+  await expect(englishRestore).toBeFocused();
+  await englishRestore.click();
+  await expect(page.getByRole("button", { name: "Collapse guidance" })).toBeFocused();
+  await expect(page.getByText("Both players", { exact: true })).toBeVisible();
+  await page.locator(".first-game-example summary").click();
+  await expect(page.locator(".first-game-example")).toContainText(
+    "Play a card: The active player chooses a card through the available action controls.",
+  );
   await page.getByRole("button", { name: "About & help" }).click();
-  await expect(page.getByRole("dialog", { name: "About & help" })).toBeVisible();
+  const englishAbout = page.getByRole("dialog", { name: "About & help" });
+  await expect(englishAbout).toBeVisible();
+  await expect(englishAbout.getByRole("link", {
+    name: "Open the Reaction Field GitHub repository in a new tab",
+  })).toHaveAttribute("rel", "noopener noreferrer");
   await page.getByRole("button", { name: "Close help" }).click();
 
   await page.getByRole("button", { name: "Start game" }).click();
@@ -223,7 +269,10 @@ test("Alpha 4 English display covers setup, all public phases, dialogs, and fata
   await switchToEnglish("/?scenario=experiment-counterattack-window");
   await expect(page.getByRole("heading", { name: "Experiment Counterattack selection" })).toBeVisible();
   await switchToEnglish("/?scenario=reaction-h2o");
-  await expect(page.getByText("Successful reaction · Acid-base neutralization", { exact: true })).toBeVisible();
+  await expect(page.locator(".successful-reaction-notice")).toHaveCount(0);
+  await expect(page.locator(".game-log__reaction")).toContainText(
+    "Successful reaction · Acid-base neutralization",
+  );
   await switchToEnglish("/?scenario=game-over");
   await expect(page.getByRole("heading", { name: "Game over", exact: true })).toBeVisible();
   await switchToEnglish("/?scenario=fatal");
@@ -259,6 +308,53 @@ test("默认配置、正式元数据与 configuring 帮助界面", async ({ page
 test("新手引导覆盖真实流程和 fixture 窗口，并保持可键盘恢复", async ({ page, runtimeErrors }) => {
   void runtimeErrors;
   await page.goto("/");
+  await expect(page.getByText(
+    "当前目标：确认本地同屏双人阵容后，再开始本局公开对局。",
+    { exact: true },
+  )).toBeVisible();
+  const initialExpand = page.getByRole("button", { name: "展开新手引导" });
+  await expect(initialExpand).toHaveAttribute("aria-expanded", "false");
+  await expect(page.getByText("双方玩家", { exact: true })).toBeHidden();
+
+  const playerASelect = page.getByLabel("player_1 角色");
+  const playerBSelect = page.getByLabel("player_2 角色");
+  const startButton = page.getByRole("button", { name: "开始游戏" });
+  const firstGameExample = page.locator(".first-game-example");
+  expect(await page.evaluate(() => {
+    const playerA = document.querySelector('[aria-label="player_1 角色"]');
+    const playerB = document.querySelector('[aria-label="player_2 角色"]');
+    const start = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent === "开始游戏",
+    );
+    const guidance = document.querySelector(".new-player-guidance");
+    const example = document.querySelector(".first-game-example");
+    const catalog = document.querySelector(".character-catalog");
+    if (!playerA || !playerB || !start || !guidance || !example || !catalog) return false;
+    const follows = (left: Node, right: Node) => Boolean(
+      left.compareDocumentPosition(right) & Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    return follows(playerA, playerB) && follows(playerB, start) &&
+      follows(start, guidance) && follows(guidance, example) && follows(example, catalog);
+  })).toBe(true);
+
+  await playerASelect.focus();
+  await page.keyboard.press("Tab");
+  await expect(playerBSelect).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(startButton).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(initialExpand).toBeFocused();
+
+  const exampleDetails = firstGameExample.locator("details");
+  await expect(exampleDetails).not.toHaveAttribute("open", "");
+  await exampleDetails.locator("summary").click();
+  await expect(firstGameExample).toContainText("出牌：当前玩家选择一张符合现有操作条件的牌。");
+  await expect(firstGameExample).toContainText("响应：另一位玩家可使用现有响应入口。");
+  await expect(firstGameExample).toContainText(
+    "反应与记录：若形成已实现的成功反应，结果显示并写入公开日志。",
+  );
+  await expect(firstGameExample.locator("button")).toHaveCount(0);
+
   await expectGuidanceCopy(
     page,
     "新手引导：配置",
@@ -281,6 +377,19 @@ test("新手引导覆盖真实流程和 fixture 窗口，并保持可键盘恢�
   await skip.focus();
   await page.keyboard.press("Space");
   const show = page.getByRole("button", { name: "重新显示新手引导" });
+  await expect(page.getByText(
+    "当前目标：确认本地同屏双人阵容后，再开始本局公开对局。",
+    { exact: true },
+  )).toBeVisible();
+  await expect(page.getByText("双方玩家", { exact: true })).toBeHidden();
+  await expect(page.getByText(
+    "使用下方“玩家 A”“玩家 B”角色选择与“开始游戏”。",
+    { exact: true },
+  )).toBeHidden();
+  await expect(page.getByText(
+    "双方手牌公开；刷新页面会回到默认角色预选，不保存当前对局。",
+    { exact: true },
+  )).toBeHidden();
   await expect(show).toBeFocused();
   expect(await readGuidanceInvariants(page)).toEqual(configuringGuidanceBaseline);
   await page.keyboard.press("Enter");
@@ -490,8 +599,23 @@ test("gameOver 后重开和返回角色选择均无需确认，帮助仍可访�
   await page.goto("/?scenario=game-over");
   await expectFactoryCount(page, 1);
   await expect(page.getByRole("heading", { name: "本地双人公开对局" })).toBeVisible();
+  const gameOverRepository = page.getByRole("link", { name: "在新标签页打开反应域 GitHub 仓库" });
+  await expect(gameOverRepository).toHaveAttribute(
+    "href",
+    "https://github.com/9947447-alt/Chemistry-online-Card-Game",
+  );
+  await expect(gameOverRepository).toHaveAttribute("target", "_blank");
+  await expect(gameOverRepository).toHaveAttribute("rel", "noopener noreferrer");
   await page.getByRole("button", { name: "关于与帮助" }).click();
-  await expect(page.getByRole("dialog", { name: "关于与帮助" })).toBeVisible();
+  const about = page.getByRole("dialog", { name: "关于与帮助" });
+  await expect(about).toBeVisible();
+  const aboutRepository = about.getByRole("link", { name: "在新标签页打开反应域 GitHub 仓库" });
+  await expect(aboutRepository).toHaveAttribute(
+    "href",
+    "https://github.com/9947447-alt/Chemistry-online-Card-Game",
+  );
+  await expect(aboutRepository).toHaveAttribute("target", "_blank");
+  await expect(aboutRepository).toHaveAttribute("rel", "noopener noreferrer");
   await page.getByRole("button", { name: "关闭帮助" }).click();
 
   await page.getByRole("button", { name: "按当前阵容重开" }).click();
@@ -541,17 +665,25 @@ test("React ErrorBoundary 显示脱敏兜底且提供重新加载", async ({ pag
 test("成功反应公开摘要不泄漏内部状态标识，调试详情保留结构化诊断", async ({ page, runtimeErrors }) => {
   void runtimeErrors;
   await page.goto("/?scenario=reaction-h2o");
-  await expect(page.getByText("伤害已完全抵消；生成虚拟结果 H2O")).toBeVisible();
+  await expect(page.locator(".successful-reaction-notice")).toHaveCount(0);
+  await expect(page.locator(".game-log__reaction")).toContainText("成功反应 · 酸碱中和");
+  await expect(page.locator(".game-log__reaction")).toContainText("伤害已完全抵消；生成虚拟结果 H2O");
 
   await page.goto("/?scenario=reaction-co2");
-  await expect(page.getByText("伤害已完全抵消；生成虚拟结果 CO2")).toBeVisible();
+  await expect(page.locator(".successful-reaction-notice")).toHaveCount(0);
+  await expect(page.locator(".game-log__reaction")).toContainText("成功反应 · 酸与碳酸盐");
+  await expect(page.locator(".game-log__reaction")).toContainText("伤害已完全抵消；生成虚拟结果 CO2");
 
   await page.goto("/?scenario=reaction-so2-immediate");
+  await expect(page.locator(".successful-reaction-notice")).toHaveCount(0);
+  await expect(page.locator(".game-log__reaction")).toContainText("成功反应 · SO2 碱性吸收");
   await expect(page.getByText("入口：即时多目标响应")).toBeVisible();
   await expect(page.getByText("结果：伤害已完全抵消")).toBeVisible();
 
   await page.goto("/?scenario=reaction-so2-status");
+  await expect(page.locator(".successful-reaction-notice")).toHaveCount(0);
   const reaction = page.locator(".game-log__reaction");
+  await expect(reaction).toContainText("成功反应 · SO2 碱性吸收");
   await expect(reaction).toContainText("入口：状态处理响应");
   await expect(reaction).toContainText("结果：待处理状态已移除");
   await expect(reaction).not.toContainText("status_phase11_fixture_so2");
@@ -560,6 +692,30 @@ test("成功反应公开摘要不泄漏内部状态标识，调试详情保留�
   await expect(details).not.toHaveAttribute("open", "");
   await details.locator("summary").click();
   await expect(details).toContainText("status_phase11_fixture_so2");
+
+  await page.goto("/?scenario=response-window");
+  await expect(page.locator(".successful-reaction-notice")).toHaveCount(0);
+  await page.locator(".response-panel").getByRole("button", {
+    name: "稀 NaOH 可在当前对局中选择",
+  }).click();
+  await expect(page.locator(".successful-reaction-notice")).toContainText("成功反应 · 酸碱中和");
+  await expect(page.locator(".game-log__reaction")).toContainText("成功反应 · 酸碱中和");
+  await page.getByRole("button", { name: "English" }).click();
+  await expect(page.locator(".successful-reaction-notice")).toContainText(
+    "Successful reaction · Acid-base neutralization",
+  );
+  await expect(page.locator(".successful-reaction-notice")).toBeHidden({ timeout: 3000 });
+  await page.getByRole("button", { name: "中文" }).click();
+  await expect(page.locator(".successful-reaction-notice")).toBeHidden();
+  await expect(page.locator(".game-log__reaction")).toContainText("成功反应 · 酸碱中和");
+
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/?scenario=response-window");
+  await page.locator(".response-panel").getByRole("button", {
+    name: "稀 NaOH 可在当前对局中选择",
+  }).click();
+  await expect(page.locator(".successful-reaction-notice")).toBeVisible();
+  await expect(page.locator(".successful-reaction-notice")).toHaveCSS("animation-name", "none");
 });
 
 test("真实 reducer 长日志可滚动且页面无水平溢出", async ({ page, runtimeErrors }) => {
@@ -644,6 +800,19 @@ test("390×844 覆盖 configuring、playing、reaction、About、fatal 与 gameO
   await gameOverSkip.focus();
   await page.keyboard.press("Space");
   const gameOverShow = page.getByRole("button", { name: "重新显示新手引导" });
+  await expect(page.getByText(
+    "当前目标：查看公开日志与结果，再决定是否开始下一局。",
+    { exact: true },
+  )).toBeVisible();
+  await expect(page.getByText("本局结果：玩家 B 获胜", { exact: true })).toBeHidden();
+  await expect(page.getByText(
+    "查看公开日志，并使用页面顶部“按当前阵容重开”或“返回角色选择”。",
+    { exact: true },
+  )).toBeHidden();
+  await expect(page.getByText(
+    "结果已由既有对局结算确定；引导不改变胜负或重开行为。",
+    { exact: true },
+  )).toBeHidden();
   await expect(gameOverShow).toBeFocused();
   expect(await readGuidanceInvariants(page)).toEqual(gameOverGuidanceBaseline);
   await expectNoHorizontalOverflow(page);

--- a/src/app/projectRepository.test.tsx
+++ b/src/app/projectRepository.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it } from "vitest";
+import { ProjectRepositoryLink, projectRepositoryUrl } from "./projectRepository";
+
+describe("Phase 15 project repository link", () => {
+  it("uses only the approved static GitHub URL and safe new-tab attributes", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => root.render(createElement(ProjectRepositoryLink)));
+      const link = container.querySelector("a");
+
+      expect(projectRepositoryUrl).toBe(
+        "https://github.com/9947447-alt/Chemistry-online-Card-Game",
+      );
+      expect(link?.getAttribute("href")).toBe(projectRepositoryUrl);
+      expect(link?.getAttribute("target")).toBe("_blank");
+      expect(link?.getAttribute("rel")).toBe("noopener noreferrer");
+      expect(link?.getAttribute("aria-label")).toContain("GitHub");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+});

--- a/src/app/projectRepository.tsx
+++ b/src/app/projectRepository.tsx
@@ -1,0 +1,25 @@
+import { useLocale } from "./locale";
+
+export const projectRepositoryUrl =
+  "https://github.com/9947447-alt/Chemistry-online-Card-Game";
+
+export function ProjectRepositoryLink() {
+  const { locale } = useLocale();
+  const label = locale === "en"
+    ? "Open the Reaction Field GitHub repository in a new tab"
+    : "在新标签页打开反应域 GitHub 仓库";
+
+  return (
+    <a
+      aria-label={label}
+      className="project-repository-link"
+      href={projectRepositoryUrl}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      {locale === "en"
+        ? "GitHub repository (opens in a new tab)"
+        : "GitHub 仓库（将在新标签页打开）"}
+    </a>
+  );
+}

--- a/src/features/local-game/LocalGamePage.tsx
+++ b/src/features/local-game/LocalGamePage.tsx
@@ -2,6 +2,7 @@ import "./local-game.css";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { FeedbackLink } from "../../app/feedback";
 import { LocaleSwitch, useLocale } from "../../app/locale";
+import { ProjectRepositoryLink } from "../../app/projectRepository";
 import { releaseMetadata } from "../../app/releaseMetadata";
 import type { GameAction } from "../../game/engine/actions";
 import type { CardInstanceId } from "../../game/engine/types";
@@ -22,6 +23,7 @@ import { PlayerPanel } from "./components/PlayerPanel";
 import { PreparationPanel } from "./components/PreparationPanel";
 import { ResponsePanel } from "./components/ResponsePanel";
 import { StatusPanel } from "./components/StatusPanel";
+import { SuccessfulReactionNotice } from "./components/SuccessfulReactionNotice";
 import { useLocalGameDebug } from "./hooks/useLocalGameDebug";
 import type {
   LocalGameEngineReducer,
@@ -76,6 +78,7 @@ function PlayingGame({
         onRestart={(trigger) => onRequestSessionExit("restart", trigger)}
         onReturnToCharacterSelection={(trigger) => onRequestSessionExit("return", trigger)}
       />
+      <SuccessfulReactionNotice game={game} />
       <div className="debug-layout">
         <div className="debug-main">
           <div className="players-grid">
@@ -128,6 +131,7 @@ function PlayingGame({
               <p className="panel-note">
                 {isEnglish ? "Review the full log, or use the header to restart with the current lineup or return to character selection." : "可以查看完整日志，或使用顶部“按当前阵容重开”“返回角色选择”。"}
               </p>
+              <ProjectRepositoryLink />
             </section>
           ) : null}
         </aside>
@@ -158,7 +162,7 @@ export function LocalGamePage({
   const [aboutOpen, setAboutOpen] = useState(false);
   const [confirmation, setConfirmation] = useState<PendingSessionConfirmation | null>(null);
   const [guidanceVisible, setGuidanceVisible] = useState(true);
-  const [guidanceCollapsed, setGuidanceCollapsed] = useState(false);
+  const [guidanceCollapsed, setGuidanceCollapsed] = useState(true);
   const aboutTriggerRef = useRef<HTMLButtonElement>(null);
   const confirmationExecutedRef = useRef(false);
   const playingPhase = session.mode === "playing" ? session.game.phase : session.mode;

--- a/src/features/local-game/components/AboutDialog.tsx
+++ b/src/features/local-game/components/AboutDialog.tsx
@@ -1,6 +1,7 @@
 import { useRef } from "react";
 import { useLocale } from "../../../app/locale";
 import { releaseMetadata } from "../../../app/releaseMetadata";
+import { ProjectRepositoryLink } from "../../../app/projectRepository";
 import { characterDefinitions } from "../../../game/data/characterDefinitions";
 import {
   getPublicCharacterSkills,
@@ -57,6 +58,7 @@ export function AboutDialog({ onClose }: AboutDialogProps) {
             <div><dt>{isEnglish ? "Rules version" : "规则版本"}</dt><dd>{releaseMetadata.rulesVersion}</dd></div>
             <div><dt>Commit</dt><dd>{releaseMetadata.commit}</dd></div>
           </dl>
+          <ProjectRepositoryLink />
         </section>
 
         <section className="about-section">

--- a/src/features/local-game/components/CharacterSelectionPanel.tsx
+++ b/src/features/local-game/components/CharacterSelectionPanel.tsx
@@ -15,6 +15,7 @@ import {
   getImplementationStatusDisplayName,
   getSkillTypeDisplayName,
 } from "../presentationLocale";
+import { FirstGameExample } from "./FirstGameExample";
 
 type CharacterSelectionPanelProps = {
   session: ConfiguringLocalGameSession;
@@ -42,13 +43,6 @@ export function CharacterSelectionPanel({
 
   return (
     <main className="local-game-page character-selection-page">
-      <NewPlayerGuidance
-        collapsed={guidanceCollapsed}
-        mode="configuring"
-        onCollapsedChange={onGuidanceCollapsedChange}
-        onVisibleChange={onGuidanceVisibleChange}
-        visible={guidanceVisible}
-      />
       <section className="debug-section character-selection-hero" aria-labelledby="character-selection-title">
         <div className="character-selection-hero__heading">
           <img
@@ -117,6 +111,16 @@ export function CharacterSelectionPanel({
           {isEnglish ? "Start game" : "开始游戏"}
         </button>
       </section>
+
+      <NewPlayerGuidance
+        collapsed={guidanceCollapsed}
+        mode="configuring"
+        onCollapsedChange={onGuidanceCollapsedChange}
+        onVisibleChange={onGuidanceVisibleChange}
+        visible={guidanceVisible}
+      />
+
+      <FirstGameExample />
 
       <section className="character-catalog" aria-labelledby="character-catalog-title">
         <div className="character-catalog__heading">

--- a/src/features/local-game/components/FirstGameExample.test.tsx
+++ b/src/features/local-game/components/FirstGameExample.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it } from "vitest";
+import { LocaleProvider, LocaleSwitch } from "../../../app/locale";
+import { FirstGameExample } from "./FirstGameExample";
+
+beforeEach(() => {
+  Object.defineProperty(globalThis.navigator, "language", {
+    configurable: true,
+    value: "zh-CN",
+  });
+  Object.defineProperty(globalThis.navigator, "languages", {
+    configurable: true,
+    value: ["zh-CN"],
+  });
+});
+
+describe("Phase 15 static first-game example", () => {
+  it("is collapsed by default and contains the exact Chinese three-step copy", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => root.render(
+        createElement(LocaleProvider, null, createElement(FirstGameExample)),
+      ));
+      const details = container.querySelector("details");
+      expect(details?.open).toBe(false);
+      expect(container.textContent).toContain("出牌：当前玩家选择一张符合现有操作条件的牌。");
+      expect(container.textContent).toContain("响应：另一位玩家可使用现有响应入口。");
+      expect(container.textContent).toContain(
+        "反应与记录：若形成已实现的成功反应，结果显示并写入公开日志。",
+      );
+      expect(container.querySelector("button")).toBeNull();
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  it("switches to the exact English copy without adding an action control", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => root.render(
+        createElement(LocaleProvider, null, createElement("div", null,
+          createElement(LocaleSwitch),
+          createElement(FirstGameExample),
+        )),
+      ));
+      const englishButton = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "English",
+      );
+      if (!englishButton) throw new Error("Expected English locale control.");
+      await act(async () => englishButton.click());
+      expect(container.textContent).toContain(
+        "Play a card: The active player chooses a card through the available action controls.",
+      );
+      expect(container.textContent).toContain(
+        "Respond: The other player may use the available response controls.",
+      );
+      expect(container.textContent).toContain(
+        "Resolve and record: If an implemented successful reaction occurs, its result is shown and recorded in the public log.",
+      );
+      expect(container.querySelector(".first-game-example button")).toBeNull();
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+});

--- a/src/features/local-game/components/FirstGameExample.tsx
+++ b/src/features/local-game/components/FirstGameExample.tsx
@@ -1,0 +1,42 @@
+import { useLocale } from "../../../app/locale";
+
+export function FirstGameExample() {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
+
+  return (
+    <section className="debug-section first-game-example" aria-labelledby="first-game-example-title">
+      <p className="debug-kicker">
+        {isEnglish ? "Three-step example · Display only" : "三步玩法示例 · 仅作展示"}
+      </p>
+      <h2 id="first-game-example-title">
+        {isEnglish ? "See how one action can resolve" : "查看一次行动如何结算"}
+      </h2>
+      <details className="first-game-example__details">
+        <summary>{isEnglish ? "Open the three-step example" : "展开三步玩法示例"}</summary>
+        <ol>
+          <li>
+            {isEnglish
+              ? "Play a card: The active player chooses a card through the available action controls."
+              : "出牌：当前玩家选择一张符合现有操作条件的牌。"}
+          </li>
+          <li>
+            {isEnglish
+              ? "Respond: The other player may use the available response controls."
+              : "响应：另一位玩家可使用现有响应入口。"}
+          </li>
+          <li>
+            {isEnglish
+              ? "Resolve and record: If an implemented successful reaction occurs, its result is shown and recorded in the public log."
+              : "反应与记录：若形成已实现的成功反应，结果显示并写入公开日志。"}
+          </li>
+        </ol>
+        <p className="panel-note">
+          {isEnglish
+            ? "This example does not judge card legality and does not imply that every play creates a reaction."
+            : "本示例不判断卡牌合法性，也不表示每次出牌都会产生反应。"}
+        </p>
+      </details>
+    </section>
+  );
+}

--- a/src/features/local-game/components/NewPlayerGuidance.test.tsx
+++ b/src/features/local-game/components/NewPlayerGuidance.test.tsx
@@ -3,6 +3,7 @@
 import { act, createElement, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { describe, expect, it } from "vitest";
+import { LocaleProvider, LocaleSwitch } from "../../../app/locale";
 import { createInitialGame } from "../../../game/engine/createInitialGame";
 import { engineReducer } from "../../../game/engine/reducer";
 import type {
@@ -305,6 +306,10 @@ describe("Phase 13 new-player guidance", () => {
       await act(async () => collapseButton.click());
       expect(collapseButton.getAttribute("aria-expanded")).toBe("false");
       expect(document.activeElement).toBe(collapseButton);
+      expect(container.textContent).toContain(
+        "当前目标：由当前行动玩家完成一次主行动，或结束本次行动。",
+      );
+      expect(container.textContent).not.toContain("当前行动者：玩家 A");
 
       await act(async () => collapseButton.click());
       const skipButton = Array.from(container.querySelectorAll("button")).find(
@@ -317,6 +322,17 @@ describe("Phase 13 new-player guidance", () => {
         (button) => button.textContent === "重新显示新手引导",
       );
       if (!showButton) throw new Error("Expected stable guidance restore control.");
+      expect(container.querySelector(".new-player-guidance")?.getAttribute("aria-label")).toBe("新手引导");
+      expect(container.textContent).toContain(
+        "当前目标：由当前行动玩家完成一次主行动，或结束本次行动。",
+      );
+      expect(container.textContent).not.toContain("当前行动者：玩家 A");
+      expect(container.textContent).not.toContain(
+        "使用下方“主行动”“主动 DIY”与角色技能入口，或“结束本次行动”。",
+      );
+      expect(container.textContent).not.toContain(
+        "场面基准只说明当前场面的参考；是否可关联以现有操作面板的提示为准。",
+      );
       expect(document.activeElement).toBe(showButton);
 
       await act(async () => showButton.click());
@@ -324,6 +340,13 @@ describe("Phase 13 new-player guidance", () => {
         (button) => button.textContent === "折叠新手引导",
       );
       expect(document.activeElement).toBe(restoredCollapseButton);
+      expect(container.textContent).toContain("当前行动者：玩家 A");
+      expect(container.textContent).toContain(
+        "使用下方“主行动”“主动 DIY”与角色技能入口，或“结束本次行动”。",
+      );
+      expect(container.textContent).toContain(
+        "场面基准只说明当前场面的参考；是否可关联以现有操作面板的提示为准。",
+      );
       expect(getPlayingGuidance(game)?.title).toBe("主行动");
       expect({
         activePlayerId: game.activePlayerId,
@@ -334,6 +357,65 @@ describe("Phase 13 new-player guidance", () => {
         pendingExperimentCounterattack: game.pendingExperimentCounterattack,
         phase: game.phase,
       }).toEqual(baseline);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  it("keeps only the current goal and exact restore control visible while English details are hidden", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const game = createMainActionGame();
+    const baseline = JSON.stringify(game);
+
+    try {
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(LocaleSwitch),
+        createElement(GuidanceHarness, { game }),
+      )));
+      const englishButton = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "English",
+      );
+      if (!englishButton) throw new Error("Expected English locale control.");
+      await act(async () => englishButton.click());
+
+      const hideButton = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Hide new player guidance",
+      );
+      if (!hideButton) throw new Error("Expected English hide control.");
+      await act(async () => hideButton.click());
+
+      const showButton = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Show new player guidance again",
+      );
+      if (!showButton) throw new Error("Expected exact English restore control.");
+      expect(document.activeElement).toBe(showButton);
+      expect(container.querySelector(".new-player-guidance")?.getAttribute("aria-label")).toBe(
+        "New player guidance",
+      );
+      expect(container.textContent).toContain(
+        "Current goal: The active player completes one main action or ends this action.",
+      );
+      expect(container.textContent).not.toContain("Active player: Player A");
+      expect(container.textContent).not.toContain(
+        "Use Main action, Active DIY, character-skill entries, or End this action below.",
+      );
+      expect(container.textContent).not.toContain(
+        "The table reference only describes the current reference; use the existing action-panel notice to determine association.",
+      );
+
+      await act(async () => showButton.click());
+      const collapseButton = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Collapse guidance",
+      );
+      expect(document.activeElement).toBe(collapseButton);
+      expect(container.textContent).toContain("Active player: Player A");
+      expect(JSON.stringify(game)).toBe(baseline);
     } finally {
       await act(async () => root.unmount());
       container.remove();

--- a/src/features/local-game/components/NewPlayerGuidance.tsx
+++ b/src/features/local-game/components/NewPlayerGuidance.tsx
@@ -59,6 +59,10 @@ export function NewPlayerGuidance({
   if (!visible) {
     return (
       <section className="new-player-guidance new-player-guidance--hidden" aria-label={isEnglish ? "New player guidance" : "新手引导"}>
+        <p className="new-player-guidance__goal">
+          <strong>{isEnglish ? "Current goal: " : "当前目标："}</strong>
+          {guidance.goal}
+        </p>
         <button
           className="secondary-button new-player-guidance__show"
           onClick={() => onVisibleChange(true)}
@@ -91,11 +95,14 @@ export function NewPlayerGuidance({
           {collapsed ? (isEnglish ? "Expand guidance" : "展开新手引导") : (isEnglish ? "Collapse guidance" : "折叠新手引导")}
         </button>
       </div>
+      <p className="new-player-guidance__goal">
+        <strong>{isEnglish ? "Current goal: " : "当前目标："}</strong>
+        {guidance.goal}
+      </p>
       {!collapsed ? (
         <div className="new-player-guidance__content" id={contentId}>
           <p className="new-player-guidance__actor">{guidance.actor}</p>
           <dl className="new-player-guidance__facts">
-            <div><dt>{isEnglish ? "Goal" : "本阶段目标"}</dt><dd>{guidance.goal}</dd></div>
             <div><dt>{isEnglish ? "Action entry" : "操作入口"}</dt><dd>{guidance.entry}</dd></div>
             <div><dt>{isEnglish ? "Concept" : "相关概念"}</dt><dd>{guidance.concept}</dd></div>
           </dl>

--- a/src/features/local-game/components/SuccessfulReactionNotice.test.tsx
+++ b/src/features/local-game/components/SuccessfulReactionNotice.test.tsx
@@ -1,0 +1,412 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider, LocaleSwitch } from "../../../app/locale";
+import { createInitialGame } from "../../../game/engine/createInitialGame";
+import type { GameState } from "../../../game/engine/types";
+import type { SuccessfulReactionEvent } from "../../../game/engine/reactions";
+import { identityShuffle } from "../../../shared/random";
+import { SuccessfulReactionNotice } from "./SuccessfulReactionNotice";
+
+function createGame(): GameState {
+  return createInitialGame({
+    characterIds: ["chemical_factory_ceo", "acid_king"],
+    shuffle: identityShuffle,
+  });
+}
+
+function withReaction(
+  game: GameState,
+  id: string,
+  reaction: SuccessfulReactionEvent,
+): GameState {
+  return {
+    ...game,
+    log: [...game.log, { id, message: "该中文日志不得成为提示数据源。", reaction }],
+  };
+}
+
+const acidBaseEvent: SuccessfulReactionEvent = {
+  definitionId: "acid_base_neutralization",
+  trigger: { kind: "single-damage-response", responsePolicy: "acid-base" },
+  participants: [
+    {
+      kind: "card",
+      playerId: "player_1",
+      cardInstanceId: "substance_hcl_dilute_01",
+      cardDefinitionId: "substance_hcl_dilute",
+      role: "attacker",
+    },
+    {
+      kind: "card",
+      playerId: "player_2",
+      cardInstanceId: "substance_naoh_dilute_01",
+      cardDefinitionId: "substance_naoh_dilute",
+      role: "responder",
+    },
+  ],
+  outcome: { kind: "virtual-product", product: "H2O", damageCancelled: true },
+};
+
+const acidCarbonateEvent: SuccessfulReactionEvent = {
+  definitionId: "acid_carbonate_co2",
+  trigger: { kind: "single-damage-response", responsePolicy: "acid-base" },
+  participants: [
+    {
+      kind: "card",
+      playerId: "player_1",
+      cardInstanceId: "substance_hcl_dilute_01",
+      cardDefinitionId: "substance_hcl_dilute",
+      role: "attacker",
+    },
+    {
+      kind: "card",
+      playerId: "player_2",
+      cardInstanceId: "ion_co3_01",
+      cardDefinitionId: "ion_co3",
+      role: "responder",
+    },
+  ],
+  outcome: { kind: "virtual-product", product: "CO2", damageCancelled: true },
+};
+
+const immediateSo2Event: SuccessfulReactionEvent = {
+  definitionId: "so2_alkaline_absorption",
+  trigger: { kind: "multi-target-damage-response", sourceSkillId: "exhaust_leak" },
+  participants: [
+    {
+      kind: "character-skill",
+      sourcePlayerId: "player_1",
+      skillId: "exhaust_leak",
+      role: "attacker",
+    },
+    {
+      kind: "card",
+      playerId: "player_2",
+      cardInstanceId: "ion_oh_01",
+      cardDefinitionId: "ion_oh",
+      role: "responder",
+    },
+  ],
+  outcome: { kind: "damage-cancelled", finalDamage: 0 },
+};
+
+const statusSo2Event: SuccessfulReactionEvent = {
+  definitionId: "so2_alkaline_absorption",
+  trigger: { kind: "status-handling", statusId: "SO2_LEAK" },
+  participants: [
+    {
+      kind: "status",
+      targetPlayerId: "player_1",
+      statusInstanceId: "status_phase15_so2",
+      statusId: "SO2_LEAK",
+      role: "affected-status",
+    },
+    {
+      kind: "card",
+      playerId: "player_1",
+      cardInstanceId: "substance_naoh_dilute_01",
+      cardDefinitionId: "substance_naoh_dilute",
+      role: "status-handler",
+    },
+  ],
+  outcome: {
+    kind: "status-removed",
+    targetPlayerId: "player_1",
+    statusInstanceId: "status_phase15_so2",
+    statusId: "SO2_LEAK",
+  },
+};
+
+beforeEach(() => {
+  Object.defineProperty(globalThis.navigator, "language", {
+    configurable: true,
+    value: "zh-CN",
+  });
+  Object.defineProperty(globalThis.navigator, "languages", {
+    configurable: true,
+    value: ["zh-CN"],
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Phase 15 successful reaction notice", () => {
+  it.each([
+    ["no reaction", createGame()],
+    ["one historical reaction", withReaction(createGame(), "log_historical_1", acidBaseEvent)],
+    [
+      "multiple historical reactions",
+      withReaction(
+        withReaction(createGame(), "log_historical_1", acidBaseEvent),
+        "log_historical_2",
+        acidCarbonateEvent,
+      ),
+    ],
+  ])("establishes its first observation baseline for %s without showing or timing", async (
+    _label,
+    game,
+  ) => {
+    vi.useFakeTimers();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(SuccessfulReactionNotice, { game }),
+      )));
+      expect(container.querySelector('[role="status"]')).toBeNull();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  it.each([
+    [acidBaseEvent, "酸碱中和", "伤害已完全抵消；生成虚拟结果 H2O"],
+    [acidCarbonateEvent, "酸与碳酸盐", "伤害已完全抵消；生成虚拟结果 CO2"],
+    [immediateSo2Event, "SO2 碱性吸收", "伤害已完全抵消"],
+    [statusSo2Event, "SO2 碱性吸收", "待处理状态已移除"],
+  ])("renders newly appended structured event %# without parsing its Chinese message", async (
+    event,
+    name,
+    outcome,
+  ) => {
+    vi.useFakeTimers();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const baseline = createGame();
+    const game = withReaction(baseline, "log_phase15_reaction", event);
+
+    try {
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(SuccessfulReactionNotice, { game: baseline }),
+      )));
+      expect(container.querySelector('[role="status"]')).toBeNull();
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(SuccessfulReactionNotice, { game }),
+      )));
+      const notice = container.querySelector('[role="status"]');
+      expect(notice?.getAttribute("aria-live")).toBe("polite");
+      expect(notice?.textContent).toContain(`成功反应 · ${name}`);
+      expect(notice?.textContent).toContain(outcome);
+      expect(notice?.textContent).not.toContain("该中文日志不得成为提示数据源");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  it("updates an active notice in place on language change without restarting or replaying it", async () => {
+    vi.useFakeTimers();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const baseline = createGame();
+    const game = withReaction(baseline, "log_phase15_english", acidBaseEvent);
+
+    try {
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(LocaleSwitch),
+        createElement(SuccessfulReactionNotice, { game: baseline }),
+      )));
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(LocaleSwitch),
+        createElement(SuccessfulReactionNotice, { game }),
+      )));
+      await act(async () => vi.advanceTimersByTime(1500));
+      const englishButton = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "English",
+      );
+      if (!englishButton) throw new Error("Expected English locale control.");
+      await act(async () => englishButton.click());
+      expect(container.querySelector('[role="status"]')?.textContent).toContain(
+        "Successful reaction · Acid-base neutralization",
+      );
+      expect(container.querySelector('[role="status"]')?.textContent).toContain(
+        "Damage was fully cancelled; virtual result H2O was produced",
+      );
+      expect(vi.getTimerCount()).toBe(1);
+      await act(async () => vi.advanceTimersByTime(499));
+      expect(container.querySelector('[role="status"]')).not.toBeNull();
+      await act(async () => vi.advanceTimersByTime(1));
+      expect(container.querySelector('[role="status"]')).toBeNull();
+
+      const chineseButton = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "中文",
+      );
+      if (!chineseButton) throw new Error("Expected Chinese locale control.");
+      await act(async () => chineseButton.click());
+      expect(container.querySelector('[role="status"]')).toBeNull();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  it("shows only appended reactions, keeps focus, and resets the timer for consecutive events", async () => {
+    vi.useFakeTimers();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    const focusTarget = document.createElement("button");
+    focusTarget.textContent = "keep focus";
+    document.body.append(focusTarget, container);
+    focusTarget.focus();
+    const root = createRoot(container);
+    const baseline = createGame();
+
+    try {
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(SuccessfulReactionNotice, { game: baseline }),
+      )));
+      expect(container.querySelector('[role="status"]')).toBeNull();
+
+      const first = withReaction(baseline, "log_first", acidBaseEvent);
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(SuccessfulReactionNotice, { game: first }),
+      )));
+      expect(container.querySelector('[role="status"]')?.textContent).toContain("酸碱中和");
+      expect(document.activeElement).toBe(focusTarget);
+
+      await act(async () => vi.advanceTimersByTime(1900));
+      expect(container.querySelector('[role="status"]')).not.toBeNull();
+
+      const second = withReaction(first, "log_second", acidCarbonateEvent);
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(SuccessfulReactionNotice, { game: second }),
+      )));
+      await act(async () => vi.advanceTimersByTime(1900));
+      expect(container.querySelector('[role="status"]')?.textContent).toContain("酸与碳酸盐");
+      await act(async () => vi.advanceTimersByTime(100));
+      expect(container.querySelector('[role="status"]')).toBeNull();
+      expect(document.activeElement).toBe(focusTarget);
+
+      const logSnapshot = JSON.stringify(second.log);
+      expect(JSON.stringify(second.log)).toBe(logSnapshot);
+      await act(async () => root.unmount());
+      expect(vi.getTimerCount()).toBe(0);
+      container.remove();
+    } finally {
+      if (container.isConnected) await act(async () => root.unmount());
+      focusTarget.remove();
+      container.remove();
+    }
+  });
+
+  it("treats a replaced log identity as a new session even when reaction IDs repeat", async () => {
+    vi.useFakeTimers();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const firstBaseline = createGame();
+    const firstReaction = withReaction(firstBaseline, "log_repeated", acidBaseEvent);
+    const secondSessionHistory = withReaction(createGame(), "log_repeated", acidCarbonateEvent);
+
+    try {
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(SuccessfulReactionNotice, { game: firstBaseline }),
+      )));
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(SuccessfulReactionNotice, { game: firstReaction }),
+      )));
+      expect(container.querySelector('[role="status"]')?.textContent).toContain("酸碱中和");
+
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(SuccessfulReactionNotice, { game: secondSessionHistory }),
+      )));
+      expect(container.querySelector('[role="status"]')).toBeNull();
+      expect(vi.getTimerCount()).toBe(0);
+
+      const freshReaction = withReaction(secondSessionHistory, "log_fresh", statusSo2Event);
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(SuccessfulReactionNotice, { game: freshReaction }),
+      )));
+      expect(container.querySelector('[role="status"]')?.textContent).toContain("SO2 碱性吸收");
+      expect(vi.getTimerCount()).toBe(1);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  it("ignores appended ordinary Chinese and FIRE logs and clears its timer on unmount", async () => {
+    vi.useFakeTimers();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const baseline = createGame();
+    const ordinaryGame: GameState = {
+      ...baseline,
+      log: [
+        ...baseline.log,
+        { id: "log_plain", message: "成功反应：这只是普通中文日志。" },
+        { id: "log_fire", message: "玩家使用 H2O 处理 FIRE。" },
+      ],
+    };
+
+    try {
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(SuccessfulReactionNotice, { game: baseline }),
+      )));
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(SuccessfulReactionNotice, { game: ordinaryGame }),
+      )));
+      expect(container.querySelector('[role="status"]')).toBeNull();
+      expect(vi.getTimerCount()).toBe(0);
+
+      const reactionGame = withReaction(ordinaryGame, "log_reaction", immediateSo2Event);
+      await act(async () => root.render(createElement(
+        LocaleProvider,
+        null,
+        createElement(SuccessfulReactionNotice, { game: reactionGame }),
+      )));
+      expect(vi.getTimerCount()).toBe(1);
+      await act(async () => root.unmount());
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      if (container.isConnected) await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+});

--- a/src/features/local-game/components/SuccessfulReactionNotice.tsx
+++ b/src/features/local-game/components/SuccessfulReactionNotice.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState } from "react";
+import { useLocale } from "../../../app/locale";
+import type { GameState } from "../../../game/engine/types";
+import { getPublicReactionLogView } from "../localGameView";
+
+type SuccessfulReactionNoticeProps = Readonly<{
+  game: GameState;
+}>;
+
+const successfulReactionNoticeDurationMs = 2000;
+
+export function SuccessfulReactionNotice({ game }: SuccessfulReactionNoticeProps) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
+  const [activeEntry, setActiveEntry] = useState<GameState["log"][number] | null>(null);
+  const previousLogRef = useRef<GameState["log"] | null>(null);
+  const lastObservedReactionEntryRef = useRef<GameState["log"][number] | null>(null);
+
+  useEffect(() => {
+    const previousLog = previousLogRef.current;
+    const latestReactionEntry = [...game.log].reverse().find((entry) => entry.reaction) ?? null;
+    previousLogRef.current = game.log;
+
+    if (
+      previousLog === null ||
+      previousLog.length > game.log.length ||
+      !previousLog.every((entry, index) => game.log[index] === entry)
+    ) {
+      lastObservedReactionEntryRef.current = latestReactionEntry;
+      setActiveEntry(null);
+      return;
+    }
+
+    if (
+      latestReactionEntry === null ||
+      lastObservedReactionEntryRef.current === latestReactionEntry
+    ) {
+      return;
+    }
+
+    lastObservedReactionEntryRef.current = latestReactionEntry;
+    setActiveEntry(latestReactionEntry);
+  }, [game.log]);
+
+  useEffect(() => {
+    if (!activeEntry) {
+      return undefined;
+    }
+
+    const timer = window.setTimeout(() => {
+      setActiveEntry(null);
+    }, successfulReactionNoticeDurationMs);
+
+    return () => window.clearTimeout(timer);
+  }, [activeEntry]);
+
+  const currentActiveEntry = activeEntry
+    ? game.log.find((entry) => entry === activeEntry && entry.reaction)
+    : undefined;
+  const reaction = currentActiveEntry
+    ? getPublicReactionLogView(game, currentActiveEntry, locale)
+    : undefined;
+
+  if (!reaction) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-atomic="true"
+      aria-live="polite"
+      className="successful-reaction-notice"
+      role="status"
+    >
+      <strong>
+        {isEnglish ? "Successful reaction" : "成功反应"} · {reaction.name}
+      </strong>
+      <span>{reaction.outcome}</span>
+    </section>
+  );
+}

--- a/src/features/local-game/local-game.css
+++ b/src/features/local-game/local-game.css
@@ -163,6 +163,15 @@
   padding: 8px 10px;
 }
 
+.new-player-guidance__goal {
+  background: #eef7f2;
+  border-left: 4px solid #2f7658;
+  border-radius: 6px;
+  line-height: 1.5;
+  margin: 0;
+  padding: 10px 12px;
+}
+
 .new-player-guidance__facts {
   display: grid;
   gap: 8px;
@@ -185,6 +194,65 @@
 .new-player-guidance__skip,
 .new-player-guidance__show {
   justify-self: start;
+}
+
+.first-game-example {
+  display: grid;
+  gap: 10px;
+}
+
+.first-game-example__details ol {
+  display: grid;
+  gap: 8px;
+  margin: 12px 0;
+  padding-left: 24px;
+}
+
+.first-game-example__details li {
+  line-height: 1.5;
+}
+
+.project-repository-link {
+  color: #175f47;
+  font-weight: 800;
+  overflow-wrap: anywhere;
+}
+
+.successful-reaction-notice {
+  animation: successful-reaction-notice-in 160ms ease-out;
+  background: #e6f4ee;
+  border: 1px solid #9bcdb7;
+  border-radius: 8px;
+  display: grid;
+  gap: 4px;
+  margin: 16px auto 0;
+  max-width: 1480px;
+  padding: 12px 14px;
+}
+
+.successful-reaction-notice strong {
+  color: #205d44;
+}
+
+.successful-reaction-notice span {
+  color: #3d5f50;
+}
+
+@keyframes successful-reaction-notice-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .successful-reaction-notice {
+    animation: none;
+  }
 }
 
 .mirror-note,


### PR DESCRIPTION
## Summary

- move character selection and the Start button ahead of detailed onboarding
- keep the current objective visible while detailed guidance is hidden
- add a bilingual, non-interactive three-step first-game example
- add a temporary accessible notice for newly generated structured reaction events
- add GitHub repository links to About and game-over views

## Rule boundary

- no changes to the game engine, reducer, game state, card data, legality rules, card pool, or reaction definitions
- successful-reaction notices consume only structured `GameLogEntry.reaction` data
- ordinary game logs remain unchanged
- Microsoft Forms behavior and privacy boundaries remain unchanged

## Verification

- TypeScript passed
- Vitest: 40 files, 522 tests passed
- shuffled Vitest: 40 files, 522 tests passed
- fixture E2E: 13/13 passed
- production E2E: 2/2 passed
- production isolation and size gates passed
- branch CI passed
- `git diff --check` passed

## Known limitations

- iOS 27 beta Firefox modal/root failure remains unresolved
- mobile browser acceptance used Chromium at 390×844, not physical-device coverage
- JavaScript gzip size is close to the existing limit
