### PR TITLE
chore(release): prepare Reaction Field Alpha 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ The external Core Rulebook is an extended tabletop reference, not the authoritat
 ## Try the Web Playtest
 
 - Play: [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)
-- Current public milestone: **Reaction Field Alpha 4**
-- Current published technical version: `0.14.0-alpha.1`
-- Current public tag: `web-playtest-v0.14.0-alpha.1`
-- Alpha 5 release-candidate version: `0.15.0-alpha.1`
+- Current public milestone: **Reaction Field Alpha 5**
+- Current published technical version: `0.15.0-alpha.1`
+- Current public tag: `web-playtest-v0.15.0-alpha.1`
+- Alpha 6 release-candidate version: `0.16.0-alpha.1`
 - Rules version: `MVP0-P10`
 
-The Alpha 4 international playtest is the current public build. Phase 15 has been merged into `main`, and this branch only prepares the Alpha 5 / `0.15.0-alpha.1` release candidate. The planned `web-playtest-v0.15.0-alpha.1` tag does not exist; Alpha 5 has not been deployed, publicly accepted, or published as a GitHub Release. Until a new tag is deployed, the public URL continues to serve Alpha 4 / `0.14.0-alpha.1`.
+The Alpha 5 playtest is the current public build. Phase 16 has been merged into `main`, and this branch only prepares the Alpha 6 / `0.16.0-alpha.1` release candidate. The planned `web-playtest-v0.16.0-alpha.1` tag does not exist; Alpha 6 has not been deployed, publicly accepted, or published as a GitHub Release. Until a new tag is deployed, the public URL continues to serve Alpha 5 / `0.15.0-alpha.1`.
 
 ## What Is Reaction Field?
 
@@ -49,21 +49,25 @@ This is an alpha playtest, not a stable release.
 
 ## Alpha Status
 
-The current public release is Reaction Field Alpha 4, technical version `0.14.0-alpha.1`, rules version `MVP0-P10`, and tag `web-playtest-v0.14.0-alpha.1`. Its public Pages build remains active until a later tag is deployed; this is not evidence of broad cross-browser compatibility.
+The current public release is Reaction Field Alpha 5, technical version `0.15.0-alpha.1`, rules version `MVP0-P10`, and tag `web-playtest-v0.15.0-alpha.1`. Its public Pages build remains active until a later tag is deployed; this is not evidence of broad cross-browser compatibility.
 
 The earlier `web-playtest-v0.13.0-alpha.2` tag remains unchanged at `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`. Its Pages workflow failed because a production E2E assertion was pinned to an older commit, so alpha.2 was not deployed successfully. Historical tags remain immutable.
 
-## Alpha 4 International Playtest Status
+## International Playtest and Bilingual Game Log Status
 
-Alpha 4 is implemented, merged, and publicly available as `0.14.0-alpha.1`. It provides Simplified Chinese and English presentation layers without changing game state or rules.
+The international presentation layer provides Simplified Chinese and English modes without changing game state or rules.
 
 - The display language is suggested from browser language preferences and can be switched in the page.
 - The selection is held only for the current React page lifecycle. It is not persisted; after a refresh, the suggestion is evaluated again from the browser language.
-- Ordinary formal game-log messages remain in Simplified Chinese in English mode. Some structured reaction presentation is localized, but the game must not be described as having a fully English game log.
+- Ordinary engine-generated game logs now support Simplified Chinese and English through typed structured events and one authoritative payload.
+- Card play, responses, reactions, DIY virtual attacks, status handling, notices, and character-related flows support localized rendering.
+- English alkaline damage is displayed as `alkaline` while the internal rule identifier remains `base`.
+- Production Reaction and DIY UI paths have formal E2E coverage.
+- The production JavaScript bundle was reduced to pass the frozen Node 24 size gate with reliable headroom.
 
-## Alpha 5 / Phase 15 Candidate Status
+## Alpha 6 / Phase 16 Candidate Status
 
