### PR TITLE
feat: add Phase 18C junior chemistry data foundation

### DIFF
--- a/src/chemistry/chemistryData.test.ts
+++ b/src/chemistry/chemistryData.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from "vitest";
+import {
+  chemicalSpeciesList,
+  chemicalSpeciesMap,
+  elementKnowledgeList,
+  elementKnowledgeMap,
+  getChemicalSpecies,
+  getElementKnowledge,
+  getRadicalKnowledge,
+  isIonSpecies,
+  isNeutralElementalComponentSpecies,
+  radicalKnowledgeList,
+  radicalKnowledgeMap,
+} from "./index";
+import { cardDefinitions } from "../game/data/cardDefinitions";
+import { starterDeck, starterDeckSize } from "../game/data/starterDeck";
+
+describe("Phase 18C: Junior Chemistry Data Foundation", () => {
+  describe("Element Knowledge Registry (Freeze Section 3.1)", () => {
+    it("contains exactly 21 elements", () => {
+      expect(elementKnowledgeList).toHaveLength(21);
+      expect(elementKnowledgeMap.size).toBe(21);
+    });
+
+    it("has unique element symbols", () => {
+      const symbols = elementKnowledgeList.map((e) => e.symbol);
+      const uniqueSymbols = new Set(symbols);
+      expect(uniqueSymbols.size).toBe(21);
+    });
+
+    it("matches authoritative element definitions and common valences", () => {
+      const expectedElements = [
+        { symbol: "H", nameEn: "Hydrogen", nameZh: "氢", commonValences: [1] },
+        { symbol: "Na", nameEn: "Sodium", nameZh: "钠", commonValences: [1] },
+        { symbol: "K", nameEn: "Potassium", nameZh: "钾", commonValences: [1] },
+        { symbol: "Cu", nameEn: "Copper", nameZh: "铜", commonValences: [1, 2] },
+        { symbol: "Ag", nameEn: "Silver", nameZh: "银", commonValences: [1] },
+        { symbol: "Mg", nameEn: "Magnesium", nameZh: "镁", commonValences: [2] },
+        { symbol: "Ca", nameEn: "Calcium", nameZh: "钙", commonValences: [2] },
+        { symbol: "Ba", nameEn: "Barium", nameZh: "钡", commonValences: [2] },
+        { symbol: "Zn", nameEn: "Zinc", nameZh: "锌", commonValences: [2] },
+        { symbol: "Al", nameEn: "Aluminium", nameZh: "铝", commonValences: [3] },
+        {
+          symbol: "Mn",
+          nameEn: "Manganese",
+          nameZh: "锰",
+          commonValences: [2, 4, 6, 7],
+        },
+        { symbol: "Fe", nameEn: "Iron", nameZh: "铁", commonValences: [2, 3] },
+        { symbol: "F", nameEn: "Fluorine", nameZh: "氟", commonValences: [-1] },
+        {
+          symbol: "Cl",
+          nameEn: "Chlorine",
+          nameZh: "氯",
+          commonValences: [-1, 1, 5, 7],
+        },
+        { symbol: "Br", nameEn: "Bromine", nameZh: "溴", commonValences: [-1] },
+        { symbol: "O", nameEn: "Oxygen", nameZh: "氧", commonValences: [-2] },
+        { symbol: "S", nameEn: "Sulfur", nameZh: "硫", commonValences: [-2, 4, 6] },
+        {
+          symbol: "N",
+          nameEn: "Nitrogen",
+          nameZh: "氮",
+          commonValences: [-3, 2, 3, 4, 5],
+        },
+        {
+          symbol: "P",
+          nameEn: "Phosphorus",
+          nameZh: "磷",
+          commonValences: [-3, 3, 5],
+        },
+        { symbol: "C", nameEn: "Carbon", nameZh: "碳", commonValences: [2, 4] },
+        { symbol: "Si", nameEn: "Silicon", nameZh: "硅", commonValences: [4] },
+      ];
+
+      expect(elementKnowledgeList).toEqual(expectedElements);
+
+      for (const item of expectedElements) {
+        const found = getElementKnowledge(item.symbol);
+        expect(found).toBeDefined();
+        expect(found).toEqual(item);
+      }
+    });
+
+    it("returns undefined for unknown element symbols", () => {
+      expect(getElementKnowledge("Xx")).toBeUndefined();
+      expect(getElementKnowledge("Gold")).toBeUndefined();
+      expect(getElementKnowledge("")).toBeUndefined();
+    });
+  });
+
+  describe("Radical Knowledge Registry (Freeze Section 3.2)", () => {
+    it("contains exactly 5 radicals", () => {
+      expect(radicalKnowledgeList).toHaveLength(5);
+      expect(radicalKnowledgeMap.size).toBe(5);
+    });
+
+    it("has unique radical formulas", () => {
+      const formulas = radicalKnowledgeList.map((r) => r.formula);
+      const uniqueFormulas = new Set(formulas);
+      expect(uniqueFormulas.size).toBe(5);
+    });
+
+    it("matches authoritative radical definitions and charges", () => {
+      const expectedRadicals = [
+        { formula: "OH", nameZh: "氢氧根", nameEn: "Hydroxide", charge: -1 },
+        { formula: "NO3", nameZh: "硝酸根", nameEn: "Nitrate", charge: -1 },
+        { formula: "CO3", nameZh: "碳酸根", nameEn: "Carbonate", charge: -2 },
+        { formula: "SO4", nameZh: "硫酸根", nameEn: "Sulfate", charge: -2 },
+        { formula: "NH4", nameZh: "铵根", nameEn: "Ammonium", charge: 1 },
+      ];
+
+      expect(radicalKnowledgeList).toEqual(expectedRadicals);
+
+      for (const item of expectedRadicals) {
+        const found = getRadicalKnowledge(item.formula);
+        expect(found).toBeDefined();
+        expect(found).toEqual(item);
+      }
+    });
+
+    it("returns undefined for unknown radical formulas", () => {
+      expect(getRadicalKnowledge("PO4")).toBeUndefined();
+      expect(getRadicalKnowledge("HCO3")).toBeUndefined();
+      expect(getRadicalKnowledge("")).toBeUndefined();
+    });
+  });
+
+  describe("Chemical Species Registry Seed (Freeze Section 3.3)", () => {
+    it("contains exactly 13 explicit species", () => {
+      expect(chemicalSpeciesList).toHaveLength(13);
+      expect(chemicalSpeciesMap.size).toBe(13);
+    });
+
+    it("has unique species IDs", () => {
+      const ids = chemicalSpeciesList.map((s) => s.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(13);
+    });
+
+    it("matches authoritative neutral elemental component species", () => {
+      const neutralComponents = chemicalSpeciesList.filter(
+        isNeutralElementalComponentSpecies,
+      );
+      expect(neutralComponents).toHaveLength(3);
+
+      expect(getChemicalSpecies("species_c")).toEqual({
+        id: "species_c",
+        kind: "neutral_elemental_component",
+        formula: "C",
+        charge: 0,
+        nameZh: "碳单质组件",
+        nameEn: "Carbon elemental component",
+      });
+
+      expect(getChemicalSpecies("species_o")).toEqual({
+        id: "species_o",
+        kind: "neutral_elemental_component",
+        formula: "O",
+        charge: 0,
+        nameZh: "氧单质组件",
+        nameEn: "Oxygen elemental component",
+      });
+
+      expect(getChemicalSpecies("species_s")).toEqual({
+        id: "species_s",
+        kind: "neutral_elemental_component",
+        formula: "S",
+        charge: 0,
+        nameZh: "硫单质组件",
+        nameEn: "Sulfur elemental component",
+      });
+    });
+
+    it("strictly differentiates species_o (O elemental component) from O2 gas substance", () => {
+      const speciesO = getChemicalSpecies("species_o");
+      expect(speciesO).toBeDefined();
+      expect(speciesO?.formula).toBe("O");
+      expect(speciesO?.charge).toBe(0);
+      expect(speciesO?.formula).not.toBe("O2");
+    });
+
+    it("matches authoritative explicit ion species", () => {
+      const ions = chemicalSpeciesList.filter(isIonSpecies);
+      expect(ions).toHaveLength(10);
+
+      const expectedIons = [
+        {
+          id: "species_ion_h",
+          kind: "ion",
+          formula: "H+",
+          charge: 1,
+          nameZh: "氢离子",
+          nameEn: "Hydrogen ion",
+        },
+        {
+          id: "species_ion_na",
+          kind: "ion",
+          formula: "Na+",
+          charge: 1,
+          nameZh: "钠离子",
+          nameEn: "Sodium ion",
+        },
+        {
+          id: "species_ion_k",
+          kind: "ion",
+          formula: "K+",
+          charge: 1,
+          nameZh: "钾离子",
+          nameEn: "Potassium ion",
+        },
+        {
+          id: "species_ion_ca",
+          kind: "ion",
+          formula: "Ca2+",
+          charge: 2,
+          nameZh: "钙离子",
+          nameEn: "Calcium ion",
+        },
+        {
+          id: "species_ion_cl",
+          kind: "ion",
+          formula: "Cl-",
+          charge: -1,
+          nameZh: "氯离子",
+          nameEn: "Chloride ion",
+        },
+        {
+          id: "species_ion_oh",
+          kind: "ion",
+          formula: "OH-",
+          charge: -1,
+          nameZh: "氢氧根离子",
+          nameEn: "Hydroxide ion",
+        },
+        {
+          id: "species_ion_co3",
+          kind: "ion",
+          formula: "CO3^2-",
+          charge: -2,
+          nameZh: "碳酸根离子",
+          nameEn: "Carbonate ion",
+        },
+        {
+          id: "species_ion_so4",
+          kind: "ion",
+          formula: "SO4^2-",
+          charge: -2,
+          nameZh: "硫酸根离子",
+          nameEn: "Sulfate ion",
+        },
+        {
+          id: "species_ion_no3",
+          kind: "ion",
+          formula: "NO3-",
+          charge: -1,
+          nameZh: "硝酸根离子",
+          nameEn: "Nitrate ion",
+        },
+        {
+          id: "species_ion_nh4",
+          kind: "ion",
+          formula: "NH4+",
+          charge: 1,
+          nameZh: "铵根离子",
+          nameEn: "Ammonium ion",
+        },
+      ];
+
+      for (const expected of expectedIons) {
+        const found = getChemicalSpecies(expected.id);
+        expect(found).toBeDefined();
+        expect(found).toEqual(expected);
+      }
+    });
+
+    it("returns undefined for unknown species IDs", () => {
+      expect(getChemicalSpecies("species_fe")).toBeUndefined();
+      expect(getChemicalSpecies("species_ion_fe2")).toBeUndefined();
+      expect(getChemicalSpecies("species_ion_fe3")).toBeUndefined();
+      expect(getChemicalSpecies("species_ion_cu2")).toBeUndefined();
+      expect(getChemicalSpecies("species_ion_mg2")).toBeUndefined();
+      expect(getChemicalSpecies("species_ion_al3")).toBeUndefined();
+      expect(getChemicalSpecies("species_ion_f")).toBeUndefined();
+      expect(getChemicalSpecies("species_ion_br")).toBeUndefined();
+    });
+  });
+
+  describe("Four-Dimensional Isolation Guardrails (Freeze Section 4 & 5)", () => {
+    it("ensures unapproved species are NOT synthesized from commonValences", () => {
+      // Element knowledge contains Fe (+2, +3), Cu (+1, +2), Al (+3), etc.
+      const feKnowledge = getElementKnowledge("Fe");
+      expect(feKnowledge?.commonValences).toEqual([2, 3]);
+
+      // But species registry must NOT contain unapproved ion species
+      const allSpeciesIds = new Set(chemicalSpeciesList.map((s) => s.id));
+      expect(allSpeciesIds.has("species_ion_fe2" as any)).toBe(false);
+      expect(allSpeciesIds.has("species_ion_fe3" as any)).toBe(false);
+      expect(allSpeciesIds.has("species_ion_cu" as any)).toBe(false);
+      expect(allSpeciesIds.has("species_ion_cu2" as any)).toBe(false);
+      expect(allSpeciesIds.has("species_ion_mg" as any)).toBe(false);
+      expect(allSpeciesIds.has("species_ion_mg2" as any)).toBe(false);
+      expect(allSpeciesIds.has("species_ion_al3" as any)).toBe(false);
+      expect(allSpeciesIds.has("species_ion_ag" as any)).toBe(false);
+      expect(allSpeciesIds.has("species_ion_ba2" as any)).toBe(false);
+      expect(allSpeciesIds.has("species_ion_f" as any)).toBe(false);
+      expect(allSpeciesIds.has("species_ion_br" as any)).toBe(false);
+    });
+
+    it("ensures NO3- and NH4+ exist in Chemistry registry without creating physical cards", () => {
+      // NO3- and NH4+ are in Layer 1 Chemistry Species
+      expect(getChemicalSpecies("species_ion_no3")).toBeDefined();
+      expect(getChemicalSpecies("species_ion_nh4")).toBeDefined();
+
+      // But neither NO3- nor NH4+ exist as CardDefinitions
+      const cardIds = new Set(cardDefinitions.map((c) => c.id));
+      expect(cardIds.has("ion_no3")).toBe(false);
+      expect(cardIds.has("ion_nh4")).toBe(false);
+
+      // Starter deck ordinary physical card pool remains exactly 68 cards
+      expect(starterDeckSize).toBe(68);
+      const totalCards = starterDeck.reduce((acc, entry) => acc + entry.count, 0);
+      expect(totalCards).toBe(68);
+    });
+  });
+});

--- a/src/chemistry/chemistryData.test.ts
+++ b/src/chemistry/chemistryData.test.ts
@@ -12,8 +12,6 @@ import {
   radicalKnowledgeList,
   radicalKnowledgeMap,
 } from "./index";
-import { cardDefinitions } from "../game/data/cardDefinitions";
-import { starterDeck, starterDeckSize } from "../game/data/starterDeck";
 
 describe("Phase 18C: Junior Chemistry Data Foundation", () => {
   describe("Element Knowledge Registry (Freeze Section 3.1)", () => {
@@ -307,20 +305,46 @@ describe("Phase 18C: Junior Chemistry Data Foundation", () => {
       expect(allSpeciesIds.has("species_ion_br" as any)).toBe(false);
     });
 
-    it("ensures NO3- and NH4+ exist in Chemistry registry without creating physical cards", () => {
+    it("ensures NO3- and NH4+ exist in Chemistry registry as explicit species", () => {
       // NO3- and NH4+ are in Layer 1 Chemistry Species
-      expect(getChemicalSpecies("species_ion_no3")).toBeDefined();
+      const no3 = getChemicalSpecies("species_ion_no3");
+      expect(no3).toBeDefined();
+      expect(no3).toEqual({
+        id: "species_ion_no3",
+        kind: "ion",
+        formula: "NO3-",
+        charge: -1,
+        nameZh: "硝酸根离子",
+        nameEn: "Nitrate ion",
+      });
+
+      const nh4 = getChemicalSpecies("species_ion_nh4");
+      expect(nh4).toBeDefined();
+      expect(nh4).toEqual({
+        id: "species_ion_nh4",
+        kind: "ion",
+        formula: "NH4+",
+        charge: 1,
+        nameZh: "铵根离子",
+        nameEn: "Ammonium ion",
+      });
+    });
+
+    it("ensures all chemistry registries initialize and query independently", () => {
+      // Elements can be queried
+      expect(elementKnowledgeList.length).toBe(21);
+      expect(getElementKnowledge("H")).toBeDefined();
+      expect(getElementKnowledge("Si")).toBeDefined();
+
+      // Radicals can be queried
+      expect(radicalKnowledgeList.length).toBe(5);
+      expect(getRadicalKnowledge("OH")).toBeDefined();
+      expect(getRadicalKnowledge("NH4")).toBeDefined();
+
+      // Species can be queried
+      expect(chemicalSpeciesList.length).toBe(13);
+      expect(getChemicalSpecies("species_c")).toBeDefined();
       expect(getChemicalSpecies("species_ion_nh4")).toBeDefined();
-
-      // But neither NO3- nor NH4+ exist as CardDefinitions
-      const cardIds = new Set(cardDefinitions.map((c) => c.id));
-      expect(cardIds.has("ion_no3")).toBe(false);
-      expect(cardIds.has("ion_nh4")).toBe(false);
-
-      // Starter deck ordinary physical card pool remains exactly 68 cards
-      expect(starterDeckSize).toBe(68);
-      const totalCards = starterDeck.reduce((acc, entry) => acc + entry.count, 0);
-      expect(totalCards).toBe(68);
     });
   });
 });

--- a/src/chemistry/elements.ts
+++ b/src/chemistry/elements.ts
@@ -1,0 +1,139 @@
+import type { ElementKnowledge, ElementSymbol } from "./types";
+
+export const elementKnowledgeList: readonly ElementKnowledge[] = [
+  {
+    symbol: "H",
+    nameEn: "Hydrogen",
+    nameZh: "氢",
+    commonValences: [1],
+  },
+  {
+    symbol: "Na",
+    nameEn: "Sodium",
+    nameZh: "钠",
+    commonValences: [1],
+  },
+  {
+    symbol: "K",
+    nameEn: "Potassium",
+    nameZh: "钾",
+    commonValences: [1],
+  },
+  {
+    symbol: "Cu",
+    nameEn: "Copper",
+    nameZh: "铜",
+    commonValences: [1, 2],
+  },
+  {
+    symbol: "Ag",
+    nameEn: "Silver",
+    nameZh: "银",
+    commonValences: [1],
+  },
+  {
+    symbol: "Mg",
+    nameEn: "Magnesium",
+    nameZh: "镁",
+    commonValences: [2],
+  },
+  {
+    symbol: "Ca",
+    nameEn: "Calcium",
+    nameZh: "钙",
+    commonValences: [2],
+  },
+  {
+    symbol: "Ba",
+    nameEn: "Barium",
+    nameZh: "钡",
+    commonValences: [2],
+  },
+  {
+    symbol: "Zn",
+    nameEn: "Zinc",
+    nameZh: "锌",
+    commonValences: [2],
+  },
+  {
+    symbol: "Al",
+    nameEn: "Aluminium",
+    nameZh: "铝",
+    commonValences: [3],
+  },
+  {
+    symbol: "Mn",
+    nameEn: "Manganese",
+    nameZh: "锰",
+    commonValences: [2, 4, 6, 7],
+  },
+  {
+    symbol: "Fe",
+    nameEn: "Iron",
+    nameZh: "铁",
+    commonValences: [2, 3],
+  },
+  {
+    symbol: "F",
+    nameEn: "Fluorine",
+    nameZh: "氟",
+    commonValences: [-1],
+  },
+  {
+    symbol: "Cl",
+    nameEn: "Chlorine",
+    nameZh: "氯",
+    commonValences: [-1, 1, 5, 7],
+  },
+  {
+    symbol: "Br",
+    nameEn: "Bromine",
+    nameZh: "溴",
+    commonValences: [-1],
+  },
+  {
+    symbol: "O",
+    nameEn: "Oxygen",
+    nameZh: "氧",
+    commonValences: [-2],
+  },
+  {
+    symbol: "S",
+    nameEn: "Sulfur",
+    nameZh: "硫",
+    commonValences: [-2, 4, 6],
+  },
+  {
+    symbol: "N",
+    nameEn: "Nitrogen",
+    nameZh: "氮",
+    commonValences: [-3, 2, 3, 4, 5],
+  },
+  {
+    symbol: "P",
+    nameEn: "Phosphorus",
+    nameZh: "磷",
+    commonValences: [-3, 3, 5],
+  },
+  {
+    symbol: "C",
+    nameEn: "Carbon",
+    nameZh: "碳",
+    commonValences: [2, 4],
+  },
+  {
+    symbol: "Si",
+    nameEn: "Silicon",
+    nameZh: "硅",
+    commonValences: [4],
+  },
+] as const;
+
+export const elementKnowledgeMap: ReadonlyMap<ElementSymbol, ElementKnowledge> =
+  new Map(elementKnowledgeList.map((entry) => [entry.symbol, entry]));
+
+export function getElementKnowledge(
+  symbol: ElementSymbol | string,
+): ElementKnowledge | undefined {
+  return elementKnowledgeMap.get(symbol as ElementSymbol);
+}

--- a/src/chemistry/index.ts
+++ b/src/chemistry/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export * from "./elements";
+export * from "./radicals";
+export * from "./species";

--- a/src/chemistry/radicals.ts
+++ b/src/chemistry/radicals.ts
@@ -1,0 +1,43 @@
+import type { RadicalFormula, RadicalKnowledge } from "./types";
+
+export const radicalKnowledgeList: readonly RadicalKnowledge[] = [
+  {
+    formula: "OH",
+    nameZh: "氢氧根",
+    nameEn: "Hydroxide",
+    charge: -1,
+  },
+  {
+    formula: "NO3",
+    nameZh: "硝酸根",
+    nameEn: "Nitrate",
+    charge: -1,
+  },
+  {
+    formula: "CO3",
+    nameZh: "碳酸根",
+    nameEn: "Carbonate",
+    charge: -2,
+  },
+  {
+    formula: "SO4",
+    nameZh: "硫酸根",
+    nameEn: "Sulfate",
+    charge: -2,
+  },
+  {
+    formula: "NH4",
+    nameZh: "铵根",
+    nameEn: "Ammonium",
+    charge: 1,
+  },
+] as const;
+
+export const radicalKnowledgeMap: ReadonlyMap<RadicalFormula, RadicalKnowledge> =
+  new Map(radicalKnowledgeList.map((entry) => [entry.formula, entry]));
+
+export function getRadicalKnowledge(
+  formula: RadicalFormula | string,
+): RadicalKnowledge | undefined {
+  return radicalKnowledgeMap.get(formula as RadicalFormula);
+}

--- a/src/chemistry/species.ts
+++ b/src/chemistry/species.ts
@@ -1,0 +1,132 @@
+import type {
+  ChemicalSpecies,
+  ChemicalSpeciesId,
+  IonSpecies,
+  NeutralElementalComponentSpecies,
+} from "./types";
+
+export const chemicalSpeciesList: readonly ChemicalSpecies[] = [
+  {
+    id: "species_c",
+    kind: "neutral_elemental_component",
+    formula: "C",
+    charge: 0,
+    nameZh: "碳单质组件",
+    nameEn: "Carbon elemental component",
+  },
+  {
+    id: "species_o",
+    kind: "neutral_elemental_component",
+    formula: "O",
+    charge: 0,
+    nameZh: "氧单质组件",
+    nameEn: "Oxygen elemental component",
+  },
+  {
+    id: "species_s",
+    kind: "neutral_elemental_component",
+    formula: "S",
+    charge: 0,
+    nameZh: "硫单质组件",
+    nameEn: "Sulfur elemental component",
+  },
+  {
+    id: "species_ion_h",
+    kind: "ion",
+    formula: "H+",
+    charge: 1,
+    nameZh: "氢离子",
+    nameEn: "Hydrogen ion",
+  },
+  {
+    id: "species_ion_na",
+    kind: "ion",
+    formula: "Na+",
+    charge: 1,
+    nameZh: "钠离子",
+    nameEn: "Sodium ion",
+  },
+  {
+    id: "species_ion_k",
+    kind: "ion",
+    formula: "K+",
+    charge: 1,
+    nameZh: "钾离子",
+    nameEn: "Potassium ion",
+  },
+  {
+    id: "species_ion_ca",
+    kind: "ion",
+    formula: "Ca2+",
+    charge: 2,
+    nameZh: "钙离子",
+    nameEn: "Calcium ion",
+  },
+  {
+    id: "species_ion_cl",
+    kind: "ion",
+    formula: "Cl-",
+    charge: -1,
+    nameZh: "氯离子",
+    nameEn: "Chloride ion",
+  },
+  {
+    id: "species_ion_oh",
+    kind: "ion",
+    formula: "OH-",
+    charge: -1,
+    nameZh: "氢氧根离子",
+    nameEn: "Hydroxide ion",
+  },
+  {
+    id: "species_ion_co3",
+    kind: "ion",
+    formula: "CO3^2-",
+    charge: -2,
+    nameZh: "碳酸根离子",
+    nameEn: "Carbonate ion",
+  },
+  {
+    id: "species_ion_so4",
+    kind: "ion",
+    formula: "SO4^2-",
+    charge: -2,
+    nameZh: "硫酸根离子",
+    nameEn: "Sulfate ion",
+  },
+  {
+    id: "species_ion_no3",
+    kind: "ion",
+    formula: "NO3-",
+    charge: -1,
+    nameZh: "硝酸根离子",
+    nameEn: "Nitrate ion",
+  },
+  {
+    id: "species_ion_nh4",
+    kind: "ion",
+    formula: "NH4+",
+    charge: 1,
+    nameZh: "铵根离子",
+    nameEn: "Ammonium ion",
+  },
+] as const;
+
+export const chemicalSpeciesMap: ReadonlyMap<ChemicalSpeciesId, ChemicalSpecies> =
+  new Map(chemicalSpeciesList.map((entry) => [entry.id, entry]));
+
+export function getChemicalSpecies(
+  id: ChemicalSpeciesId | string,
+): ChemicalSpecies | undefined {
+  return chemicalSpeciesMap.get(id as ChemicalSpeciesId);
+}
+
+export function isNeutralElementalComponentSpecies(
+  species: ChemicalSpecies,
+): species is NeutralElementalComponentSpecies {
+  return species.kind === "neutral_elemental_component";
+}
+
+export function isIonSpecies(species: ChemicalSpecies): species is IonSpecies {
+  return species.kind === "ion";
+}

--- a/src/chemistry/types.ts
+++ b/src/chemistry/types.ts
@@ -1,0 +1,83 @@
+export type ElementSymbol =
+  | "H"
+  | "Na"
+  | "K"
+  | "Cu"
+  | "Ag"
+  | "Mg"
+  | "Ca"
+  | "Ba"
+  | "Zn"
+  | "Al"
+  | "Mn"
+  | "Fe"
+  | "F"
+  | "Cl"
+  | "Br"
+  | "O"
+  | "S"
+  | "N"
+  | "P"
+  | "C"
+  | "Si";
+
+export interface ElementKnowledge {
+  readonly symbol: ElementSymbol;
+  readonly nameZh: string;
+  readonly nameEn: string;
+  readonly commonValences: readonly number[];
+}
+
+export type RadicalFormula = "OH" | "NO3" | "CO3" | "SO4" | "NH4";
+
+export interface RadicalKnowledge {
+  readonly formula: RadicalFormula;
+  readonly nameZh: string;
+  readonly nameEn: string;
+  readonly charge: number;
+}
+
+export type NeutralElementalComponentSpeciesId =
+  | "species_c"
+  | "species_o"
+  | "species_s";
+
+export type IonSpeciesId =
+  | "species_ion_h"
+  | "species_ion_na"
+  | "species_ion_k"
+  | "species_ion_ca"
+  | "species_ion_cl"
+  | "species_ion_oh"
+  | "species_ion_co3"
+  | "species_ion_so4"
+  | "species_ion_no3"
+  | "species_ion_nh4";
+
+export type ChemicalSpeciesId =
+  | NeutralElementalComponentSpeciesId
+  | IonSpeciesId;
+
+export type ChemicalSpeciesKind = "neutral_elemental_component" | "ion";
+
+export interface NeutralElementalComponentSpecies {
+  readonly id: NeutralElementalComponentSpeciesId;
+  readonly kind: "neutral_elemental_component";
+  readonly formula: "C" | "O" | "S";
+  readonly charge: 0;
+  readonly nameZh: string;
+  readonly nameEn: string;
+}
+
+export interface IonSpecies {
+  readonly id: IonSpeciesId;
+  readonly kind: "ion";
+  readonly formula: string;
+  readonly charge: number;
+  readonly nameZh: string;
+  readonly nameEn: string;
+}
+
+export type ChemicalSpecies =
+  | NeutralElementalComponentSpecies
+  | IonSpecies;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -96,6 +96,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: [
+      "src/chemistry/**/*.test.ts",
       "src/game/tests/**/*.test.ts",
       "src/app/**/*.test.tsx",
       "src/features/**/*.test.tsx",


### PR DESCRIPTION
## Phase 18C: Junior Chemistry Data Foundation

### Scope & Architectural Layer
- Implements **Layer 1 (Chemistry Knowledge / Data Foundation)** only.
- Strict isolation: zero gameplay engine, state, card pool, or UI dependencies.
- No Card Adapter (`CardDefinitionId -> ChemicalSpeciesId` deferred).
- No Formula Composer or equation balancer.

### Authoritative Data Implemented
1. **21 Elements** (`ElementKnowledge`):
   - H, Na, K, Cu, Ag, Mg, Ca, Ba, Zn, Al, Mn, Fe, F, Cl, Br, O, S, N, P, C, Si
   - Includes English & Chinese names and confirmed `commonValences`.
2. **5 Radicals** (`RadicalKnowledge`):
   - OH (-1), NO3 (-1), CO3 (-2), SO4 (-2), NH4 (+1)
3. **13 Explicit Species Seed** (`ChemicalSpecies`):
   - 3 Neutral elemental components: `species_c` (C), `species_o` (O), `species_s` (S)
   - 10 Explicit ions: `species_ion_h` (H+), `species_ion_na` (Na+), `species_ion_k` (K+), `species_ion_ca` (Ca2+), `species_ion_cl` (Cl-), `species_ion_oh` (OH-), `species_ion_co3` (CO3^2-), `species_ion_so4` (SO4^2-), `species_ion_no3` (NO3-), `species_ion_nh4` (NH4+)

### Guardrails & Non-Regression
- Physical ordinary card pool remains strictly 68 cards.
- Active DIY recipes remain strictly 8 recipes with 100% equivalence.
- Zero reducer/action/UI/rules changes.

### Validation Results
- `pnpm vitest run src/chemistry/chemistryData.test.ts`: 16/16 passed
- `pnpm run test:run`: 43 test files, 607/607 passed
- `pnpm run test:shuffle`: 43 test files, 607/607 passed
- `pnpm run build`: Typecheck, Vite bundle & production isolation passed
- `pnpm run check:size`: Passed within limits
- `pnpm run test:e2e`: 13/13 passed
- `pnpm run test:e2e:production`: 3/3 passed
- `pnpm run check:tracked-clean`: Passed