### PR TITLE
docs: close Phase 17 post-merge review gaps

### DIFF
--- a/docs/PHASE17_BRAND_IDENTITY_FREEZE.md
+++ b/docs/PHASE17_BRAND_IDENTITY_FREEZE.md
@@ -294,8 +294,9 @@
 ### 4.4 Release Preparation、Tag 创建、Pages 部署、Phase 17E 验收与 GitHub Release
 
 #### 4.4.1 Release Preparation（发布与版本准备阶段）
+- **已消耗最高版本定义（`highest_consumed_version`）**：对以下两个集合的并集按 **SemVer precedence** 取最大值：已 push 到经核验正确 `origin` 的所有不可变 `web-playtest-v<version>` Release Tags 所对应版本，以及已正式发布（非 draft）的 GitHub Releases 所对应版本。Tag 一旦 push 到正确 `origin`，该版本即永久 consumed，不受 Actions 是否触发、Pages/Phase 17E 是否成功或 GitHub Release 是否创建成功影响。任何 post-tag recovery 的 `new_version` 都必须满足 `new_version > highest_consumed_version`；比较必须使用 SemVer 排序，严禁字符串字典序排序。
 - **契约约束**：`.github/workflows/phase12-web-playtest-pages.yml` 中的 `check:web-playtest-tag` 门禁强制要求 Tag 必须精确等于 `web-playtest-v${package.json.version}`。鉴于 `web-playtest-v0.16.0-alpha.1` 已随 Alpha 6 发布并作为不可变历史资产保护，若迁移后需创建新 Tag 部署 Pages，**必须先完成版本准备并合并**：
-  1. **版本号确定与授权**：在独立发布授权边界下确定新的单调递增版本号（具体版本由发布边界决定，本冻结文档不预设具体值）；
+  1. **版本号确定与授权**：在独立发布授权边界下确定满足 `new_version > highest_consumed_version` 的新版本号（按 SemVer precedence 比较；具体版本由发布边界决定，本冻结文档不预设具体值）；
   2. **代码库版本与测试断言同步**：修改 `package.json` 中的 `"version"` 字段，并同步更新 5 个关联的精确版本测试断言文件：
      - `e2e/production/reaction-field.spec.ts`
      - `e2e/tests/debug-alpha.spec.ts`
@@ -345,23 +346,56 @@
      ```
   7. **Tag 对象与 Peeled Commit SHA 校验**：
      ```bash
-     TAG_PEELED_SHA=$(git rev-parse "web-playtest-v<version>^{commit}")
+     TAG_NAME="web-playtest-v<version>"
+     TAG_REF="refs/tags/${TAG_NAME}"
+     TAG_OBJECT_SHA=$(git rev-parse "${TAG_NAME}^{tag}")
+     TAG_OBJECT_TYPE=$(git cat-file -t "${TAG_OBJECT_SHA}")
+     TAG_PEELED_SHA=$(git rev-parse "${TAG_NAME}^{commit}")
+     TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "${TAG_REF}")
+     test "${TAG_OBJECT_TYPE}" = "tag"
+     test "${TAG_PEELED_SHA}" = "${TARGET_SHA}"
+     test "${TAG_MESSAGE}" = "Release Reaction Field Alpha <N> — v<version>"
      ```
-     验证 `${TAG_PEELED_SHA}` 严格等于 `${TARGET_SHA}`，并核对 tag 对象类型与 message。
+     记录 `${TAG_OBJECT_SHA}`、`${TAG_OBJECT_TYPE}`、`${TAG_PEELED_SHA}` 与 `${TAG_MESSAGE}` 四项授权快照；验证 object type 严格为 `tag`、peeled SHA 严格等于 `${TARGET_SHA}`、message 严格等于预先报告的 Tag message。
   8. **STOP & Report 2（远端 Tag 推送独立授权门禁）**：
-     本地 Tag 创建与 peeled SHA 校验通过后，**再次停止**并向用户报告已创建的本地 Tag 对象与 peeled SHA 校验结果，申请独立的**不可变 Tag 推送明确授权**。
+     本地 Tag 创建与四项授权快照校验通过后，**再次停止**并向用户逐项报告 Tag object SHA、object type、peeled SHA 与完整 message；独立的不可变 Tag push 授权必须绑定这四项已报告值。
 
 #### 4.4.3 不可变 Tag 推送与 GitHub Actions Pages 部署工作流（独立 Tag 推送授权）
+- **Push 前授权快照再核验（TOCTOU 防护）**：
+  获得独立 push 授权后、实际 push 前，必须立即从当前本地 `refs/tags/<tag>` 重新读取四项状态：
+  ```bash
+  CURRENT_TAG_OBJECT_SHA=$(git rev-parse "${TAG_NAME}^{tag}")
+  CURRENT_TAG_OBJECT_TYPE=$(git cat-file -t "${CURRENT_TAG_OBJECT_SHA}")
+  CURRENT_TAG_PEELED_SHA=$(git rev-parse "${TAG_NAME}^{commit}")
+  CURRENT_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "${TAG_REF}")
+  test "${CURRENT_TAG_OBJECT_SHA}" = "${TAG_OBJECT_SHA}"
+  test "${CURRENT_TAG_OBJECT_TYPE}" = "tag"
+  test "${CURRENT_TAG_OBJECT_TYPE}" = "${TAG_OBJECT_TYPE}"
+  test "${CURRENT_TAG_PEELED_SHA}" = "${TARGET_SHA}"
+  test "${CURRENT_TAG_PEELED_SHA}" = "${TAG_PEELED_SHA}"
+  test "${CURRENT_TAG_MESSAGE}" = "${TAG_MESSAGE}"
+  ```
+  任一 ref 不存在或任一值相对已报告/授权快照发生变化，必须 STOP，不得 push；须重新向用户报告当前四项状态并重新申请独立 push 授权。此核验只允许读取 Tag，严禁在此阶段创建、移动、重写或清理 Tag。
 - **Tag 推送（独立推送授权后执行）**：
   在获得用户显式的独立 Tag 推送授权后，执行推送：
   ```bash
   git push origin web-playtest-v<version>
   ```
 - **远端 Tag 存在性即时核验**：
-  推送完成后，立即通过只读命令核验远端标签已就绪：
+  推送完成后，立即通过只读命令分别核验 annotated tag object 的 direct ref 与其 peeled commit ref：
   ```bash
-  git ls-remote --tags origin refs/tags/web-playtest-v<version>
+  TAG_NAME="web-playtest-v<version>"
+  TAG_REF="refs/tags/${TAG_NAME}"
+  PEELED_REF="${TAG_REF}^{}"
+  REMOTE_TAG_REFS=$(git ls-remote --exit-code --tags origin "${TAG_REF}" "${PEELED_REF}")
+  REMOTE_TAG_OBJECT_SHA=$(printf '%s\n' "${REMOTE_TAG_REFS}" | awk -v ref="${TAG_REF}" '$2 == ref {print $1}')
+  REMOTE_TAG_PEELED_SHA=$(printf '%s\n' "${REMOTE_TAG_REFS}" | awk -v ref="${PEELED_REF}" '$2 == ref {print $1}')
+  test -n "${REMOTE_TAG_OBJECT_SHA}"
+  test -n "${REMOTE_TAG_PEELED_SHA}"
+  test "${REMOTE_TAG_OBJECT_SHA}" = "${TAG_OBJECT_SHA}"
+  test "${REMOTE_TAG_PEELED_SHA}" = "${TARGET_SHA}"
   ```
+  `refs/tags/<tag>` 的 SHA 是 annotated tag object SHA，不得误当 target commit；`refs/tags/<tag>^{}` 的 SHA 才是 peeled target commit。direct 与 peeled 两条 ref 必须同时存在，且 `${REMOTE_TAG_PEELED_SHA}` 必须严格等于 `${TARGET_SHA}`。包含 `^{}` 的 refspec 必须像上例一样以已引用变量传入，严禁使用未引用的 shell/pattern 展开。
 - **不可变资产红线**：
   Tag 一旦推送到远端即成为不可变发布凭证，严禁移动、覆盖、删除、复用或重新推送 `web-playtest-v0.16.0-alpha.1` 及后续任意版本标签。
 - **GitHub Actions 触发与门禁**：
@@ -386,9 +420,12 @@
 - **远端 Tag 存在性强制核验（Remote Tag Verification）**：
   为防止 `gh release create` 在远端缺少目标 Tag 时静默创建轻量 Tag 从而绕过规范的 Tag 创建与部署流水线，在创建 Release 前**必须强制核验远端 Tag 已存在**：
   ```bash