-Phase 15 is implemented and merged into `main`. This branch only prepares its Alpha 5 version identity, release documentation, and exact test contracts. Alpha 5 is not a complete tutorial, a fully English game log, online multiplayer, complete mobile compatibility, or an iOS Firefox fix. The `web-playtest-v0.15.0-alpha.1` tag, Pages deployment, public URL acceptance, and GitHub Release have not occurred.
+Phase 16 is implemented and merged into `main`. This branch only prepares its Alpha 6 version identity, release documentation, and exact test contracts. Alpha 6 is not a complete tutorial, online multiplayer, complete mobile compatibility, or an iOS Firefox fix. The `web-playtest-v0.16.0-alpha.1` tag, Pages deployment, public URL acceptance, and GitHub Release have not occurred.
 
 ## Feedback
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 # 反应域
 
-**反应域（REACTION FIELD）** 当前公开版本是 Reaction Field Alpha 4 / `0.14.0-alpha.1`；Phase 15 已合入 `main`，本分支仅准备 Alpha 5 / `0.15.0-alpha.1` 候选。规则版本严格保持 `MVP0-P10`，不增加任何游戏规则。这是一个基于 React、TypeScript、Vite、Vitest 与 Playwright 的本地同屏双人公开试玩版本，不是正式发行版。
+**反应域（REACTION FIELD）** 当前公开版本是 Reaction Field Alpha 5 / `0.15.0-alpha.1`；Phase 16 已合入 `main`，本分支仅准备 Alpha 6 / `0.16.0-alpha.1` 候选。规则版本严格保持 `MVP0-P10`，不增加任何游戏规则。这是一个基于 React、TypeScript、Vite、Vitest 与 Playwright 的本地同屏双人公开试玩版本，不是正式发行版。
 
 ## 核心规则书 — 扩展桌面规则参考
 
@@ -30,19 +30,23 @@ Web Playtest Alpha 公开双方手牌、牌堆数量、状态与完整日志。�
 
 ## 公开试玩地址与本轮状态
 
-公开试玩入口为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)。当前公开发布事实为：对外阶段 Reaction Field Alpha 4，技术版本 `0.14.0-alpha.1`，规则版本 `MVP0-P10`，标签 `web-playtest-v0.14.0-alpha.1`；在新标签部署前，公开 Pages 继续运行该版本，但这不等同于广泛跨浏览器兼容性验收。`web-playtest-v0.13.0-alpha.2` 保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 对旧 commit 的固定断言失败，alpha.2 未成功部署。所有历史标签保持不可变。
+公开试玩入口为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)。当前公开发布事实为：对外阶段 Reaction Field Alpha 5，技术版本 `0.15.0-alpha.1`，规则版本 `MVP0-P10`，标签 `web-playtest-v0.15.0-alpha.1`；在新标签部署前，公开 Pages 继续运行该版本，但这不等同于广泛跨浏览器兼容性验收。`web-playtest-v0.13.0-alpha.2` 保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；其 Pages workflow 因 production E2E 对旧 commit 的固定断言失败，alpha.2 未成功部署。所有历史标签保持不可变。
 
-## Alpha 4 国际试玩状态
+## 国际化试玩与双语游戏日志状态
 
-Alpha 4 国际试玩功能已经实现、合入并以 `0.14.0-alpha.1` 公开。Alpha 4 提供简体中文和英文展示层，不改变游戏状态或规则。
+国际化展示层提供简体中文和英文展示层，不改变游戏状态或规则。
 
 - 展示语言根据浏览器语言偏好给出建议，也可以在页面内切换。
 - 语言选择仅保存在当前 React 页面生命周期，不做持久化；刷新后会重新根据浏览器语言建议。
-- 英文模式下，普通正式游戏日志仍保持简体中文。部分结构化反应展示已本地化，但不能据此宣称游戏已有完整英文日志。
+- 普通引擎正式游戏日志现已支持简体中文与英文，基于强类型结构化事件与单一权威载荷生成。
+- 出牌、响应、反应、DIY 虚拟攻击、状态结算、提示与角色相关流程均已支持本地化渲染。
+- 英文模式下碱性伤害展示为 `alkaline`，内部规则标识保持 `base`。
+- 正式 Reaction 与 DIY UI 路径已具备正式 E2E 覆盖。
+- 生产 JavaScript bundle 已压缩优化，确保在 Node 24 下具有充裕余量通过冻结的体积门限。
 
-## Alpha 5 / Phase 15 候选状态
+## Alpha 6 / Phase 16 候选状态
 
