### PR TITLE
chore(release): prepare v0.16.0-alpha.2

### DIFF
--- a/e2e/production/reaction-field.spec.ts
+++ b/e2e/production/reaction-field.spec.ts
@@ -111,7 +111,7 @@ for (const [path, assetPrefix, brandPrefix] of [["/", "/assets/", "/"], ["/playt
     expect(script?.contentType).toMatch(/^text\/javascript/u);
     expect(stylesheet?.path.startsWith(assetPrefix)).toBe(true);
     expect(stylesheet?.contentType).toMatch(/^text\/css/u);
-    await expect(page).toHaveTitle(/反应域 · REACTION FIELD · Web Playtest Alpha · 0\.16\.0-alpha\.1/u);
+    await expect(page).toHaveTitle(/反应域 · REACTION FIELD · Web Playtest Alpha · 0\.16\.0-alpha\.2/u);
     const iconLinks = await page.locator('link[rel~="icon"]').evaluateAll((links) => links.map((link) => ({
       href: link.getAttribute("href"),
       sizes: link.getAttribute("sizes"),
@@ -163,7 +163,7 @@ for (const [path, assetPrefix, brandPrefix] of [["/", "/assets/", "/"], ["/playt
     await page.getByRole("button", { name: "关于与帮助" }).click();
     const about = page.getByRole("dialog", { name: "关于与帮助" });
     await expect(about).toContainText("REACTION FIELD");
-    await expect(about).toContainText("0.16.0-alpha.1");
+    await expect(about).toContainText("0.16.0-alpha.2");
     await expect(about).toContainText("MVP0-P10");
     await expect(about).toContainText(expectedBuildCommit);
     const repository = about.getByRole("link", { name: "在新标签页打开反应域 GitHub 仓库" });

--- a/e2e/tests/debug-alpha.spec.ts
+++ b/e2e/tests/debug-alpha.spec.ts
@@ -288,7 +288,7 @@ test("默认配置、正式元数据与 configuring 帮助界面", async ({ page
   })).toBeVisible();
   await expect(page.getByLabel("player_1 角色")).toHaveValue("laboratory_teacher");
   await expect(page.getByLabel("player_2 角色")).toHaveValue("chemical_factory_ceo");
-  await expect(page.getByText("Web Playtest Alpha · v0.16.0-alpha.1 · MVP0-P10", {
+  await expect(page.getByText("Web Playtest Alpha · v0.16.0-alpha.2 · MVP0-P10", {
     exact: false,
   })).toBeVisible();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-field",
-  "version": "0.16.0-alpha.1",
+  "version": "0.16.0-alpha.2",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/scripts/check-production.test.mjs
+++ b/scripts/check-production.test.mjs
@@ -7,7 +7,7 @@ import {
   forbiddenProductionMarkers,
 } from "./check-production.mjs";
 
-const expectedTitle = "反应域 · REACTION FIELD · Web Playtest Alpha · 0.16.0-alpha.1 · MVP0-P10";
+const expectedTitle = "反应域 · REACTION FIELD · Web Playtest Alpha · 0.16.0-alpha.2 · MVP0-P10";
 const cleanIndex = `<!doctype html><html><head><title>${expectedTitle}</title><script src="./assets/app.js"></script><link href="./assets/app.css" rel="stylesheet"></head><body></body></html>`;
 const temporaryRoots = [];
 

--- a/scripts/check-web-playtest-tag.test.mjs
+++ b/scripts/check-web-playtest-tag.test.mjs
@@ -3,28 +3,28 @@ import { describe, expect, it } from "vitest";
 import { checkWebPlaytestTag, verifyWebPlaytestTag } from "./check-web-playtest-tag.mjs";
 
 const script = new URL("./check-web-playtest-tag.mjs", import.meta.url);
-const version = "0.16.0-alpha.1";
+const version = "0.16.0-alpha.2";
 
 function run(environment = {}, argumentsList = []) {
   return spawnSync(process.execPath, [script.pathname, ...argumentsList], {
     encoding: "utf8",
-    env: { ...process.env, GITHUB_REF: "refs/tags/web-playtest-v0.16.0-alpha.1", ...environment },
+    env: { ...process.env, GITHUB_REF: "refs/tags/web-playtest-v0.16.0-alpha.2", ...environment },
   });
 }
 
 describe("check-web-playtest-tag", () => {
   it("accepts only the exact bare tag supplied through GITHUB_REF_NAME", async () => {
-    await expect(checkWebPlaytestTag({ GITHUB_REF_NAME: "web-playtest-v0.16.0-alpha.1" })).resolves.toBe("web-playtest-v0.16.0-alpha.1");
-    expect(run({ GITHUB_REF_NAME: "web-playtest-v0.16.0-alpha.1" }).status).toBe(0);
+    await expect(checkWebPlaytestTag({ GITHUB_REF_NAME: "web-playtest-v0.16.0-alpha.2" })).resolves.toBe("web-playtest-v0.16.0-alpha.2");
+    expect(run({ GITHUB_REF_NAME: "web-playtest-v0.16.0-alpha.2" }).status).toBe(0);
   });
 
   it.each([
-    "web-playtest-v0.15.0-alpha.1",
-    "web-playtest-v0.16.0-alpha.2",
+    "web-playtest-v0.16.0-alpha.1",
+    "web-playtest-v0.16.0-alpha.3",
     "web-playtest-v0.17.0-alpha.1",
-    "web-playtest-v0.16.0-alpha.1-extra",
-    "v0.16.0-alpha.1",
-    "refs/tags/web-playtest-v0.16.0-alpha.1",
+    "web-playtest-v0.16.0-alpha.2-extra",
+    "v0.16.0-alpha.2",
+    "refs/tags/web-playtest-v0.16.0-alpha.2",
     "",
     undefined,
   ])("rejects invalid environment tag %s", async (tag) => {
@@ -34,7 +34,7 @@ describe("check-web-playtest-tag", () => {
   });
 
   it("does not accept a CLI tag or GITHUB_REF fallback", () => {
-    expect(run({ GITHUB_REF_NAME: undefined }, ["web-playtest-v0.16.0-alpha.1"]).status).toBe(1);
-    expect(() => verifyWebPlaytestTag("refs/tags/web-playtest-v0.16.0-alpha.1", version)).toThrow();
+    expect(run({ GITHUB_REF_NAME: undefined }, ["web-playtest-v0.16.0-alpha.2"]).status).toBe(1);
+    expect(() => verifyWebPlaytestTag("refs/tags/web-playtest-v0.16.0-alpha.2", version)).toThrow();
   });
 });

--- a/src/app/releaseMetadata.test.tsx
+++ b/src/app/releaseMetadata.test.tsx
@@ -12,6 +12,6 @@ describe("Alpha 6 release-candidate metadata", () => {
       rulesVersion: "MVP0-P10",
       commit: expect.stringMatching(/^(?:[0-9a-f]{12}|dev\/unknown)$/u),
     });
-    expect(packageMetadata.version).toBe("0.16.0-alpha.1");
+    expect(packageMetadata.version).toBe("0.16.0-alpha.2");
   });
 });


### PR DESCRIPTION
## Summary

This PR prepares the next application and deployable build identity for **Reaction Field / 反应域** (`v0.16.0-alpha.2`).

### Release Preparation Status & Invariants
- **Repository Migration & Link Cutover Status**: Post-rename repository link cutover (PR #14) is already merged into `release/phase15-alpha5-web-playtest-alpha1`.
- **Highest Consumed Version**: `0.16.0-alpha.1` (immutable release tag `web-playtest-v0.16.0-alpha.1` published with Alpha 6).
- **Target Prepared Version**: `0.16.0-alpha.2` (SemVer `0.16.0-alpha.2` > `0.16.0-alpha.1`, avoiding immutable tag reuse).
- **Future Expected Immutable Tag**: `web-playtest-v0.16.0-alpha.2`.
- **Tag / Deployment Boundaries**:
  - No tag has been created.
  - No tag has been pushed.
  - No Pages deployment has occurred.
  - No GitHub Release has been created.
- **Rule Integrity**: Zero changes to chemistry rules, damage pipeline, turn engine, reaction definitions, or 68-card pool (`MVP0-P10`).
- **Public Milestone**: Public milestone remains Reaction Field Alpha 6 (does not claim `0.16.0-alpha.2` is already published).

### Scope of Changes
Synchronized version identity from `0.16.0-alpha.1` to `0.16.0-alpha.2` across the strict whitelist:
1. `package.json` — bumped `"version": "0.16.0-alpha.2"`.
2. `e2e/production/reaction-field.spec.ts` — synchronized About dialog and `<title>` version assertions.
3. `e2e/tests/debug-alpha.spec.ts` — synchronized status bar version text assertion.
4. `scripts/check-production.test.mjs` — synchronized expected title assertion.
5. `scripts/check-web-playtest-tag.test.mjs` — synchronized tag check tests to `web-playtest-v0.16.0-alpha.2`.
6. `src/app/releaseMetadata.test.tsx` — synchronized package metadata test assertion.