-  git ls-remote --tags origin refs/tags/web-playtest-v<version>
+  TAG_NAME="web-playtest-v<version>"
+  TAG_REF="refs/tags/${TAG_NAME}"
+  PEELED_REF="${TAG_REF}^{}"
+  git ls-remote --exit-code --tags origin "${TAG_REF}" "${PEELED_REF}"
   ```
-  确认输出包含待发布的 `refs/tags/web-playtest-v<version>` 且 SHA 与目标 commit / annotated tag 一致。
+  必须按 4.4.3 的同一双 ref 规约重新提取并验证 direct 与 peeled ref 均存在，且 peeled SHA 严格等于已验证的 `${TARGET_SHA}`；direct ref 的 annotated tag object SHA 与 peeled commit SHA 语义不同，不得要求二者相等或将 direct SHA 误报为目标 commit。
 - **Release 创建指令与参数契约**：
   ```bash
   gh release create web-playtest-v<version> \
@@ -489,21 +526,32 @@
   > [!IMPORTANT]
   > 必须显式区分 Pre-tag 回滚与 Post-tag/Post-release 回滚，严禁破坏 SemVer 版本号的不可变性与单调递增性。
   - **Pre-tag 回滚（未打 Tag 前）**：若仅处于 Release Preparation 阶段，代码修改尚未创建或推送 Tag，在发现问题时可通过 `git revert` 或重新提交将 `package.json.version` 调整或复原为准备前的版本号。
-  - **Post-tag / Post-release 回滚（Tag 已推送或 Release 已发布后）**：**一旦不可变 Tag 推送至远端或 Release 已在平台发布，该版本号永久消耗**。严禁在回滚中使用 `git revert` 将 `package.json.version` 倒退回历史旧版本号（例如严禁将版本号从 `0.17.0-alpha.1` 倒退为 `0.16.0-alpha.1`，这会破坏单调性并引发下游构建缓存与 Tag 冲突）。若回滚需要重新构建并部署 Pages，**必须遵循抽象单调性规则：`new_version > highest_published_version`，分配一个全新的、严格大于已消耗最高版本的 SemVer 版本号**（例如在已消耗 `0.17.0-alpha.1` 时，新修复版本必须严格大于该版本，如 `0.17.1-alpha.1` 或 `0.18.0-alpha.1`，严禁使用小于或等于已消耗版本的编号），走完整的 Release Preparation 流程并打新 Tag 部署。
+  - **Post-tag / Post-release 回滚（Tag 已推送或 Release 已发布后）**：**一旦不可变 Tag 推送至正确 `origin` 或 Release 已在平台发布，该版本号永久消耗**。严禁在回滚中使用 `git revert` 将 `package.json.version` 倒退回历史旧版本号（例如严禁将版本号从 `0.17.0-alpha.1` 倒退为 `0.16.0-alpha.1`，这会破坏单调性并引发下游构建缓存与 Tag 冲突）。若回滚需要重新构建并部署 Pages，**必须遵循 4.4.1 定义的单调性规则：`new_version > highest_consumed_version`，分配一个全新的、严格大于已消耗最高版本的 SemVer 版本号**（例如在已消耗 `0.17.0-alpha.1` 时，新修复版本必须严格大于该版本，如 `0.17.1-alpha.1` 或 `0.18.0-alpha.1`，严禁使用小于或等于已消耗版本的编号），走完整的 Release Preparation 流程并打新 Tag 部署。
   - **发布与 Tag 红线及未推送本地标签清理规约**：
     - **远端已推送 Tag 不可变红线**：不可变资产红线严格适用于推送到远端的 Release Tag（`git push origin <tag>`）。**严禁删除、移动、覆盖或复用已有远端 Git Tags**。
     - **未推送本地 Tag 中止与清理规约**：若在本地已执行 `git tag -a` 创建了本地标签，但后续 peeled SHA 校验不通过，或在第二道授权门禁中推送授权被用户中止/拒绝，**必须在本地执行 `git tag -d web-playtest-v<version>` 显式删除未推送的本地标签**，防止重试或修正时遭遇 `fatal: tag '...' already exists` 报错。未推送到远端的本地中止标签不消耗版本号。
 
 ### 6.3 6 大标准故障恢复分支规约（Six Standard Failure Recovery Branches）
 
+- **Same-run rerun 严格准入合同**：`gh run rerun <run_id>` 只允许同时满足以下全部条件时使用：存在目标 workflow 的既有 `run_id`；该 run 的 release source/tag 仍通过 4.4.3 的 direct + peeled 远端核验、expected version 与 Release-Source identity 校验；日志证据确认失败仅来自 transient platform/infrastructure、runner queue、外部服务抖动或 cancellation；且不存在任何 source/tag gate、build、test、metadata 或 workflow config 错误证据。rerun 必须复用同一 `run_id` 对应的不可变 source/tag、重新执行全部正常 release gates，不得改变部署源或跳过门禁。
+- **Run identity 强绑定合同**：任何 `gh run rerun <run_id>` 前，必须先通过 `gh run list` 筛选候选，再用 `gh run view` 对选中的唯一 run 做二次 JSON 核验：
+  ```bash
+  gh workflow list --all --json id,name,path,state
+  gh run list --all --workflow=phase12-web-playtest-pages.yml --event push --branch "${TAG_NAME}" --commit "${REMOTE_TAG_PEELED_SHA}" --json databaseId,event,headBranch,headSha,workflowDatabaseId,workflowName
+  gh run view "${RUN_ID}" --json databaseId,event,headBranch,headSha,workflowDatabaseId,workflowName,status,conclusion,attempt
+  ```
+  `gh workflow list` 必须恰好得到一条 `path == .github/workflows/phase12-web-playtest-pages.yml` 且 `state == active` 的 workflow；run 的 `workflowDatabaseId` 必须等于该 workflow 的 `id`，`workflowName` 必须等于 `Phase 12 Web Playtest Pages`。`databaseId` 必须等于拟 rerun 的 `${RUN_ID}`，`event` 必须为 `push`，`headBranch` 必须严格等于 `web-playtest-v<version>`，`headSha` 必须严格等于已远端核验的 `${REMOTE_TAG_PEELED_SHA}` 与 `${TARGET_SHA}`。候选为零条、多条，或任一字段不匹配时必须 STOP 并报告，不得 rerun。`gh run rerun` 只按 `run_id` 执行，命令本身不能附加或补救 tag/SHA 选择，因此 identity 校验不得省略或事后补做。
+- **STOP & Report 3（Same-run rerun 独立授权门禁）**：Same-run rerun 技术准入与 Run identity 强绑定校验全部通过后，仍必须 STOP，不得直接 rerun。须报告：唯一 `${RUN_ID}`；workflow ID / name / path；`event`；`${TAG_NAME}`；已报告并授权的本地 `${TAG_OBJECT_SHA}`；远端 direct `${REMOTE_TAG_OBJECT_SHA}`；远端 peeled `${REMOTE_TAG_PEELED_SHA}` / `${TARGET_SHA}`；run `headBranch` / `headSha`；run `status` / `conclusion` / `attempt`；确认 transient platform/infrastructure/cancellation 的具体日志证据；不存在 source/gate/build/test/metadata/config defect 的证据；以及拟执行的精确命令 `gh run rerun ${RUN_ID}`。随后申请绑定上述全部值与证据的独立 **rerun/deployment 明确授权**；Tag push 授权、原自动触发授权或其他发布授权均不得推定覆盖 rerun。授权后、执行前必须立即重新核验 run/source/tag/status 与证据；任一值或证据变化均须 STOP、重新报告并重新申请授权。只有 Same-run rerun 技术准入、Run identity 强绑定和本独立授权三者同时满足，才可执行精确 rerun 命令。
+- **Reproducible/source failure 禁止 rerun 合同**：`check:web-playtest-tag`、deterministic build、deterministic Vitest/E2E、metadata mismatch、source defect 或 workflow/config defect 均不得以反复 rerun 已消费 Tag 处理；必须提交 source repair PR，合并后分配满足 `new_version > highest_consumed_version` 的新 SemVer 版本，创建并推送新的不可变 Tag，再走完整 Release-Source 校验、正常 gates、Pages、Phase 17E 与 Release pipeline。
+
 | 故障分支 | 触发阶段与典型场景 | 标准化处理规约 |
 | :--- | :--- | :--- |
 | **Branch 1: Failure before tag creation / push**<br>(Tag 创建或推送前失败) | Release Preparation 本地/CI 验证失败，或 Release-Source 校验失败（如 ancestry 校验不通过、远端快照版本/包名/代码链接与 Tag 不匹配），或本地 Tag 创建后中止推送。 | 1. 立即终止发版流程，不向远端推送 Tag；<br>2. 若本地已执行 `git tag -a` 创建了未推送的本地标签，必须在本地执行 `git tag -d web-playtest-v<version>` 显式清理，防止重试冲突；<br>3. 在集成分支或本地修正代码，或提交 `git revert` 撤销版本 bump commit；<br>4. 在未打 Tag 推送前，版本号允许复用或重新递增（未推送的中止标签不消耗版本号）；<br>5. 重新完成全量构建测试与 PR 合并门禁。 |
