### PR TITLE
chore(brand): cut over post-rename project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,15 @@ The external Core Rulebook is an extended tabletop reference, not the authoritat
 
 ## Try the Web Playtest
 
-- Play: [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)
+- Play: [https://9947447-alt.github.io/reaction-field/](https://9947447-alt.github.io/reaction-field/)
 - Current public milestone: **Reaction Field Alpha 6**
 - Current published technical version: `0.16.0-alpha.1`
 - Current public tag: `web-playtest-v0.16.0-alpha.1`
 - Rules version: `MVP0-P10`
-- GitHub Release: [Reaction Field Alpha 6](https://github.com/9947447-alt/Chemistry-online-Card-Game/releases/tag/web-playtest-v0.16.0-alpha.1)
-- Planned migration target repository: `https://github.com/9947447-alt/reaction-field`
-- Planned migration target Pages URL: `https://9947447-alt.github.io/reaction-field/`
+- GitHub Release: [Reaction Field Alpha 6](https://github.com/9947447-alt/reaction-field/releases/tag/web-playtest-v0.16.0-alpha.1)
+- Repository: [https://github.com/9947447-alt/reaction-field](https://github.com/9947447-alt/reaction-field)
 
-The current public release is Reaction Field Alpha 6 (`0.16.0-alpha.1`) with rules version `MVP0-P10` and public tag `web-playtest-v0.16.0-alpha.1`. The live playtest URL continues to be served from `https://9947447-alt.github.io/Chemistry-online-Card-Game/` until repository rename and new deployment cutover are completed.
+The current public release is Reaction Field Alpha 6 (`0.16.0-alpha.1`) with rules version `MVP0-P10` and public tag `web-playtest-v0.16.0-alpha.1`. The live playtest URL is served from `https://9947447-alt.github.io/reaction-field/` following the repository rename.
 
 ## What Is Reaction Field?
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,16 +30,15 @@ Web Playtest Alpha 公开双方手牌、牌堆数量、状态与完整日志。�
 
 ## 公开试玩地址与本轮状态
 
-- 公开试玩入口：[https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)
+- 公开试玩入口：[https://9947447-alt.github.io/reaction-field/](https://9947447-alt.github.io/reaction-field/)
 - 当前公开发布阶段：**Reaction Field Alpha 6**
 - 当前发布技术版本：`0.16.0-alpha.1`
 - 当前公开发布标签：`web-playtest-v0.16.0-alpha.1`
 - 规则版本：`MVP0-P10`
-- GitHub Release：[Reaction Field Alpha 6](https://github.com/9947447-alt/Chemistry-online-Card-Game/releases/tag/web-playtest-v0.16.0-alpha.1)
-- 规划迁移目标仓库：`https://github.com/9947447-alt/reaction-field`
-- 规划迁移目标 Pages：`https://9947447-alt.github.io/reaction-field/`
+- GitHub Release：[Reaction Field Alpha 6](https://github.com/9947447-alt/reaction-field/releases/tag/web-playtest-v0.16.0-alpha.1)
+- 官方仓库：[https://github.com/9947447-alt/reaction-field](https://github.com/9947447-alt/reaction-field)
 
-当前公开发布事实为：对外阶段 Reaction Field Alpha 6，技术版本 `0.16.0-alpha.1`，规则版本 `MVP0-P10`，标签 `web-playtest-v0.16.0-alpha.1`。公开试玩入口在完成仓库改名和新部署切流前，继续由当前 live 地址 `https://9947447-alt.github.io/Chemistry-online-Card-Game/` 提供。历史标签 `web-playtest-v0.13.0-alpha.2` 保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；所有历史标签保持不可变。
+当前公开发布事实为：对外阶段 Reaction Field Alpha 6，技术版本 `0.16.0-alpha.1`，规则版本 `MVP0-P10`，标签 `web-playtest-v0.16.0-alpha.1`。随着 GitHub 仓库重命名完成，公开试玩入口已迁移至当前 live 地址 `https://9947447-alt.github.io/reaction-field/`。历史标签 `web-playtest-v0.13.0-alpha.2` 保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；所有历史标签保持不可变。
 
 ## 国际化试玩与双语游戏日志状态
 

--- a/docs/MVP_PLAN.md
+++ b/docs/MVP_PLAN.md
@@ -34,7 +34,7 @@ Phase 13 的权威实现边界见 `docs/PHASE13_NEW_PLAYER_GUIDANCE_FREEZE.md`�
 
 - 配置阶段位于角色选择操作之前；playing 阶段位于 preparation、main action、response、status、counterattack 与 game over 操作区之前。窄屏保持正常文档流，不使用浮层、遮罩、sticky coach mark 或 modal。
 - 阶段文案覆盖配置、备课、主行动、响应、状态处理、实验反击与对局结束；不复制合法性、卡牌匹配、伤害、反应或出牌建议，不 dispatch `GameAction`，不增加任何规则表。
-- 保持 `MVP0-P10`、68 张普通实体卡池、角色和冻结规则不变；Phase 13 引导实现已在 alpha.1 基线完成，`web-playtest-v0.13.0-alpha.1` 标签永久保持不变。当前应用版本为 `0.16.0-alpha.1`，由 `package.json` 作为唯一真值来源，`releaseMetadata` 继续读取构建注入的版本。当前公开版本是 Reaction Field Alpha 6 / `0.16.0-alpha.1`，公开标签为 `web-playtest-v0.16.0-alpha.1`；公开试玩地址为 [https://9947447-alt.github.io/Chemistry-online-Card-Game/](https://9947447-alt.github.io/Chemistry-online-Card-Game/)。
+- 保持 `MVP0-P10`、68 张普通实体卡池、角色和冻结规则不变；Phase 13 引导实现已在 alpha.1 基线完成，`web-playtest-v0.13.0-alpha.1` 标签永久保持不变。当前应用版本为 `0.16.0-alpha.1`，由 `package.json` 作为唯一真值来源，`releaseMetadata` 继续读取构建注入的版本。当前公开版本是 Reaction Field Alpha 6 / `0.16.0-alpha.1`，公开标签为 `web-playtest-v0.16.0-alpha.1`；公开试玩地址为 [https://9947447-alt.github.io/reaction-field/](https://9947447-alt.github.io/reaction-field/)。
 
 ## 0.13.0-alpha.3 已公开发布（Reaction Field Alpha 2）
 
@@ -54,25 +54,27 @@ Phase 16 已公开发布为 Reaction Field Alpha 6，技术版本 `0.16.0-alpha.
 
 已知兼容性边界：iOS 27 beta 的 Firefox 在打开帮助或重开确认框时可能进入 `ROOT_RUNTIME_FAILED`；先前的 `requestAnimationFrame` 聚焦实验未解决该问题，未进入稳定分支。Safari 与已测试的 Edge 路径正常属于已有真机/浏览器记录，不代表所有版本的普遍保证。本次 Alpha 6 发布不修复也不声称修复 iOS Firefox beta；失败热修复分支 `fix/ios-firefox-modal-focus-alpha2` 不复制、不合并、不修改。
 
-## Phase 17 反应域品牌与仓库身份迁移（Phase 17C 进行中）
+## Phase 17 反应域品牌与仓库身份迁移（Post-rename 代码链接切换进行中）
 
 Phase 17 正式启动 Reaction Field 品牌统一与仓库身份迁移，方案由 `docs/PHASE17_BRAND_IDENTITY_FREEZE.md` 冻结。
 
 实施子阶段与路线图状态：
 - **Phase 17A（品牌与仓库身份审计）**：已完成。核实中英文正式品牌、UI 装饰大写、包名、仓库 slug、Pages URL、公开元数据及全量代码/文档引用点。
-- **Phase 17B（方案冻结与合并后修复）**：已完成。产出 `docs/PHASE17_BRAND_IDENTITY_FREEZE.md`，确立 9 阶段确定性发布状态机与双重授权门禁。
-- **Phase 17C（Pre-rename 内部身份与安全文档准备）**：当前进行中 / 本分支实施。修改 `package.json` 中的 `"name": "reaction-field"`，同步中英文 README 定位与 Alpha 6 发布事实，更新路线图与审计快照；严禁提前修改 live 仓库与 live Pages 链接。
-- **Phase 17D（GitHub 仓库改名与设置）**：尚未执行，仍需独立外部授权。
-- **Post-rename（代码库链接正式切换 Cutover）**：尚未执行。
-- **Release Preparation / Tag / Pages 部署 / Phase 17E 公网验收 / GitHub Release**：尚未执行。
+- **Phase 17B（方案冻结与合并后修复）**：已完成。产出 `docs/PHASE17_BRAND_IDENTITY_FREEZE.md` 及合并后修复文档，确立 9 阶段确定性发布状态机与双重授权门禁。
+- **Phase 17C（Pre-rename 内部身份与安全文档准备）**：已完成。同步 `package.json` 中的 `"name": "reaction-field"`，同步中英文 README 定位与 Alpha 6 发布事实，更新路线图与审计快照。
+- **Phase 17D（GitHub 仓库改名与设置）**：已完成。GitHub 仓库成功重命名为 `9947447-alt/reaction-field`，仓库数字身份（numeric ID）保持不变，Description、Topics 与 local remote 已更新。
+- **Post-rename（代码库链接与 Live Pages 切换 Cutover）**：当前进行中 / 本分支实施。正式将应用内静态仓库链接 `src/app/projectRepository.tsx`、测试断言及 README 切换至 `9947447-alt/reaction-field`；记录并同步真实 live Pages URL 到 `https://9947447-alt.github.io/reaction-field/`。
+- **Release Preparation / Tag / Pages 部署 / Phase 17E 公网验收 / GitHub Release**：尚未执行。后续仍需在独立发布授权下完成版本准备、创建新不可变标签与部署，使线上产物正式包含 post-rename 代码链接变更。
 
-身份与 URL 映射（严格区分目标规划与当前真实公开事实）：
-- **当前真实 Live 仓库**：`https://github.com/9947447-alt/Chemistry-online-Card-Game`
-- **当前真实 Live Pages 试玩**：`https://9947447-alt.github.io/Chemistry-online-Card-Game/`
-- **目标仓库 Slug**：`reaction-field`（备用：`reaction-field-card-game`）
-- **目标仓库 URL**：`https://github.com/9947447-alt/reaction-field`（规划 target，非当前 live）
-- **目标 Pages URL**：`https://9947447-alt.github.io/reaction-field/`（规划 target，非当前 live）
-- **包名目标 / Phase 17C 内部身份**：`reaction-field`（`package.json`）
+身份与 URL 映射及平台真实行为：
+- **当前活跃仓库（Active Repository）**：`https://github.com/9947447-alt/reaction-field`（仓库 numeric ID 不变）
+- **当前活跃包名（Package Name）**：`reaction-field`（`package.json`）
+- **当前真实 Live Pages 试玩**：`https://9947447-alt.github.io/reaction-field/`
+- **平台 Pages 行为实测记录**：
+  - 仓库重命名后，原旧 Pages URL（`https://9947447-alt.github.io/Chemistry-online-Card-Game/`）返回 HTTP 404；
+  - 新 Pages URL（`https://9947447-alt.github.io/reaction-field/`）返回 HTTP 200 并正常提供 Alpha 6 静态站点；
+  - 因此当前 live Pages identity 已实际迁移至 `reaction-field` 路径；
+  - 注意：当前 200 响应属于平台在 rename 后的自动路径迁移行为，并非新的不可变 release tag 部署；后续仍需完成 Release Preparation 与新版本/标签部署以正式收口线上产物。
 
 ## MVP 0 定案范围
 

--- a/e2e/production/reaction-field.spec.ts
+++ b/e2e/production/reaction-field.spec.ts
@@ -169,7 +169,7 @@ for (const [path, assetPrefix, brandPrefix] of [["/", "/assets/", "/"], ["/playt
     const repository = about.getByRole("link", { name: "在新标签页打开反应域 GitHub 仓库" });
     await expect(repository).toHaveAttribute(
       "href",
-      "https://github.com/9947447-alt/Chemistry-online-Card-Game",
+      "https://github.com/9947447-alt/reaction-field",
     );
     await expect(repository).toHaveAttribute("target", "_blank");
     await expect(repository).toHaveAttribute("rel", "noopener noreferrer");

--- a/e2e/tests/debug-alpha.spec.ts
+++ b/e2e/tests/debug-alpha.spec.ts
@@ -602,7 +602,7 @@ test("gameOver 后重开和返回角色选择均无需确认，帮助仍可访�
   const gameOverRepository = page.getByRole("link", { name: "在新标签页打开反应域 GitHub 仓库" });
   await expect(gameOverRepository).toHaveAttribute(
     "href",
-    "https://github.com/9947447-alt/Chemistry-online-Card-Game",
+    "https://github.com/9947447-alt/reaction-field",
   );
   await expect(gameOverRepository).toHaveAttribute("target", "_blank");
   await expect(gameOverRepository).toHaveAttribute("rel", "noopener noreferrer");
@@ -612,7 +612,7 @@ test("gameOver 后重开和返回角色选择均无需确认，帮助仍可访�
   const aboutRepository = about.getByRole("link", { name: "在新标签页打开反应域 GitHub 仓库" });
   await expect(aboutRepository).toHaveAttribute(
     "href",
-    "https://github.com/9947447-alt/Chemistry-online-Card-Game",
+    "https://github.com/9947447-alt/reaction-field",
   );
   await expect(aboutRepository).toHaveAttribute("target", "_blank");
   await expect(aboutRepository).toHaveAttribute("rel", "noopener noreferrer");

--- a/src/app/projectRepository.test.tsx
+++ b/src/app/projectRepository.test.tsx
@@ -17,7 +17,7 @@ describe("Phase 15 project repository link", () => {
       const link = container.querySelector("a");
 
       expect(projectRepositoryUrl).toBe(
-        "https://github.com/9947447-alt/Chemistry-online-Card-Game",
+        "https://github.com/9947447-alt/reaction-field",
       );
       expect(link?.getAttribute("href")).toBe(projectRepositoryUrl);
       expect(link?.getAttribute("target")).toBe("_blank");

--- a/src/app/projectRepository.tsx
+++ b/src/app/projectRepository.tsx
@@ -1,7 +1,7 @@
 import { useLocale } from "./locale";
 
 export const projectRepositoryUrl =
-  "https://github.com/9947447-alt/Chemistry-online-Card-Game";
+  "https://github.com/9947447-alt/reaction-field";
 
 export function ProjectRepositoryLink() {
   const { locale } = useLocale();


### PR DESCRIPTION
### Summary

- **Repository rename completed**: GitHub repository rename to `9947447-alt/reaction-field` is complete.
- **Repository links cutover**: In-app static repository URL (`src/app/projectRepository.tsx`), unit/E2E test assertions, and documentation links have been switched from `Chemistry-online-Card-Game` to `https://github.com/9947447-alt/reaction-field`.
- **Live Pages platform behavior synchronized**: Empirically verified that GitHub Pages automatically migrated to the new slug upon repository rename (`https://9947447-alt.github.io/Chemistry-online-Card-Game/` returns HTTP 404, `https://9947447-alt.github.io/reaction-field/` returns HTTP 200). Updated public playtest links in README and MVP_PLAN to reflect the live Pages URL.
- **Strict Invariants Preserved**:
  - No version bump (`package.json.version` remains `0.16.0-alpha.1`)
  - No new release tags
  - No Pages deployment triggered
  - No game rules or engine logic changes
  - Historical freeze docs preserved unchanged