-Phase 15 已实现并合入 `main`；本分支只准备 Alpha 5 的版本身份、发布文档和精确测试契约。`web-playtest-v0.15.0-alpha.1` 尚未创建，Alpha 5 尚未部署、尚未执行公开 URL 验收，也未创建 GitHub Release。它不代表完整教程、完整英文日志、在线多人、完整移动端兼容或 iOS Firefox 修复。
+Phase 16 已实现并合入 `main`；本分支只准备 Alpha 6 的版本身份、发布文档和精确测试契约。`web-playtest-v0.16.0-alpha.1` 尚未创建，Alpha 6 尚未部署、尚未执行公开 URL 验收，也未创建 GitHub Release。它不代表完整教程、在线多人、完整移动端兼容或 iOS Firefox 修复。
 
 ## Feedback / 反馈
 
@@ -120,7 +124,7 @@ fatal 页面可复制的本地安全诊断只包含：
 
 ```text
 名称：反应域
-应用版本：0.15.0-alpha.1
+应用版本：0.16.0-alpha.1
 规则版本：MVP0-P10
 Commit：<短 SHA 或 dev/unknown>
 错误码：<稳定错误码>
@@ -135,7 +139,7 @@ Commit：<短 SHA 或 dev/unknown>
 - 真实金属卡池及实验反击金属选项、方程式、沉淀、响应 DIY、多人、联网、账号、存档和回放均延期。
 - 当前公开发布使用 GitHub Pages；本地开发与验证不执行部署。
 - Tauri、Electron、PWA、service worker、APP / DMG / EXE / MSI、签名、公证和自动更新均未实现，也不在本阶段范围。
-- 已知兼容性边界：在 iOS 27 beta 的 Firefox 中，打开帮助或重开确认框可能进入 `ROOT_RUNTIME_FAILED`。此前的 `requestAnimationFrame` 聚焦实验未解决该问题，未进入稳定分支；Safari 与已测试的 Edge 路径正常只是已有真机/浏览器记录，不构成所有版本的普遍保证。本次 Alpha 5 候选不修复也不声称修复 iOS Firefox beta；失败热修复分支 `fix/ios-firefox-modal-focus-alpha2` 不复制、不合并、不修改。
+- 已知兼容性边界：在 iOS 27 beta 的 Firefox 中，打开帮助或重开确认框可能进入 `ROOT_RUNTIME_FAILED`。此前的 `requestAnimationFrame` 聚焦实验未解决该问题，未进入稳定分支；Safari 与已测试的 Edge 路径正常只是已有真机/浏览器记录，不构成所有版本的普遍保证。本次 Alpha 6 候选不修复也不声称修复 iOS Firefox beta；失败热修复分支 `fix/ios-firefox-modal-focus-alpha2` 不复制、不合并、不修改。
 
 发布、标签、回滚与停止公开试玩说明见 [`docs/PHASE12_REACTION_FIELD_WEB_PLAYTEST_FREEZE.md`](docs/PHASE12_REACTION_FIELD_WEB_PLAYTEST_FREEZE.md)。Phase 11 是历史稳定性基线；规则边界继续由 [`docs/MVP0_RULE_FREEZE.md`](docs/MVP0_RULE_FREEZE.md)、[`docs/PHASE8_CHARACTER_RULE_FREEZE.md`](docs/PHASE8_CHARACTER_RULE_FREEZE.md)、[`docs/PHASE9_DEBUG_UI_RULE_FREEZE.md`](docs/PHASE9_DEBUG_UI_RULE_FREEZE.md) 和 [`docs/PHASE10_REACTION_EVENT_RULE_FREEZE.md`](docs/PHASE10_REACTION_EVENT_RULE_FREEZE.md) 冻结；阶段总览见 [`docs/MVP_PLAN.md`](docs/MVP_PLAN.md)。
 

--- a/docs/MVP_PLAN.md
+++ b/docs/MVP_PLAN.md
@@ -17,10 +17,11 @@
 - `docs/PHASE12_REACTION_FIELD_WEB_PLAYTEST_FREEZE.md`：Phase 12 反应域静态 Web 试玩发布边界、标签、回滚与停止公开说明；不是规则冻结文档。
 - `docs/PHASE13_NEW_PLAYER_GUIDANCE_FREEZE.md`：Phase 13 新玩家首局引导的展示、可访问性、测试与发布边界；不改写现有规则冻结。
 - `docs/PHASE15_FIRST_GAME_CONVERSION_FREEZE.md`：Phase 15 配置页信息层级、静态示例、非模态成功反应提示和 GitHub 入口边界；不改写现有规则冻结。
+- `docs/PHASE16_BILINGUAL_GAME_LOG_FREEZE.md`：Phase 16 双语结构化游戏日志冻结合同；不改写现有规则冻结。
 
-## Phase 15 首局转化与玩法可理解性（实现已合并；Alpha 5 未发布候选）
+## Phase 16 完整双语游戏日志（实现已合并；Alpha 6 未发布候选）
 
-Phase 15 只调整配置页信息层级、默认折叠的双语三步示例、消费既有 `GameLogEntry.reaction` 的约两秒非模态成功反应提示，以及 About / `gameOver` 的静态 GitHub 仓库链接。实现已通过 PR #7 合入 `main`。规则版本保持 `MVP0-P10`，默认实验室老师 / 化工厂 CEO 阵容不变，不新增媒体或外部请求，也不修改 engine、data、game tests、reaction definitions、Forms 或 size gate。当前分支只准备 Alpha 5 / `0.15.0-alpha.1` 的版本身份、发布文档和精确测试契约，不改变 Phase 15 产品实现。
+Phase 16 将普通引擎正式日志从内嵌中文字符串升级为基于强类型结构化事件与单一权威载荷的双语渲染，支持简体中文与英文。实现已通过 PR #9 合入 `main`。规则版本保持 `MVP0-P10`，默认实验室老师 / 化工厂 CEO 阵容不变，不新增媒体或外部请求，不修改 engine 核心规则、data、game tests、reaction definitions、Forms 或 size gate。当前分支只准备 Alpha 6 / `0.16.0-alpha.1` 的版本身份、发布文档和精确测试契约，不改变 Phase 16 产品实现。
 
 ## Phase 12 发布边界
 
@@ -32,7 +33,7 @@ Phase 13 的权威实现边界见 `docs/PHASE13_NEW_PLAYER_GUIDANCE_FREEZE.md`�
 
 - 配置阶段位于角色选择操作之前；playing 阶段位于 preparation、main action、response、status、counterattack 与 game over 操作区之前。窄屏保持正常文档流，不使用浮层、遮罩、sticky coach mark 或 modal。
 - 阶段文案覆盖配置、备课、主行动、响应、状态处理、实验反击与对局结束；不复制合法性、卡牌匹配、伤害、反应或出牌建议，不 dispatch `GameAction`，不增加任何规则表。
-- 保持 `MVP0-P10`、68 张普通实体卡池、角色和冻结规则不变；Phase 13 引导实现已在 alpha.1 基线完成，`web-playtest-v0.13.0-alpha.1` 标签永久保持不变。当前候选应用版本为 `0.15.0-alpha.1`，由 `package.json` 作为唯一真值来源，`releaseMetadata` 继续读取构建注入的版本。当前公开版本是 Reaction Field Alpha 4 / `0.14.0-alpha.1`，公开标签为 `web-playtest-v0.14.0-alpha.1`；公开试玩地址为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)。
+- 保持 `MVP0-P10`、68 张普通实体卡池、角色和冻结规则不变；Phase 13 引导实现已在 alpha.1 基线完成，`web-playtest-v0.13.0-alpha.1` 标签永久保持不变。当前候选应用版本为 `0.16.0-alpha.1`，由 `package.json` 作为唯一真值来源，`releaseMetadata` 继续读取构建注入的版本。当前公开版本是 Reaction Field Alpha 5 / `0.15.0-alpha.1`，公开标签为 `web-playtest-v0.15.0-alpha.1`；公开试玩地址为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)。
 
 ## 0.13.0-alpha.3 已公开发布（Reaction Field Alpha 2）
 
@@ -40,13 +41,17 @@ alpha.2 的品牌资产更新包含 01-B 游戏图标、favicon、Apple Touch Ic
 
 ## 0.14.0-alpha.1 已公开发布（Reaction Field Alpha 4）
 
-Alpha 4 的简体中文与 English 展示层、页面内语言切换和 Microsoft Forms 普通外链反馈入口已经实现、合入并公开；普通 engine 正式日志在英文模式下仍为简体中文。当前公开版本为 `0.14.0-alpha.1`，标签为 `web-playtest-v0.14.0-alpha.1`；新标签部署完成前，公开站点继续运行该版本。游戏不会自动向 Forms 发送 `GameState`、手牌、日志、诊断或浏览器数据；iOS 27 beta Firefox 的 modal / `ROOT_RUNTIME_FAILED` 风险仍未解决。
+Alpha 4 的简体中文与 English 展示层、页面内语言切换和 Microsoft Forms 普通外链反馈入口已经实现、合入并公开；当前公开版本已升级为 Alpha 5。游戏不会自动向 Forms 发送 `GameState`、手牌、日志、诊断或浏览器数据；iOS 27 beta Firefox 的 modal / `ROOT_RUNTIME_FAILED` 风险仍未解决。
 
-## 0.15.0-alpha.1 发布候选（Reaction Field Alpha 5）
+## 0.15.0-alpha.1 已公开发布（Reaction Field Alpha 5）
 
-Phase 15 已实现并合入 `main`。当前分支仅准备 Alpha 5 的版本身份、发布文档和精确测试契约；预定标签 `web-playtest-v0.15.0-alpha.1` 尚未创建，Alpha 5 尚未部署、尚未执行公开 URL 验收，也未创建 GitHub Release。配置页提前角色选择、阵容摘要与开始按钮；当前目标保持可见，详细引导可折叠、隐藏和恢复；双语三步示例默认折叠且纯展示；新产生的结构化成功反应可显示约 2000ms 的非模态提示，仅读取 `GameLogEntry.reaction` 并复用正式展示入口，首次挂载不重播历史 reaction；About 与 `gameOver` 提供静态 GitHub 仓库链接。普通正式日志仍为简体中文，Forms 数据边界不变。
+Phase 15 调整配置页信息层级、默认折叠的双语三步示例、消费既有 `GameLogEntry.reaction` 的约两秒非模态成功反应提示，以及 About / `gameOver` 的静态 GitHub 仓库链接。已公开发布为 Reaction Field Alpha 5，技术版本 `0.15.0-alpha.1`，规则版本 `MVP0-P10`，标签 `web-playtest-v0.15.0-alpha.1`。
 
-已知兼容性边界：iOS 27 beta 的 Firefox 在打开帮助或重开确认框时可能进入 `ROOT_RUNTIME_FAILED`；先前的 `requestAnimationFrame` 聚焦实验未解决该问题，未进入稳定分支。Safari 与已测试的 Edge 路径正常属于已有真机/浏览器记录，不代表所有版本的普遍保证。本次 Alpha 5 候选不修复也不声称修复 iOS Firefox beta；失败热修复分支 `fix/ios-firefox-modal-focus-alpha2` 不复制、不合并、不修改。
+## 0.16.0-alpha.1 发布候选（Reaction Field Alpha 6）
+
+Phase 16 已实现并合入 `main`。当前分支仅准备 Alpha 6 的版本身份、发布文档和精确测试契约；预定标签 `web-playtest-v0.16.0-alpha.1` 尚未创建，Alpha 6 尚未部署、尚未执行公开 URL 验收，也未创建 GitHub Release。普通引擎正式游戏日志现已支持简体中文与英文，使用强类型结构化事件与单一权威载荷；出牌、响应、反应、DIY 虚拟攻击、状态处理、提示与角色相关流程支持本地化渲染；英文模式下碱性伤害展示为 `alkaline`（内部规则标识保持 `base`）；生产 Reaction 与 DIY UI 路径建立正式 E2E 覆盖；生产 JS bundle 经压缩优化以充裕余量通过 Node 24 体积门限。
+
+已知兼容性边界：iOS 27 beta 的 Firefox 在打开帮助或重开确认框时可能进入 `ROOT_RUNTIME_FAILED`；先前的 `requestAnimationFrame` 聚焦实验未解决该问题，未进入稳定分支。Safari 与已测试的 Edge 路径正常属于已有真机/浏览器记录，不代表所有版本的普遍保证。本次 Alpha 6 候选不修复也不声称修复 iOS Firefox beta；失败热修复分支 `fix/ios-firefox-modal-focus-alpha2` 不复制、不合并、不修改。
 
 ## MVP 0 定案范围
 

--- a/e2e/production/reaction-field.spec.ts
+++ b/e2e/production/reaction-field.spec.ts
@@ -111,7 +111,7 @@ for (const [path, assetPrefix, brandPrefix] of [["/", "/assets/", "/"], ["/playt
     expect(script?.contentType).toMatch(/^text\/javascript/u);
     expect(stylesheet?.path.startsWith(assetPrefix)).toBe(true);
     expect(stylesheet?.contentType).toMatch(/^text\/css/u);
-    await expect(page).toHaveTitle(/反应域 · REACTION FIELD · Web Playtest Alpha · 0\.15\.0-alpha\.1/u);
+    await expect(page).toHaveTitle(/反应域 · REACTION FIELD · Web Playtest Alpha · 0\.16\.0-alpha\.1/u);
     const iconLinks = await page.locator('link[rel~="icon"]').evaluateAll((links) => links.map((link) => ({
       href: link.getAttribute("href"),
       sizes: link.getAttribute("sizes"),
@@ -163,7 +163,7 @@ for (const [path, assetPrefix, brandPrefix] of [["/", "/assets/", "/"], ["/playt
     await page.getByRole("button", { name: "关于与帮助" }).click();
     const about = page.getByRole("dialog", { name: "关于与帮助" });
     await expect(about).toContainText("REACTION FIELD");
-    await expect(about).toContainText("0.15.0-alpha.1");
+    await expect(about).toContainText("0.16.0-alpha.1");
     await expect(about).toContainText("MVP0-P10");
     await expect(about).toContainText(expectedBuildCommit);
     const repository = about.getByRole("link", { name: "在新标签页打开反应域 GitHub 仓库" });

--- a/e2e/tests/debug-alpha.spec.ts
+++ b/e2e/tests/debug-alpha.spec.ts
@@ -288,7 +288,7 @@ test("默认配置、正式元数据与 configuring 帮助界面", async ({ page
   })).toBeVisible();
   await expect(page.getByLabel("player_1 角色")).toHaveValue("laboratory_teacher");
   await expect(page.getByLabel("player_2 角色")).toHaveValue("chemical_factory_ceo");
-  await expect(page.getByText("Web Playtest Alpha · v0.15.0-alpha.1 · MVP0-P10", {
+  await expect(page.getByText("Web Playtest Alpha · v0.16.0-alpha.1 · MVP0-P10", {
     exact: false,
   })).toBeVisible();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chemistry-online-card-game",
-  "version": "0.15.0-alpha.1",
+  "version": "0.16.0-alpha.1",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/scripts/check-production.test.mjs
+++ b/scripts/check-production.test.mjs
@@ -7,7 +7,7 @@ import {
   forbiddenProductionMarkers,
 } from "./check-production.mjs";
 
-const expectedTitle = "反应域 · REACTION FIELD · Web Playtest Alpha · 0.15.0-alpha.1 · MVP0-P10";
+const expectedTitle = "反应域 · REACTION FIELD · Web Playtest Alpha · 0.16.0-alpha.1 · MVP0-P10";
 const cleanIndex = `<!doctype html><html><head><title>${expectedTitle}</title><script src="./assets/app.js"></script><link href="./assets/app.css" rel="stylesheet"></head><body></body></html>`;
 const temporaryRoots = [];
 

--- a/scripts/check-web-playtest-tag.test.mjs
+++ b/scripts/check-web-playtest-tag.test.mjs
@@ -3,28 +3,28 @@ import { describe, expect, it } from "vitest";
 import { checkWebPlaytestTag, verifyWebPlaytestTag } from "./check-web-playtest-tag.mjs";
 
 const script = new URL("./check-web-playtest-tag.mjs", import.meta.url);
-const version = "0.15.0-alpha.1";
+const version = "0.16.0-alpha.1";
 
 function run(environment = {}, argumentsList = []) {
   return spawnSync(process.execPath, [script.pathname, ...argumentsList], {
     encoding: "utf8",
-    env: { ...process.env, GITHUB_REF: "refs/tags/web-playtest-v0.15.0-alpha.1", ...environment },
+    env: { ...process.env, GITHUB_REF: "refs/tags/web-playtest-v0.16.0-alpha.1", ...environment },
   });
 }
 
 describe("check-web-playtest-tag", () => {
   it("accepts only the exact bare tag supplied through GITHUB_REF_NAME", async () => {
-    await expect(checkWebPlaytestTag({ GITHUB_REF_NAME: "web-playtest-v0.15.0-alpha.1" })).resolves.toBe("web-playtest-v0.15.0-alpha.1");
-    expect(run({ GITHUB_REF_NAME: "web-playtest-v0.15.0-alpha.1" }).status).toBe(0);
+    await expect(checkWebPlaytestTag({ GITHUB_REF_NAME: "web-playtest-v0.16.0-alpha.1" })).resolves.toBe("web-playtest-v0.16.0-alpha.1");
+    expect(run({ GITHUB_REF_NAME: "web-playtest-v0.16.0-alpha.1" }).status).toBe(0);
   });
 
   it.each([
-    "web-playtest-v0.14.0-alpha.1",
-    "web-playtest-v0.15.0-alpha.2",
-    "web-playtest-v0.16.0-alpha.1",
-    "web-playtest-v0.15.0-alpha.1-extra",
-    "v0.15.0-alpha.1",
-    "refs/tags/web-playtest-v0.15.0-alpha.1",
+    "web-playtest-v0.15.0-alpha.1",
+    "web-playtest-v0.16.0-alpha.2",
+    "web-playtest-v0.17.0-alpha.1",
+    "web-playtest-v0.16.0-alpha.1-extra",
+    "v0.16.0-alpha.1",
+    "refs/tags/web-playtest-v0.16.0-alpha.1",
     "",
     undefined,
   ])("rejects invalid environment tag %s", async (tag) => {
@@ -34,7 +34,7 @@ describe("check-web-playtest-tag", () => {
   });
 
   it("does not accept a CLI tag or GITHUB_REF fallback", () => {
-    expect(run({ GITHUB_REF_NAME: undefined }, ["web-playtest-v0.15.0-alpha.1"]).status).toBe(1);
-    expect(() => verifyWebPlaytestTag("refs/tags/web-playtest-v0.15.0-alpha.1", version)).toThrow();
+    expect(run({ GITHUB_REF_NAME: undefined }, ["web-playtest-v0.16.0-alpha.1"]).status).toBe(1);
+    expect(() => verifyWebPlaytestTag("refs/tags/web-playtest-v0.16.0-alpha.1", version)).toThrow();
   });
 });

--- a/src/app/releaseMetadata.test.tsx
+++ b/src/app/releaseMetadata.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import packageMetadata from "../../package.json";
 import { releaseMetadata } from "./releaseMetadata";
 
-describe("Alpha 5 release-candidate metadata", () => {
+describe("Alpha 6 release-candidate metadata", () => {
   it("uses package.json as the application version single source of truth", () => {
     expect(releaseMetadata).toEqual({
       displayName: "反应域",
@@ -12,6 +12,6 @@ describe("Alpha 5 release-candidate metadata", () => {
       rulesVersion: "MVP0-P10",
       commit: expect.stringMatching(/^(?:[0-9a-f]{12}|dev\/unknown)$/u),
     });
-    expect(packageMetadata.version).toBe("0.15.0-alpha.1");
+    expect(packageMetadata.version).toBe("0.16.0-alpha.1");
   });
 });


### PR DESCRIPTION
## Summary

- prepare Reaction Field Alpha 6 as `0.16.0-alpha.1`
- prepare the release tag contract for `web-playtest-v0.16.0-alpha.1`
- update the English and Simplified Chinese public Alpha 6 release information
- align production, E2E, release-metadata, and tag-validation assertions
- include the Phase 16 bilingual structured game-log work in the Alpha 6 candidate

## Scope

This is release-preparation work only. It does not change game rules, card behavior, reaction resolution, DIY recipes, or turn sequencing.

## Verification

Local verification reported:

- `pnpm exec tsc -b`
- `pnpm run test:run`: 42 files, 591 tests passed
- `pnpm run build`
- `pnpm run check:production`
- `pnpm run check:size`
- simulated `web-playtest-v0.16.0-alpha.1` tag verification
- `git diff --check`
- `git diff --cached --check`

Push CI:

- Workflow: Phase 11 Debug Alpha
- Run ID: 31859556399
- Conclusion: success
- https://github.com/9947447-alt/Chemistry-online-Card-Game/actions/runs/31859556399

## Release boundaries

This PR does not create or move a tag, create a GitHub Release, change GitHub Pages settings, or deploy the public site. Those remain separate approval boundaries.