-| **Branch 2: Failure after tag push, before deploy completes**<br>(Tag 已推送但 Actions 未触发或排队阻塞) | Tag 已推送到远端，但 GitHub Actions 平台未触发工作流、webhook 丢失或 runner 队列发生死锁。 | 1. **严禁删除、移动或重新推送同名 Tag**（已推送 Tag 为不可变发布凭据，严禁通过删 tag 重推来强行触发）；<br>2. 通过平台只读命令（`gh run list --workflow=phase12-web-playtest-pages.yml`）排查运行状态，显式区分以下两种场景：<br>   - **场景 A（存在工作流运行记录，已有 run_id）**：若工作流已生成运行记录但因队列阻塞、临时抖动、取消或构建失败，可通过 `gh run rerun <run_id>` 合法重新触发运行；<br>   - **场景 B（平台从未生成工作流运行记录，无 run_id 可用）**：因 `.github/workflows/phase12-web-playtest-pages.yml` 当前仅监听 `push: tags: ['web-playtest-v*']` 且未配置 `workflow_dispatch`，此时无法调用 `gh run rerun`。**必须立即 STOP** 并向用户报告无 run 记录状态，进入独立恢复通道（例如获得用户明确授权后，在集成分支为工作流补充安全的 manual `workflow_dispatch` 触发器并合并后调度；或走标准流程准备全新的单调递增版本号、重新走 Release-Source 校验并打新 Tag 触发发版流水线），绝对不留无法执行的操作死胡同；<br>3. 若属工作流配置自身缺陷需要改动代码，必须在集成分支提交修复、递增全新单调递增版本号走新发版流程，严禁复用当前 Tag。 |
-| **Branch 3: Pages deployment workflow failure**<br>(Pages 构建或部署流水线报错失败) | GitHub Actions 运行中 `check:web-playtest-tag` 门禁报错、`pnpm run build` 失败、E2E 测试失败或 Pages 部署步骤异常退出。 | 1. **已推送 Tag 永久保留作为失败构建记录，严禁删除/覆盖**；<br>2. 分析 Actions 构建日志定位报错根因；<br>3. 在集成分支提交修复 PR 并合并；<br>4. 遵循 `new_version > highest_published_version` 分配全新的单调递增版本号，重新走完整 Release 流程打新 Tag 重新部署。 |
-| **Branch 4: Deployment success but Phase 17E acceptance failure**<br>(部署成功但公网验收未通过) | GitHub Actions 部署成功，但在 Phase 17E 真实公网验收中发现静态资源 404、About/结算页仓库外链失效、JS 报错或 smoke test 失败。 | 1. **绝对禁止执行 README 公开入口切流**（确保用户继续访问稳定可用的旧 Pages 入口）；<br>2. 已推送 Tag 永久保留；<br>3. 排查公网环境特异性失效根因并在集成分支提交修复 PR；<br>4. 遵循 `new_version > highest_published_version` 分配新的单调递增版本号，重新走发版与 Tag 部署流程；<br>5. 只有新版本公网验收 100% 全部通过后，才允许进行公开入口与发布事实切流。 |
+| **Branch 2: Failure after tag push, before deploy completes**<br>(Tag 已推送但 Actions 未触发或排队阻塞) | Tag 已推送到远端，但 GitHub Actions 平台未触发工作流、webhook 丢失或 runner 队列发生死锁。 | 1. **严禁删除、移动或重新推送同名 Tag**（已推送 Tag 为不可变发布凭据，严禁通过删 tag 重推来强行触发）；<br>2. 通过平台只读命令（`gh run list --workflow=phase12-web-playtest-pages.yml`）排查运行状态，显式区分以下两种场景：<br>   - **场景 A（存在工作流运行记录，已有 run_id）**：只有同时满足本节 Same-run rerun 技术准入、Run identity 强绑定与 STOP & Report 3 独立授权三项合同，才可执行 `gh run rerun <run_id>`；构建/测试失败本身不是 transient 证据。<br>   - **场景 B（平台从未生成工作流运行记录，无 run_id 可用）**：`.github/workflows/phase12-web-playtest-pages.yml` 当前仅监听 `push: tags: ['web-playtest-v*']`，未实现 `workflow_dispatch` 或 exact-tag manual recovery；该 manual path **当前不可用且不得宣称可用**，必须立即 STOP 并报告。exact-tag manual recovery 只能作为**未来独立授权的 workflow change**实现：其输入必须显式接受并确定既有远端不可变 Tag，checkout exact remote `refs/tags/<tag>`（detached），并在部署前重新验证 direct + peeled ref 均存在、peeled SHA == expected target commit、`HEAD` == peeled SHA、expected version、Release-Source identity，以及正常 release gates 全部通过；严禁 checkout 或部署 integration/default branch HEAD，`gh workflow run --ref <integration-or-default-branch>` 也不得被当作已消费 Tag 的 release source。该 workflow change 实现并独立获准前，唯一可执行 fallback 是 source repair PR → `new_version > highest_consumed_version` → new immutable Tag → normal pipeline；未来实现后若无法安全保证 exact-tag recovery，也必须使用该 fallback。<br>3. 若属 workflow/config 缺陷，必须走 source repair 与全新版本/Tag，严禁复用当前 Tag。 |
+| **Branch 3: Pages deployment workflow failure**<br>(Pages 构建或部署流水线报错失败) | GitHub Actions 运行中 `check:web-playtest-tag` 门禁报错、`pnpm run build` 失败、Vitest/E2E 失败、metadata mismatch，或 Pages 部署步骤异常退出。 | 1. **已推送 Tag 永久保留作为失败构建记录，严禁删除/覆盖**；<br>2. 分析 Actions 日志并分类：只有证据确认的 transient platform/infrastructure/cancellation，且同时满足 Same-run rerun 技术准入、Run identity 强绑定与 STOP & Report 3 独立授权三项合同，才允许 rerun 同一 `run_id`；<br>3. `check:web-playtest-tag`、deterministic build、deterministic Vitest/E2E、metadata mismatch、source/config defect 必须走 source repair PR；<br>4. 修复合并后遵循 `new_version > highest_consumed_version` 分配新 SemVer 版本并创建新 immutable Tag，重新走完整 pipeline；严禁无限 rerun defective Tag。 |
+| **Branch 4: Deployment success but Phase 17E acceptance failure**<br>(部署成功但公网验收未通过) | GitHub Actions 部署成功，但在 Phase 17E 真实公网验收中发现静态资源 404、About/结算页仓库外链失效、JS 报错或 smoke test 失败。 | 1. **绝对禁止执行 README 公开入口切流**（确保用户继续访问稳定可用的旧 Pages 入口）；<br>2. 已推送 Tag 永久保留；<br>3. 排查公网环境特异性失效根因并在集成分支提交修复 PR；<br>4. 遵循 `new_version > highest_consumed_version` 分配新的单调递增版本号，重新走发版与 Tag 部署流程；<br>5. 只有新版本公网验收 100% 全部通过后，才允许进行公开入口与发布事实切流。 |
 | **Branch 5: Failure during GitHub Release creation**<br>(部署与验收通过，但 gh release create 失败) | GitHub Actions Pages 部署成功且 Phase 17E 公网验收全部通过，但在执行 `gh release create` 时因网络抖动、Token 权限不足或平台接口异常导致发布失败。 | 1. **Pages 部署静态站点与远端不可变 Tag 保持完好有效，严禁删除远端 Tag 或重新递增版本号**；<br>2. **绝对禁止提前执行 Step 9 README/文档切流**；<br>3. 通过平台命令（`gh release view web-playtest-v<version>`）检查远端 Release 实际状态；<br>4. 排查并解决网络、认证 Token 或参数问题；<br>5. 重新执行经授权的 Release 创建指令（`gh release create web-playtest-v<version> --verify-tag ...`）；<br>6. 平台确认 Release 发布成功后，继续进入 Step 9 公开入口与发布事实切流。 |
