### PR TITLE
docs: close Phase 17 release migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ The external Core Rulebook is an extended tabletop reference, not the authoritat
 
 - Play: [https://9947447-alt.github.io/reaction-field/](https://9947447-alt.github.io/reaction-field/)
 - Current public milestone: **Reaction Field Alpha 6**
-- Current published technical version: `0.16.0-alpha.1`
-- Current public tag: `web-playtest-v0.16.0-alpha.1`
+- Current published technical version: `0.16.0-alpha.2`
+- Current public tag: `web-playtest-v0.16.0-alpha.2`
 - Rules version: `MVP0-P10`
-- GitHub Release: [Reaction Field Alpha 6](https://github.com/9947447-alt/reaction-field/releases/tag/web-playtest-v0.16.0-alpha.1)
+- GitHub Release: [Reaction Field Alpha 6 — v0.16.0-alpha.2](https://github.com/9947447-alt/reaction-field/releases/tag/web-playtest-v0.16.0-alpha.2)
 - Repository: [https://github.com/9947447-alt/reaction-field](https://github.com/9947447-alt/reaction-field)
 
-The current public release is Reaction Field Alpha 6 (`0.16.0-alpha.1`) with rules version `MVP0-P10` and public tag `web-playtest-v0.16.0-alpha.1`. The live playtest URL is served from `https://9947447-alt.github.io/reaction-field/` following the repository rename.
+The current public release is Reaction Field Alpha 6 (`0.16.0-alpha.2`) with rules version `MVP0-P10` and public tag `web-playtest-v0.16.0-alpha.2`. The live playtest URL is served from `https://9947447-alt.github.io/reaction-field/` following the repository rename and Phase 17 release deployment.
 
 ## What Is Reaction Field?
 
@@ -50,7 +50,7 @@ This is an alpha playtest, not a stable release.
 
 ## Alpha Status
 
-The current public release is Reaction Field Alpha 6, technical version `0.16.0-alpha.1`, rules version `MVP0-P10`, and tag `web-playtest-v0.16.0-alpha.1`. Its public Pages build is served from the live URL; this is not evidence of broad cross-browser compatibility.
+The current public release is Reaction Field Alpha 6, technical version `0.16.0-alpha.2`, rules version `MVP0-P10`, and tag `web-playtest-v0.16.0-alpha.2`. Its public Pages build is served from the live URL; this is not evidence of broad cross-browser compatibility.
 
 The earlier `web-playtest-v0.13.0-alpha.2` tag remains unchanged at `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`. Its Pages workflow failed because a production E2E assertion was pinned to an older commit, so alpha.2 was not deployed successfully. Historical tags remain immutable.
 
@@ -66,9 +66,9 @@ The international presentation layer provides Simplified Chinese and English mod
 - Production Reaction and DIY UI paths have formal E2E coverage.
 - The production JavaScript bundle was reduced to pass the frozen Node 24 size gate with reliable headroom.
 
-## Alpha 6 / Phase 16 Release Status
+## Alpha 6 / Phase 16 & Phase 17 Release Status
 
-Phase 16 full bilingual game log is implemented and published as Reaction Field Alpha 6 (`0.16.0-alpha.1`) under tag `web-playtest-v0.16.0-alpha.1`. Alpha 6 provides bilingual structured logs, localized damage and status rendering, and production test coverage. Alpha 6 is an alpha playtest; it does not include online multiplayer, accounts, persistence, complete mobile compatibility, or an iOS Firefox fix.
+Phase 16 full bilingual game log and Phase 17 repository identity migration are implemented and published as Reaction Field Alpha 6 (`0.16.0-alpha.2`) under tag `web-playtest-v0.16.0-alpha.2`. Alpha 6 provides bilingual structured logs, localized damage and status rendering, migrated repository and Pages identity under `9947447-alt/reaction-field`, and production test coverage. Alpha 6 is an alpha playtest; it does not include online multiplayer, accounts, persistence, complete mobile compatibility, or an iOS Firefox fix.
 
 ## Feedback
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 # 反应域
 
-**反应域（REACTION FIELD）** 是一款基于化学主题的开源本地同屏双人策略卡牌游戏，当前以公开 Web Playtest Alpha 分发。当前公开版本为 Reaction Field Alpha 6 / `0.16.0-alpha.1`，发布标签为 `web-playtest-v0.16.0-alpha.1`，规则版本严格保持 `MVP0-P10`，不增加任何游戏规则。这是一个基于 React、TypeScript、Vite、Vitest 与 Playwright 的本地同屏双人公开试玩版本，不是正式发行版。
+**反应域（REACTION FIELD）** 是一款基于化学主题的开源本地同屏双人策略卡牌游戏，当前以公开 Web Playtest Alpha 分发。当前公开版本为 Reaction Field Alpha 6 / `0.16.0-alpha.2`，发布标签为 `web-playtest-v0.16.0-alpha.2`，规则版本严格保持 `MVP0-P10`，不增加任何游戏规则。这是一个基于 React、TypeScript、Vite、Vitest 与 Playwright 的本地同屏双人公开试玩版本，不是正式发行版。
 
 ## 核心规则书 — 扩展桌面规则参考
 
@@ -32,13 +32,13 @@ Web Playtest Alpha 公开双方手牌、牌堆数量、状态与完整日志。�
 
 - 公开试玩入口：[https://9947447-alt.github.io/reaction-field/](https://9947447-alt.github.io/reaction-field/)
 - 当前公开发布阶段：**Reaction Field Alpha 6**
-- 当前发布技术版本：`0.16.0-alpha.1`
-- 当前公开发布标签：`web-playtest-v0.16.0-alpha.1`
+- 当前发布技术版本：`0.16.0-alpha.2`
+- 当前公开发布标签：`web-playtest-v0.16.0-alpha.2`
 - 规则版本：`MVP0-P10`
-- GitHub Release：[Reaction Field Alpha 6](https://github.com/9947447-alt/reaction-field/releases/tag/web-playtest-v0.16.0-alpha.1)
+- GitHub Release：[Reaction Field Alpha 6 — v0.16.0-alpha.2](https://github.com/9947447-alt/reaction-field/releases/tag/web-playtest-v0.16.0-alpha.2)
 - 官方仓库：[https://github.com/9947447-alt/reaction-field](https://github.com/9947447-alt/reaction-field)
 
-当前公开发布事实为：对外阶段 Reaction Field Alpha 6，技术版本 `0.16.0-alpha.1`，规则版本 `MVP0-P10`，标签 `web-playtest-v0.16.0-alpha.1`。随着 GitHub 仓库重命名完成，公开试玩入口已迁移至当前 live 地址 `https://9947447-alt.github.io/reaction-field/`。历史标签 `web-playtest-v0.13.0-alpha.2` 保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；所有历史标签保持不可变。
+当前公开发布事实为：对外阶段 Reaction Field Alpha 6，技术版本 `0.16.0-alpha.2`，规则版本 `MVP0-P10`，标签 `web-playtest-v0.16.0-alpha.2`。随着 GitHub 仓库重命名与 Phase 17 发布部署完成，公开试玩入口已迁移并由新标签部署至当前 live 地址 `https://9947447-alt.github.io/reaction-field/`。历史标签 `web-playtest-v0.13.0-alpha.2` 保持不变，指向 `57550f70856d5d5e27ac3fcb0fa508cd698d3be6`；所有历史标签保持不可变。
 
 ## 国际化试玩与双语游戏日志状态
 
@@ -52,9 +52,9 @@ Web Playtest Alpha 公开双方手牌、牌堆数量、状态与完整日志。�
 - 正式 Reaction 与 DIY UI 路径已具备正式 E2E 覆盖。
 - 生产 JavaScript bundle 已压缩优化，确保在 Node 24 下具有充裕余量通过冻结的体积门限。
 
-## Alpha 6 / Phase 16 发布状态
+## Alpha 6 / Phase 16 & Phase 17 发布状态
 
-Phase 16 完整双语游戏日志已实现并作为 Reaction Field Alpha 6（`0.16.0-alpha.1`，标签 `web-playtest-v0.16.0-alpha.1`）正式发布。Alpha 6 支持强类型结构化双语游戏日志、伤害与状态本地化展示及生产端测试覆盖。Alpha 6 是公开试玩版本，不代表完整教程、在线多人、账号、存档、完整移动端兼容或 iOS Firefox 修复。
+Phase 16 完整双语游戏日志与 Phase 17 仓库身份迁移已实现并作为 Reaction Field Alpha 6（`0.16.0-alpha.2`，标签 `web-playtest-v0.16.0-alpha.2`）正式发布。Alpha 6 支持强类型结构化双语游戏日志、伤害与状态本地化展示、统一的 `9947447-alt/reaction-field` 仓库与 Pages 身份及生产端测试覆盖。Alpha 6 是公开试玩版本，不代表完整教程、在线多人、账号、存档、完整移动端兼容或 iOS Firefox 修复。
 
 ## Feedback / 反馈
 
@@ -132,7 +132,7 @@ fatal 页面可复制的本地安全诊断只包含：
 
 ```text
 名称：反应域
-应用版本：0.16.0-alpha.1
+应用版本：0.16.0-alpha.2
 规则版本：MVP0-P10
 Commit：<短 SHA 或 dev/unknown>
 错误码：<稳定错误码>

--- a/docs/MVP_PLAN.md
+++ b/docs/MVP_PLAN.md
@@ -34,7 +34,7 @@ Phase 13 的权威实现边界见 `docs/PHASE13_NEW_PLAYER_GUIDANCE_FREEZE.md`�
 
 - 配置阶段位于角色选择操作之前；playing 阶段位于 preparation、main action、response、status、counterattack 与 game over 操作区之前。窄屏保持正常文档流，不使用浮层、遮罩、sticky coach mark 或 modal。
 - 阶段文案覆盖配置、备课、主行动、响应、状态处理、实验反击与对局结束；不复制合法性、卡牌匹配、伤害、反应或出牌建议，不 dispatch `GameAction`，不增加任何规则表。
-- 保持 `MVP0-P10`、68 张普通实体卡池、角色和冻结规则不变；Phase 13 引导实现已在 alpha.1 基线完成，`web-playtest-v0.13.0-alpha.1` 标签永久保持不变。当前应用版本为 `0.16.0-alpha.1`，由 `package.json` 作为唯一真值来源，`releaseMetadata` 继续读取构建注入的版本。当前公开版本是 Reaction Field Alpha 6 / `0.16.0-alpha.1`，公开标签为 `web-playtest-v0.16.0-alpha.1`；公开试玩地址为 [https://9947447-alt.github.io/reaction-field/](https://9947447-alt.github.io/reaction-field/)。
+- 保持 `MVP0-P10`、68 张普通实体卡池、角色和冻结规则不变；Phase 13 引导实现已在 alpha.1 基线完成，`web-playtest-v0.13.0-alpha.1` 标签永久保持不变。当前应用版本为 `0.16.0-alpha.2`，由 `package.json` 作为唯一真值来源，`releaseMetadata` 继续读取构建注入的版本。当前公开版本是 Reaction Field Alpha 6 / `0.16.0-alpha.2`，公开标签为 `web-playtest-v0.16.0-alpha.2`；公开试玩地址为 [https://9947447-alt.github.io/reaction-field/](https://9947447-alt.github.io/reaction-field/)。
 
 ## 0.13.0-alpha.3 已公开发布（Reaction Field Alpha 2）
 
@@ -54,27 +54,32 @@ Phase 16 已公开发布为 Reaction Field Alpha 6，技术版本 `0.16.0-alpha.
 
 已知兼容性边界：iOS 27 beta 的 Firefox 在打开帮助或重开确认框时可能进入 `ROOT_RUNTIME_FAILED`；先前的 `requestAnimationFrame` 聚焦实验未解决该问题，未进入稳定分支。Safari 与已测试的 Edge 路径正常属于已有真机/浏览器记录，不代表所有版本的普遍保证。本次 Alpha 6 发布不修复也不声称修复 iOS Firefox beta；失败热修复分支 `fix/ios-firefox-modal-focus-alpha2` 不复制、不合并、不修改。
 
-## Phase 17 反应域品牌与仓库身份迁移（Post-rename 代码链接切换进行中）
+## Phase 17 反应域品牌与仓库身份迁移（已完成并公开发布）
 
-Phase 17 正式启动 Reaction Field 品牌统一与仓库身份迁移，方案由 `docs/PHASE17_BRAND_IDENTITY_FREEZE.md` 冻结。
+Phase 17 正式启动并完成 Reaction Field 品牌统一与仓库身份迁移，方案由 `docs/PHASE17_BRAND_IDENTITY_FREEZE.md` 冻结，已作为 Reaction Field Alpha 6（`0.16.0-alpha.2`，标签 `web-playtest-v0.16.0-alpha.2`）正式公开发布。
 
 实施子阶段与路线图状态：
 - **Phase 17A（品牌与仓库身份审计）**：已完成。核实中英文正式品牌、UI 装饰大写、包名、仓库 slug、Pages URL、公开元数据及全量代码/文档引用点。
 - **Phase 17B（方案冻结与合并后修复）**：已完成。产出 `docs/PHASE17_BRAND_IDENTITY_FREEZE.md` 及合并后修复文档，确立 9 阶段确定性发布状态机与双重授权门禁。
 - **Phase 17C（Pre-rename 内部身份与安全文档准备）**：已完成。同步 `package.json` 中的 `"name": "reaction-field"`，同步中英文 README 定位与 Alpha 6 发布事实，更新路线图与审计快照。
 - **Phase 17D（GitHub 仓库改名与设置）**：已完成。GitHub 仓库成功重命名为 `9947447-alt/reaction-field`，仓库数字身份（numeric ID）保持不变，Description、Topics 与 local remote 已更新。
-- **Post-rename（代码库链接与 Live Pages 切换 Cutover）**：当前进行中 / 本分支实施。正式将应用内静态仓库链接 `src/app/projectRepository.tsx`、测试断言及 README 切换至 `9947447-alt/reaction-field`；记录并同步真实 live Pages URL 到 `https://9947447-alt.github.io/reaction-field/`。
-- **Release Preparation / Tag / Pages 部署 / Phase 17E 公网验收 / GitHub Release**：尚未执行。后续仍需在独立发布授权下完成版本准备、创建新不可变标签与部署，使线上产物正式包含 post-rename 代码链接变更。
+- **Post-rename Cutover（代码库链接切换）**：已完成。正式将应用内静态仓库链接 `src/app/projectRepository.tsx`、测试断言及 README 切换至 `9947447-alt/reaction-field` 并合入集成主干。
+- **Release Preparation（发布版本准备）**：已完成。版本更新至 `0.16.0-alpha.2`，全量本地与 CI 测试通过并合入集成主干。
+- **Immutable Tag & Pages 部署**：已完成。创建并推送不可变标签 `web-playtest-v0.16.0-alpha.2`（peeled SHA `cd228fc833fbed65ef3f61ef43c0e459824d5bf8`），触发 `Phase 12 Web Playtest Pages` 工作流并构建/部署成功。
+- **Phase 17E 公网验收**：已完成。7 项公网真机/浏览器验收（新 Pages 200、旧 Pages 404、静态资源正常、标题准确、仓库与反馈链接安全、双语对局完整可用）全部通过。
+- **GitHub Release**：已完成。发布正式预发布版本 `Reaction Field Alpha 6 — v0.16.0-alpha.2`。
+- **Phase 17 收口**：全面完成。
 
 身份与 URL 映射及平台真实行为：
 - **当前活跃仓库（Active Repository）**：`https://github.com/9947447-alt/reaction-field`（仓库 numeric ID 不变）
 - **当前活跃包名（Package Name）**：`reaction-field`（`package.json`）
 - **当前真实 Live Pages 试玩**：`https://9947447-alt.github.io/reaction-field/`
+- **当前公开发布版本**：`0.16.0-alpha.2`（Tag: `web-playtest-v0.16.0-alpha.2`）
 - **平台 Pages 行为实测记录**：
-  - 仓库重命名后，原旧 Pages URL（`https://9947447-alt.github.io/Chemistry-online-Card-Game/`）返回 HTTP 404；
-  - 新 Pages URL（`https://9947447-alt.github.io/reaction-field/`）返回 HTTP 200 并正常提供 Alpha 6 静态站点；
-  - 因此当前 live Pages identity 已实际迁移至 `reaction-field` 路径；
-  - 注意：当前 200 响应属于平台在 rename 后的自动路径迁移行为，并非新的不可变 release tag 部署；后续仍需完成 Release Preparation 与新版本/标签部署以正式收口线上产物。
+  - 原旧 Pages URL（`https://9947447-alt.github.io/Chemistry-online-Card-Game/`）返回 HTTP 404；
+  - 新 Pages URL（`https://9947447-alt.github.io/reaction-field/`）返回 HTTP 200 并由 `web-playtest-v0.16.0-alpha.2` 构建正常提供 Alpha 6 静态站点；
+  - 线上代码链接、关于弹窗及对局结束链接均已指向 `9947447-alt/reaction-field`；
+  - 品牌与发布迁移全链路收口闭环。
 
 ## MVP 0 定案范围
 


### PR DESCRIPTION
## Summary

This pull request completes Phase 17 documentation closeout following the successful deployment and public acceptance of Reaction Field Alpha 6 (`0.16.0-alpha.2`) under immutable tag `web-playtest-v0.16.0-alpha.2`.

## Changes
- Synchronize current public release facts in `README.md` and `README.zh-CN.md` to technical version `0.16.0-alpha.2`, public tag `web-playtest-v0.16.0-alpha.2`, and GitHub Release `Reaction Field Alpha 6 — v0.16.0-alpha.2`.
- Update `docs/MVP_PLAN.md` to record Phase 17 completion (Phase 17A through 17E, GitHub Release publication, and full loop closeout).
- Preserve historical references and frozen MVP0-P10 game rules.

## Quality Gates Passed
- `pnpm run build`
- `pnpm run test:run` (591/591 tests passed)
- `pnpm run test:shuffle` (seed 20260723 passed)
- `pnpm run check:production`
- `pnpm run check:size`
- `git diff --check`
- `pnpm run check:tracked-clean`