-| **Branch 6: Release published & traffic switched, then critical defect discovered**<br>(全量发布切流后发现致命缺陷紧急回滚) | GitHub Release 已发布且公开入口已切流，随后在生产环境发现规则破坏、重大数据异常或严重安全/运行时崩溃缺陷。 | 1. 评估是否需要仓库改名回滚（如涉及 slug 冲突/合规）或仅需代码回滚；<br>2. 提交代码回滚 PR；<br>3. **严禁在 `package.json` 中将版本号回退为历史旧版本**，必须遵循 `new_version > highest_published_version` 分配全新的单调递增版本号（例如已消耗 `0.17.0-alpha.1` 时分配 `0.17.1-alpha.1` 或 `0.18.0-alpha.1`，严禁使用小于或等于已消耗版本的编号）；<br>4. 完成验证并合并回滚代码；<br>5. 经 Release-Source 校验与独立 Tag 创建/推送授权创建新 Tag 并推送，完成 Pages 部署与公网验收；<br>6. 在 GitHub 平台将有缺陷的旧 Release 编辑标记为 `[Deprecated / Superseded]`，并发布新的 patch Release；<br>7. 提交 PR 将 README 公开试玩入口与发布事实指向新的可用状态。 |
+| **Branch 6: Release published & traffic switched, then critical defect discovered**<br>(全量发布切流后发现致命缺陷紧急回滚) | GitHub Release 已发布且公开入口已切流，随后在生产环境发现规则破坏、重大数据异常或严重安全/运行时崩溃缺陷。 | 1. 评估是否需要仓库改名回滚（如涉及 slug 冲突/合规）或仅需代码回滚；<br>2. 提交代码回滚 PR；<br>3. **严禁在 `package.json` 中将版本号回退为历史旧版本**，必须遵循 `new_version > highest_consumed_version` 分配全新的单调递增版本号（例如已消耗 `0.17.0-alpha.1` 时分配 `0.17.1-alpha.1` 或 `0.18.0-alpha.1`，严禁使用小于或等于已消耗版本的编号）；<br>4. 完成验证并合并回滚代码；<br>5. 经 Release-Source 校验与独立 Tag 创建/推送授权创建新 Tag 并推送，完成 Pages 部署与公网验收；<br>6. 在 GitHub 平台将有缺陷的旧 Release 编辑标记为 `[Deprecated / Superseded]`，并发布新的 patch Release；<br>7. 提交 PR 将 README 公开试玩入口与发布事实指向新的可用状态。 |
 
 *注：若 Step 9 文档收口 PR 发生 CI 门禁或合并冲突失败，故障严格隔离于文档 PR 分支，不影响已发布的 Pages 与 Release，直接在 PR 分支内修复或 rebase 即可，无需递增版本号。*
 

--- a/docs/PHASE17_BRAND_IDENTITY_FREEZE.md
+++ b/docs/PHASE17_BRAND_IDENTITY_FREEZE.md
@@ -34,9 +34,9 @@
 | **UI 装饰大写** | `REACTION FIELD` | 页面 kicker、版本状态条、UI 徽标（Small-caps 风格） |
 | **首次双语并列** | `Reaction Field / 反应域` (英为主)<br>`反应域（REACTION FIELD）` (中为主) | README 标题、版权声明（NOTICE）、对外公告首句 |
 | **英文大小写规则** | 正文使用 `Reaction Field`；装饰使用 `REACTION FIELD` | 禁止使用 `Reaction field` 或小写（除包名/slug 外） |
-| **GitHub 仓库 Slug** | `reaction-field` | 唯一首选 GitHub 仓库名（小写 kebab-case） |
+| **GitHub 仓库 Slug** | `reaction-field` | 唯一首选 GitHub 仓库名（小写 kebab-case；原仓库 slug 为 `Chemistry-online-Card-Game`） |
 | **有效备用 Slug** | `reaction-field-card-game` | 仅当首选 slug 在授权实施时发生冲突，经用户明确批准并完成内部身份同步回退流程后启用 |
-| **npm Package Name** | `reaction-field` | `package.json` 中的 `"name"` 字段 |
+| **npm Package Name** | `reaction-field` | `package.json` 中的 `"name"` 字段（原包名为全小写 `chemistry-online-card-game`） |
 | **当前公开仓库 URL** | `https://github.com/9947447-alt/Chemistry-online-Card-Game` | 当前真实生效的 GitHub 仓库地址（在 Phase 17D 改名与 cutover 前保持不变） |
 | **目标仓库 URL** | `https://github.com/9947447-alt/reaction-field` | 规划目标仓库地址（target / planned URL，改名与 cutover 前非 live 仓库链接） |
 | **备用目标仓库 URL** | `https://github.com/9947447-alt/reaction-field-card-game` | 仅当首选 slug 冲突并完成回退流程后作为目标仓库地址 |
@@ -55,7 +55,7 @@
 ### 3.1 活动文件（Active Files）
 
 #### A. Phase 17C（Pre-rename 内部身份与安全文档准备阶段）活动文件
-- `package.json`：修改 `"name": "reaction-field"`（包名与目标 slug 内部对齐）。
+- `package.json`：修改 `"name": "reaction-field"`（包名与目标 slug 内部对齐；由原全小写包名 `chemistry-online-card-game` 迁移）。
 - `README.md` & `README.zh-CN.md`：
   1. 对齐冻结的中英文 positioning 副标题（见第 2 节品牌规范表）；
   2. 修正已过时的 Alpha 6 预发布描述，对齐已在 GitHub 发布的真实事实；
@@ -82,9 +82,9 @@
   4. `scripts/check-web-playtest-tag.test.mjs`（Tag 校验逻辑与预期版本断言）
   5. `src/app/releaseMetadata.test.tsx`（应用内 package metadata 版本断言）
 
-#### D. Post-deployment Acceptance 阶段（Pages 部署与验收后公开入口收口阶段）
-- `README.md` & `README.zh-CN.md`：在 Phase 17D 仓库改名完成 + Release 版本准备合并 + Pages 部署成功 + Phase 17E 公网验收通过后，正式将公开试玩入口切换至生效的新 Pages URL。
-- `docs/MVP_PLAN.md`：更新公开试玩入口记录为新 Pages URL。
+#### D. Post-deployment Acceptance 阶段（Pages 部署、Release 发布与公开事实切流收口阶段）
+- `README.md` & `README.zh-CN.md`：在 Phase 17D 仓库改名完成 + Release 版本准备合并 + Pages 部署成功 + Phase 17E 公网验收通过 + GitHub Release 正式发布后，正式执行公开入口与发布事实切流（Public Entrypoint & Release Facts Cutover），同步真实发布事实（包括适用项：当前公开版本号、不可变发布标签 `web-playtest-v<version>`、GitHub Release / prerelease 状态与链接、Pages 部署与公网验收状态、公开 Pages 试玩 URL；本冻结文档不预设未来具体版本号）。
+- `docs/MVP_PLAN.md`：更新路线图里程碑、不可变发布标签、GitHub Release 状态及公开试玩入口记录为最新真实发布事实。
 
 ### 3.2 历史冻结与踩坑文件（Historical / Frozen Files —— 严格禁止修改）
 - `docs/MVP0_RULE_FREEZE.md`
@@ -104,12 +104,12 @@
 ## 4. Phase 17 实施拆分子阶段与时序模型
 
 整体实施时序必须严格遵循 9 阶段确定性发布状态机：
-`Phase 17C (Pre-rename 内部身份与安全文档准备)` → `Phase 17D (GitHub 仓库改名与设置)` → `Post-rename (代码库链接正式切换 Cutover)` → `Release Preparation (版本准备与测试断言同步)` → `Release-Source 严格校验与本地 Annotated Tag 创建` → `不可变 Tag 推送与 GitHub Actions Pages 部署工作流` → `Phase 17E (真实公网验收与烟测)` → `GitHub Release 独立创建与发布` → `README 公开试玩入口切流与收口`
+`Phase 17C (Pre-rename 内部身份与安全文档准备)` → `Phase 17D (GitHub 仓库改名与设置)` → `Post-rename (代码库链接正式切换 Cutover)` → `Release Preparation (版本准备与测试断言同步)` → `Release-Source 严格校验与本地 Annotated Tag 创建 (独立 Tag 创建授权)` → `不可变 Tag 推送与 GitHub Actions Pages 部署工作流 (独立 Tag 推送授权)` → `Phase 17E (真实公网验收与烟测)` → `GitHub Release 独立创建与发布 (独立 Release 创建授权)` → `公开入口与发布事实切流收口 (Release Facts Cutover)`
 
 ```
 ┌────────────────────────────────────────────────────────────────────────┐
 │ 1. Phase 17C: Pre-rename 内部身份与安全文档准备                         │
-│ - package.json name -> reaction-field                                  │
+│ - package.json name -> reaction-field (原全小写包名迁移)               │
 │ - README 中英文 subtitle 对齐与 Alpha 6 状态事实修正                    │
 │ - live 仓库链接与 live Pages 链接保持 Chemistry-online-Card-Game            │
 └───────────────────────────────────┬────────────────────────────────────┘
@@ -138,18 +138,19 @@
                                     │ version bump merged
                                     ▼
 ┌────────────────────────────────────────────────────────────────────────┐
-│ 5. Release-Source 严格校验与本地 Annotated Tag 创建                    │
+│ 5. Release-Source 严格校验与本地 Annotated Tag 创建 (独立 Tag 创建授权) │
 │ - git fetch origin <integration-branch>                                │
 │ - 校验 cutover 与 bump commit 为集成分支 HEAD 祖先提交                 │
-│ - 校验远端快照 package.json.version 与新 Tag 精确匹配                   │
-│ - 显式绑定 target commit SHA 创建 annotated tag & 校验 peeled SHA      │
+│ - 校验远端快照 package.json.version 与待发布版本号精确匹配              │
+│ - STOP ➔ 申请本地 Tag 创建明确授权 ➔ 绑定 target SHA 创建 annotated tag │
+│ - 校验 tag peeled SHA 与 target SHA 一致                               │
 └───────────────────────────────────┬────────────────────────────────────┘
-                                    │ verified & push authorized
+                                    │ tag created & verified
                                     ▼
 ┌────────────────────────────────────────────────────────────────────────┐
-│ 6. 不可变 Tag 推送与 GitHub Actions Pages 部署工作流                   │
-│ - git push origin web-playtest-v<version> (不可变资产，严禁覆盖/删除)   │
-│ - Actions 自动触发 check:web-playtest-tag 门禁、构建与 Pages 部署      │
+│ 6. 不可变 Tag 推送与 GitHub Actions Pages 部署工作流 (独立 Tag 推送授权)│
+│ - STOP ➔ 申请不可变 Tag 推送明确授权 ➔ git push origin web-playtest-v... │
+│ - 远端 Tag 存在性核验 (git ls-remote) ➔ Actions 自动触发部署流水线     │
 └───────────────────────────────────┬────────────────────────────────────┘
                                     │ pages deploy success
                                     ▼
@@ -160,15 +161,15 @@
                                     │ acceptance passed
                                     ▼
 ┌────────────────────────────────────────────────────────────────────────┐
-│ 8. GitHub Release 独立创建与发布 (独立外部授权边界)                    │
-│ - gh release create web-playtest-v<version> (标题模板严格对齐规范)     │
-│ - 声明：Pages workflow 仅部署站点不建 Release，需独立授权操作           │
+│ 8. GitHub Release 独立创建与发布 (独立 Release 创建授权)               │
+│ - 强制远端 Tag 校验 (--verify-tag / ls-remote) ➔ gh release create     │
+│ - 标题模板严格对齐规范，严禁绕过 Tag 发布管线创建 Release               │
 └───────────────────────────────────┬────────────────────────────────────┘
                                     │ release published
                                     ▼
 ┌────────────────────────────────────────────────────────────────────────┐
-│ 9. 公开入口切流收口 (Public Entrypoint Switch)                         │
-│ - 四要素齐全后，提交 PR 将 README 公开试玩入口切至新 Pages URL          │
+│ 9. 公开入口与发布事实切流收口 (Public Entrypoint & Release Facts Cutover)│
+│ - 四要素齐全后，提交 PR 同步 README/MVP_PLAN 真实发布事实与新 Pages URL │
 └────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -244,12 +245,16 @@
      - **Primary branch（若 active slug 为 `reaction-field`）**：
        ```bash
        gh repo edit 9947447-alt/reaction-field --description "An open-source chemistry-themed local two-player card game with tactical reactions and emergent strategy." --add-topic card-game --add-topic chemistry --add-topic react --add-topic typescript --add-topic board-game --add-topic playtest
-       git remote set-url origin git@github.com:9947447-alt/reaction-field.git
+        # 保持当前使用的传输协议 (HTTPS 默认或 SSH)
+        git remote set-url origin https://github.com/9947447-alt/reaction-field.git
+        # 若本地使用 SSH: git remote set-url origin git@github.com:9947447-alt/reaction-field.git
        ```
      - **Fallback branch（若 active slug 为 `reaction-field-card-game`）**：
        ```bash
-       gh repo edit 9947447-alt/reaction-field-card-game --description "An open-source chemistry-themed local two-player card game with tactical reactions and emergent strategy." --add-topic card-game --add-topic chemistry --add-topic react --add-topic typescript --add-topic board-game --add-topic playtest
-       git remote set-url origin git@github.com:9947447-alt/reaction-field-card-game.git
+        gh repo edit 9947447-alt/reaction-field-card-game --description "An open-source chemistry-themed local two-player card game with tactical reactions and emergent strategy." --add-topic card-game --add-topic chemistry --add-topic react --add-topic typescript --add-topic board-game --add-topic playtest
+        # 保持当前使用的传输协议 (HTTPS 默认或 SSH)
+        git remote set-url origin https://github.com/9947447-alt/reaction-field-card-game.git
+        # 若本地使用 SSH: git remote set-url origin git@github.com:9947447-alt/reaction-field-card-game.git
        ```
      *(严禁同时执行两套指令；必须先验证 active slug 后选择唯一定向分支。更新后可通过 `git remote -v` 验证本地 remote)*
 - **停止条件与备用 Slug 回退流程（Fallback Procedure）**：
@@ -300,11 +305,11 @@
   3. **本地验证**：执行全量构建与测试验证（`pnpm run build`、`pnpm run test:run`、`pnpm run test:e2e` 等）；
   4. **双重授权合并**：获取 Commit 授权 ➔ Commit ➔ 阶段 B clean 验证 ➔ 获取 Push 授权 ➔ Push ➔ CI 通过 ➔ PR 合并至活动集成分支（当前为 `release/phase15-alpha5-web-playtest-alpha1`）。
 
-#### 4.4.2 Release-Source 严格校验与本地 Annotated Tag 创建
+#### 4.4.2 Release-Source 严格校验与本地 Annotated Tag 创建（独立 Tag 创建授权）
 > [!IMPORTANT]
-> 在创建不可变发布 Tag 前，必须执行严格的 Release-Source 校验契约，严禁在未经验证的 commit 或脏本地直接创建/推送 Tag。
+> 在创建与推送不可变发布 Tag 前，必须严格分离**本地 Tag 创建授权**与**远端 Tag 推送授权**，严禁在未经验证的 commit 或脏本地直接创建/推送 Tag，严禁将代码提交授权等同于 Tag 操作授权。
 
-- **Release-Source 校验契约（6 步执行序列）**：
+- **Release-Source 校验与本地 Tag 创建执行序列**：
   1. **Fetch 集成分支**：
      ```bash
      git fetch origin <integration-branch>
@@ -319,28 +324,43 @@
      git merge-base --is-ancestor <cutover_commit_sha> ${TARGET_SHA}
      git merge-base --is-ancestor <version_bump_commit_sha> ${TARGET_SHA}
      ```
-  4. **远端快照版本校验（Remote Snapshot Version Check）**：
-     直接从远端目标 commit 读取 `package.json` 快照，确认版本号与待发布的 `<version>` 精确匹配：
+  4. **远端快照元数据与代码链接校验（Remote Snapshot Metadata & Link Verification）**：
+     直接从远端目标 commit 读取 `package.json` 快照与 `src/app/projectRepository.tsx`，确认包名、版本号及静态仓库链接与待发布的 active slug 及 `<version>` 精确匹配：
      ```bash
+     git show ${TARGET_SHA}:package.json | grep '"name"'
      git show ${TARGET_SHA}:package.json | grep '"version"'
+     git show ${TARGET_SHA}:src/app/projectRepository.tsx | grep 'projectRepositoryUrl'
      ```
-  5. **显式绑定 Target SHA 创建本地 Annotated Tag**：
+     必须验证 `package.json.name` 精确等于 active slug（`"reaction-field"` 或 fallback slug）、`package.json.version` 精确等于待发布的 `<version>`，且 `projectRepositoryUrl` 已切至生效的目标仓库 URL。
+  5. **STOP & Report 1（本地 Tag 创建独立授权门禁）**：
+     完成上述 1–4 步只读校验后，**立即停止**并向用户报告：
+     - 目标 commit `${TARGET_SHA}`
+     - 候选发布版本号 `<version>`
+     - 拟创建的本地 Tag 名称 `web-playtest-v<version>`
+     - 拟使用的 Tag message `Release Reaction Field Alpha <N> — v<version>`
+     向用户申请独立的**本地 Annotated Tag 创建明确授权**（明确红线：Release Preparation commit/push 授权 ≠ 本地 Tag 创建授权 ≠ 远端 Tag 推送授权）。
+  6. **经授权后显式绑定 Target SHA 创建本地 Annotated Tag**：
      ```bash
      git tag -a web-playtest-v<version> ${TARGET_SHA} -m "Release Reaction Field Alpha <N> — v<version>"
      ```
-  6. **Tag Peeled Commit SHA 校验**：
+  7. **Tag 对象与 Peeled Commit SHA 校验**：
      ```bash
      TAG_PEELED_SHA=$(git rev-parse "web-playtest-v<version>^{commit}")
      ```
-     验证 `${TAG_PEELED_SHA}` 严格等于 `${TARGET_SHA}`。
-- **Tag Push 独立授权门禁**：
-  校验完成后，向用户报告 `${TARGET_SHA}`、Tag 名称及 Tag message，申请独立 Tag Push 明确授权。
+     验证 `${TAG_PEELED_SHA}` 严格等于 `${TARGET_SHA}`，并核对 tag 对象类型与 message。
+  8. **STOP & Report 2（远端 Tag 推送独立授权门禁）**：
+     本地 Tag 创建与 peeled SHA 校验通过后，**再次停止**并向用户报告已创建的本地 Tag 对象与 peeled SHA 校验结果，申请独立的**不可变 Tag 推送明确授权**。
 
-#### 4.4.3 不可变 Tag 推送与 GitHub Actions Pages 部署工作流
-- **Tag 推送**：
-  获取用户显式授权后，推送新 Tag：
+#### 4.4.3 不可变 Tag 推送与 GitHub Actions Pages 部署工作流（独立 Tag 推送授权）
+- **Tag 推送（独立推送授权后执行）**：
+  在获得用户显式的独立 Tag 推送授权后，执行推送：
   ```bash
   git push origin web-playtest-v<version>
+  ```
+- **远端 Tag 存在性即时核验**：
+  推送完成后，立即通过只读命令核验远端标签已就绪：
+  ```bash
+  git ls-remote --tags origin refs/tags/web-playtest-v<version>
   ```
 - **不可变资产红线**：
   Tag 一旦推送到远端即成为不可变发布凭证，严禁移动、覆盖、删除、复用或重新推送 `web-playtest-v0.16.0-alpha.1` 及后续任意版本标签。
@@ -363,28 +383,44 @@
 #### 4.4.5 GitHub Release 独立创建与发布（独立外部授权边界）
 - **独立授权契约**：
   在 Pages 部署成功且 Phase 17E 公网验收全部通过后，向用户申请独立的 GitHub Release 创建授权。
+- **远端 Tag 存在性强制核验（Remote Tag Verification）**：
+  为防止 `gh release create` 在远端缺少目标 Tag 时静默创建轻量 Tag 从而绕过规范的 Tag 创建与部署流水线，在创建 Release 前**必须强制核验远端 Tag 已存在**：
+  ```bash
+  git ls-remote --tags origin refs/tags/web-playtest-v<version>
+  ```
+  确认输出包含待发布的 `refs/tags/web-playtest-v<version>` 且 SHA 与目标 commit / annotated tag 一致。
 - **Release 创建指令与参数契约**：
   ```bash
   gh release create web-playtest-v<version> \
     --title "Reaction Field Alpha <N> — v<version>" \
     --notes "<release_notes_markdown>" \
     --target <target_commit_sha> \
+    --verify-tag \
     --prerelease
   ```
+  *(注：`--verify-tag` 确保目标标签已存在于远端仓库，防止 CLI 静默创建新 tag；若使用的 gh CLI 版本不识别该 flag，前面的 `git ls-remote` 显式校验作为强制底线防护)*
 - **契约要求**：
   1. 标题模板必须精确匹配第 2 节规范表：`Reaction Field Alpha <N> — v<version>`；
-  2. Tag 严格使用已推送到远端的 `web-playtest-v<version>`；
+  2. Tag 严格使用已推送到远端并通过 `git ls-remote` / `--verify-tag` 验证的 `web-playtest-v<version>`；
   3. 目标 commit 显式指定经过验证的 `<target_commit_sha>`；
-  4. 正式完成 GitHub 平台 Release 资产发布。
+  4. 严格执行发布管线顺序：`Release-Source 严格校验 ➔ 本地 Annotated Tag 创建 ➔ Tag 推送 ➔ 远端 Tag 存在性校验 ➔ GitHub Actions Pages 部署 ➔ Phase 17E 公网验收 ➔ 独立授权 GitHub Release 创建`，Release 创建绝对不得绕过 Tag 发布管线；
+  5. 正式完成 GitHub 平台 Release 资产发布。
 
-#### 4.4.6 公开入口切流收口（Public Entrypoint Switch）
+#### 4.4.6 公开入口与发布事实切流收口（Public Entrypoint & Release Facts Switch）
 - **切流前置四要素（全部满足后方可切流）**：
   1. Phase 17D GitHub 仓库改名与设置已完成；
   2. GitHub Actions Pages 工作流部署成功；
   3. Phase 17E 真实公网 7 项验收全部通过；
   4. 对应版本的 GitHub Release 已正式创建并发布。
-- **切流执行**：
-  在四要素全部齐备后，提交独立收口 PR，将 `README.md`、`README.zh-CN.md` 及 `docs/MVP_PLAN.md` 中的公开试玩入口切换至新 Pages URL。
+- **切流执行与发布事实同步（Release Facts Synchronization）**：
+  在四要素全部齐备后，提交独立收口 PR。切流收口**不得仅修改 Pages URL**，必须在 `README.md`、`README.zh-CN.md` 及 `docs/MVP_PLAN.md` 中完整同步适用的真实发布事实：
+  1. **当前公开版本**（Current Public Version）：对齐新发布的版本号（本冻结文档不预设未来具体版本号，由发布边界确定）；
+  2. **不可变发布标签**（Immutable Release Tag）：记录实际发布的 `web-playtest-v<version>` 标签；
+  3. **GitHub Release / Prerelease 状态与链接**：对齐已发布的 GitHub Release 链接与发布状态（更新预发布说明与 Release 引用）；
+  4. **Pages 部署与公网验收状态**：记录 Pages 部署通过与 Phase 17E 验收通过事实；
+  5. **公开 Pages 试玩 URL**：将公开试玩入口切换至已验收生效的新 Pages URL（`https://9947447-alt.github.io/reaction-field/` 或 fallback URL）。
+- **切流 PR 故障隔离与恢复（Documentation Cutover PR Failure Isolation）**：
+  若 Step 9 的文档收口 PR 在 CI 门禁或合并过程中出现格式报错、文档冲突或 lint 失败，该失败严格隔离于文档 PR 分支。已部署的 Pages 静态站点与已发布的 GitHub Release 资产保持完好且有效；恢复流程只需在文档 PR 分支内直接修复或 rebase 解决，绝对无需重新递增版本号或重新触发发版流水线。
 
 ---
 
@@ -426,9 +462,12 @@
 3. **Step 3（核实远端仓库名恢复）**：
    只读确认远端仓库名已成功恢复为 `Chemistry-online-Card-Game`。
 4. **Step 4（恢复本地 remote URL）**：
-   远端改名回滚成功后，再更新本地主仓库 remote URL（所有 linked worktree 自动共享）：
+   远端改名回滚成功后，再按原传输协议（HTTPS 或 SSH）更新本地主仓库 remote URL（所有 linked worktree 自动共享）：
    ```bash
-   git remote set-url origin git@github.com:9947447-alt/Chemistry-online-Card-Game.git
+   # HTTPS 默认环境:
+   git remote set-url origin https://github.com/9947447-alt/Chemistry-online-Card-Game.git
+   # 或 SSH 环境:
+   # git remote set-url origin git@github.com:9947447-alt/Chemistry-online-Card-Game.git
    ```
 5. **Step 5（验证 remote 状态）**：
    只读验证 `git remote -v` 与 `git ls-remote` 正确指向 `Chemistry-online-Card-Game`。严禁在远端改名回滚成功前提前修改 local remote，防止产生 local/remote 分裂。
@@ -440,7 +479,7 @@
   1. `src/app/projectRepository.tsx` 中的仓库链接恢复为 `https://github.com/9947447-alt/Chemistry-online-Card-Game`
   2. `src/app/projectRepository.test.tsx` 单元测试断言恢复
   3. `e2e/production/reaction-field.spec.ts` 与 `e2e/tests/debug-alpha.spec.ts` 中的 E2E 仓库链接断言恢复
-  4. `package.json` 中的 `"name"` 恢复为 `"Chemistry-online-Card-Game"`
+  4. `package.json` 中的 `"name"` 恢复为原始全小写包名 `"chemistry-online-card-game"`（严格显式区分：GitHub 仓库 slug 为 `Chemistry-online-Card-Game`，而 npm 包名 / `package.json.name` 原始字段为全小写 `chemistry-online-card-game`）
   5. `README.md` 与 `README.zh-CN.md` 中的仓库外链与 Pages 入口恢复（严禁出现仓库已退回旧名但文档仍指向新 slug 的半回滚状态）
   6. `docs/MVP_PLAN.md` 中的仓库 URL 与 Pages URL 记录恢复
   7. 经 merge diff 发现的其他所有 slug 派生活动值恢复
@@ -450,18 +489,23 @@
   > [!IMPORTANT]
   > 必须显式区分 Pre-tag 回滚与 Post-tag/Post-release 回滚，严禁破坏 SemVer 版本号的不可变性与单调递增性。
   - **Pre-tag 回滚（未打 Tag 前）**：若仅处于 Release Preparation 阶段，代码修改尚未创建或推送 Tag，在发现问题时可通过 `git revert` 或重新提交将 `package.json.version` 调整或复原为准备前的版本号。
-  - **Post-tag / Post-release 回滚（Tag 已推送或 Release 已发布后）**：**一旦不可变 Tag 推送至远端或 Release 已在平台发布，该版本号永久消耗**。严禁在回滚中使用 `git revert` 将 `package.json.version` 倒退回历史旧版本号（例如严禁将版本号从 `0.17.0-alpha.1` 倒退为 `0.16.0-alpha.1`，这会破坏单调性并引发下游构建缓存与 Tag 冲突）。若回滚需要重新构建并部署 Pages，**必须分配一个全新的、单调递增的 SemVer 版本号**（例如新 patch 版本 `v0.16.1-alpha.1` 或 `v0.17.1-alpha.1`），走完整的 Release Preparation 流程并打新 Tag 部署。
-  - **发布与 Tag 红线**：**严禁删除、移动、覆盖或复用已有 Git Tags**。
+  - **Post-tag / Post-release 回滚（Tag 已推送或 Release 已发布后）**：**一旦不可变 Tag 推送至远端或 Release 已在平台发布，该版本号永久消耗**。严禁在回滚中使用 `git revert` 将 `package.json.version` 倒退回历史旧版本号（例如严禁将版本号从 `0.17.0-alpha.1` 倒退为 `0.16.0-alpha.1`，这会破坏单调性并引发下游构建缓存与 Tag 冲突）。若回滚需要重新构建并部署 Pages，**必须遵循抽象单调性规则：`new_version > highest_published_version`，分配一个全新的、严格大于已消耗最高版本的 SemVer 版本号**（例如在已消耗 `0.17.0-alpha.1` 时，新修复版本必须严格大于该版本，如 `0.17.1-alpha.1` 或 `0.18.0-alpha.1`，严禁使用小于或等于已消耗版本的编号），走完整的 Release Preparation 流程并打新 Tag 部署。
+  - **发布与 Tag 红线及未推送本地标签清理规约**：
+    - **远端已推送 Tag 不可变红线**：不可变资产红线严格适用于推送到远端的 Release Tag（`git push origin <tag>`）。**严禁删除、移动、覆盖或复用已有远端 Git Tags**。
+    - **未推送本地 Tag 中止与清理规约**：若在本地已执行 `git tag -a` 创建了本地标签，但后续 peeled SHA 校验不通过，或在第二道授权门禁中推送授权被用户中止/拒绝，**必须在本地执行 `git tag -d web-playtest-v<version>` 显式删除未推送的本地标签**，防止重试或修正时遭遇 `fatal: tag '...' already exists` 报错。未推送到远端的本地中止标签不消耗版本号。
 
-### 6.3 5 大标准故障恢复分支规约（Five Standard Failure Recovery Branches）
+### 6.3 6 大标准故障恢复分支规约（Six Standard Failure Recovery Branches）
 
 | 故障分支 | 触发阶段与典型场景 | 标准化处理规约 |
 | :--- | :--- | :--- |
-| **Branch 1: Failure before tag creation / push**<br>(Tag 创建或推送前失败) | Release Preparation 本地/CI 验证失败，或 Release-Source 校验失败（如 ancestry 校验不通过、远端快照版本与 Tag 不匹配）。 | 1. 立即终止发版流程，不创建/不推送 Tag；<br>2. 在集成分支或本地修正代码，或提交 `git revert` 撤销版本 bump commit；<br>3. 在未打 Tag 推送前，版本号允许复用或重新递增；<br>4. 重新完成全量构建测试与 PR 合并门禁。 |
-| **Branch 2: Failure after tag push, before deploy completes**<br>(Tag 已推送但 Actions 未触发或排队阻塞) | Tag 已推送到远端，但 GitHub Actions 平台未触发工作流、webhook 丢失或 runner 队列发生死锁。 | 1. **严禁删除、移动或重新推送同名 Tag**（已推送 Tag 为不可变发布凭据）；<br>2. 通过平台命令（`gh run list --workflow=phase12-web-playtest-pages.yml`）排查运行状态；<br>3. 若属 GitHub 平台临时抖动，通过 `gh run rerun <run_id>` 重新运行工作流；<br>4. 若属工作流配置自身缺陷需要改动代码，必须在集成分支提交修复、递增全新版本号走新发版流程，严禁复用当前 Tag。 |
-| **Branch 3: Pages deployment workflow failure**<br>(Pages 构建或部署流水线报错失败) | GitHub Actions 运行中 `check:web-playtest-tag` 门禁报错、`pnpm run build` 失败、E2E 测试失败或 Pages 部署步骤异常退出。 | 1. **已推送 Tag 永久保留作为失败构建记录，严禁删除/覆盖**；<br>2. 分析 Actions 构建日志定位报错根因；<br>3. 在集成分支提交修复 PR 并合并；<br>4. 分配全新的单调递增版本号，重新走完整 Release 流程打新 Tag 重新部署。 |
-| **Branch 4: Deployment success but Phase 17E acceptance failure**<br>(部署成功但公网验收未通过) | GitHub Actions 部署成功，但在 Phase 17E 真实公网验收中发现静态资源 404、About/结算页仓库外链失效、JS 报错或 smoke test 失败。 | 1. **绝对禁止执行 README 公开入口切流**（确保用户继续访问稳定可用的旧 Pages 入口）；<br>2. 已推送 Tag 永久保留；<br>3. 排查公网环境特异性失效根因并在集成分支提交修复 PR；<br>4. 分配新的单调递增版本号，重新走发版与 Tag 部署流程；<br>5. 只有新版本公网验收 100% 全部通过后，才允许进行公开入口切流。 |
-| **Branch 5: Release published & traffic switched, then critical defect discovered**<br>(全量发布切流后发现致命缺陷紧急回滚) | GitHub Release 已发布且公开入口已切流，随后在生产环境发现规则破坏、重大数据异常或严重安全/运行时崩溃缺陷。 | 1. 评估是否需要仓库改名回滚（如涉及 slug 冲突/合规）或仅需代码回滚；<br>2. 提交代码回滚 PR；<br>3. **严禁在 `package.json` 中将版本号回退为历史旧版本**，必须分配全新的单调递增 patch 版本号（例如 `v0.17.1-alpha.1`）；<br>4. 完成验证并合并回滚代码；<br>5. 经 Release-Source 校验创建新 Tag 并推送，完成 Pages 部署与公网验收；<br>6. 在 GitHub 平台将有缺陷的旧 Release 编辑标记为 `[Deprecated / Superseded]`，并发布新的 patch Release；<br>7. 提交 PR 将 README 公开试玩入口指向新的可用状态。 |
+| **Branch 1: Failure before tag creation / push**<br>(Tag 创建或推送前失败) | Release Preparation 本地/CI 验证失败，或 Release-Source 校验失败（如 ancestry 校验不通过、远端快照版本/包名/代码链接与 Tag 不匹配），或本地 Tag 创建后中止推送。 | 1. 立即终止发版流程，不向远端推送 Tag；<br>2. 若本地已执行 `git tag -a` 创建了未推送的本地标签，必须在本地执行 `git tag -d web-playtest-v<version>` 显式清理，防止重试冲突；<br>3. 在集成分支或本地修正代码，或提交 `git revert` 撤销版本 bump commit；<br>4. 在未打 Tag 推送前，版本号允许复用或重新递增（未推送的中止标签不消耗版本号）；<br>5. 重新完成全量构建测试与 PR 合并门禁。 |
+| **Branch 2: Failure after tag push, before deploy completes**<br>(Tag 已推送但 Actions 未触发或排队阻塞) | Tag 已推送到远端，但 GitHub Actions 平台未触发工作流、webhook 丢失或 runner 队列发生死锁。 | 1. **严禁删除、移动或重新推送同名 Tag**（已推送 Tag 为不可变发布凭据，严禁通过删 tag 重推来强行触发）；<br>2. 通过平台只读命令（`gh run list --workflow=phase12-web-playtest-pages.yml`）排查运行状态，显式区分以下两种场景：<br>   - **场景 A（存在工作流运行记录，已有 run_id）**：若工作流已生成运行记录但因队列阻塞、临时抖动、取消或构建失败，可通过 `gh run rerun <run_id>` 合法重新触发运行；<br>   - **场景 B（平台从未生成工作流运行记录，无 run_id 可用）**：因 `.github/workflows/phase12-web-playtest-pages.yml` 当前仅监听 `push: tags: ['web-playtest-v*']` 且未配置 `workflow_dispatch`，此时无法调用 `gh run rerun`。**必须立即 STOP** 并向用户报告无 run 记录状态，进入独立恢复通道（例如获得用户明确授权后，在集成分支为工作流补充安全的 manual `workflow_dispatch` 触发器并合并后调度；或走标准流程准备全新的单调递增版本号、重新走 Release-Source 校验并打新 Tag 触发发版流水线），绝对不留无法执行的操作死胡同；<br>3. 若属工作流配置自身缺陷需要改动代码，必须在集成分支提交修复、递增全新单调递增版本号走新发版流程，严禁复用当前 Tag。 |
+| **Branch 3: Pages deployment workflow failure**<br>(Pages 构建或部署流水线报错失败) | GitHub Actions 运行中 `check:web-playtest-tag` 门禁报错、`pnpm run build` 失败、E2E 测试失败或 Pages 部署步骤异常退出。 | 1. **已推送 Tag 永久保留作为失败构建记录，严禁删除/覆盖**；<br>2. 分析 Actions 构建日志定位报错根因；<br>3. 在集成分支提交修复 PR 并合并；<br>4. 遵循 `new_version > highest_published_version` 分配全新的单调递增版本号，重新走完整 Release 流程打新 Tag 重新部署。 |
+| **Branch 4: Deployment success but Phase 17E acceptance failure**<br>(部署成功但公网验收未通过) | GitHub Actions 部署成功，但在 Phase 17E 真实公网验收中发现静态资源 404、About/结算页仓库外链失效、JS 报错或 smoke test 失败。 | 1. **绝对禁止执行 README 公开入口切流**（确保用户继续访问稳定可用的旧 Pages 入口）；<br>2. 已推送 Tag 永久保留；<br>3. 排查公网环境特异性失效根因并在集成分支提交修复 PR；<br>4. 遵循 `new_version > highest_published_version` 分配新的单调递增版本号，重新走发版与 Tag 部署流程；<br>5. 只有新版本公网验收 100% 全部通过后，才允许进行公开入口与发布事实切流。 |
+| **Branch 5: Failure during GitHub Release creation**<br>(部署与验收通过，但 gh release create 失败) | GitHub Actions Pages 部署成功且 Phase 17E 公网验收全部通过，但在执行 `gh release create` 时因网络抖动、Token 权限不足或平台接口异常导致发布失败。 | 1. **Pages 部署静态站点与远端不可变 Tag 保持完好有效，严禁删除远端 Tag 或重新递增版本号**；<br>2. **绝对禁止提前执行 Step 9 README/文档切流**；<br>3. 通过平台命令（`gh release view web-playtest-v<version>`）检查远端 Release 实际状态；<br>4. 排查并解决网络、认证 Token 或参数问题；<br>5. 重新执行经授权的 Release 创建指令（`gh release create web-playtest-v<version> --verify-tag ...`）；<br>6. 平台确认 Release 发布成功后，继续进入 Step 9 公开入口与发布事实切流。 |
+| **Branch 6: Release published & traffic switched, then critical defect discovered**<br>(全量发布切流后发现致命缺陷紧急回滚) | GitHub Release 已发布且公开入口已切流，随后在生产环境发现规则破坏、重大数据异常或严重安全/运行时崩溃缺陷。 | 1. 评估是否需要仓库改名回滚（如涉及 slug 冲突/合规）或仅需代码回滚；<br>2. 提交代码回滚 PR；<br>3. **严禁在 `package.json` 中将版本号回退为历史旧版本**，必须遵循 `new_version > highest_published_version` 分配全新的单调递增版本号（例如已消耗 `0.17.0-alpha.1` 时分配 `0.17.1-alpha.1` 或 `0.18.0-alpha.1`，严禁使用小于或等于已消耗版本的编号）；<br>4. 完成验证并合并回滚代码；<br>5. 经 Release-Source 校验与独立 Tag 创建/推送授权创建新 Tag 并推送，完成 Pages 部署与公网验收；<br>6. 在 GitHub 平台将有缺陷的旧 Release 编辑标记为 `[Deprecated / Superseded]`，并发布新的 patch Release；<br>7. 提交 PR 将 README 公开试玩入口与发布事实指向新的可用状态。 |
+
+*注：若 Step 9 文档收口 PR 发生 CI 门禁或合并冲突失败，故障严格隔离于文档 PR 分支，不影响已发布的 Pages 与 Release，直接在 PR 分支内修复或 rebase 即可，无需递增版本号。*
 
 ---
 


### PR DESCRIPTION
## Summary
- corrective follow-up after PR #11
- fixes six late PR #11 findings
- incorporates five initial Subagent 2.0 same-scope findings
- incorporates four PR #12 Codex findings
- incorporates three additional Sol/Subagent 2.0 release-recovery findings
- hardens release/tag/recovery/rollback/public-cutover contracts

## Scope
- documentation only
- exactly one changed file: docs/PHASE17_BRAND_IDENTITY_FREEZE.md
- zero game-rule/product/workflow/package/README changes

## Validation
- latest head: 8758a0d35d8e816888c0447c870501074f0003a6
- latest push + PR CI successful
- latest Codex review completed with no new findings / 👍
- final release-recovery audit = 0 material blockers

## Base / Head
- base: `release/phase15-alpha5-web-playtest-alpha1`
- head: `docs/phase17-post-merge-corrective`
- current head SHA: `8758a0d35d8e816888c0447c870501074f0003a6`