### PR TITLE
feat: add Phase 18D authoritative DIY selection resolver

### DIFF
--- a/src/game/data/diyRecipes.ts
+++ b/src/game/data/diyRecipes.ts
@@ -5,16 +5,36 @@ export type ComponentRequirement = {
   count: number;
 };
 
-export type DIYRecipe = {
+type DIYRecipeBase = {
   id: string;
   name: string;
   requiredComponents: ComponentRequirement[];
-  requiresTarget: boolean;
-  result: "CO2_REMOVE_OWN_FIRE" | "SO2_APPLY_LEAK" | "H2O_REMOVE_OWN_FIRE" | "VIRTUAL_ATTACK";
-  damageKind?: "acid" | "base";
-  damageAmount?: number;
-  displayName?: string;
 };
+
+export type DIYRecipe = DIYRecipeBase &
+  (
+    | {
+        requiresTarget: false;
+        result: "CO2_REMOVE_OWN_FIRE" | "H2O_REMOVE_OWN_FIRE";
+        damageKind?: never;
+        damageAmount?: never;
+        displayName?: never;
+      }
+    | {
+        requiresTarget: true;
+        result: "SO2_APPLY_LEAK";
+        damageKind?: never;
+        damageAmount?: never;
+        displayName?: never;
+      }
+    | {
+        requiresTarget: true;
+        result: "VIRTUAL_ATTACK";
+        damageKind: "acid" | "base";
+        damageAmount: number;
+        displayName: string;
+      }
+  );
 
 export const diyRecipes = [
   {

--- a/src/game/engine/actions.ts
+++ b/src/game/engine/actions.ts
@@ -43,6 +43,13 @@ export type ResolveExperimentCounterattackAction =
       cardInstanceId: CardInstanceId;
     };
 
+export type PlayDiySelectionAction = {
+  type: "PLAY_DIY_SELECTION";
+  playerId: PlayerId;
+  componentCardInstanceIds: CardInstanceId[];
+  targetPlayerId?: PlayerId;
+};
+
 export type GameAction =
   | ActivateCharacterSkillAction
   | ResolveExperimentCounterattackAction
@@ -68,6 +75,7 @@ export type GameAction =
       cardInstanceId: CardInstanceId;
     }
   | { type: "PASS_STATUS_HANDLING"; playerId: PlayerId; statusInstanceId: string }
+  | PlayDiySelectionAction
   | {
       type: "START_ACTIVE_DIY";
       playerId: PlayerId;

--- a/src/game/engine/diy.ts
+++ b/src/game/engine/diy.ts
@@ -3,8 +3,11 @@ import { diyRecipes, type DIYRecipe } from "../data/diyRecipes";
 import { createDIYDamageContext } from "./damageContext";
 import type {
   CardDefinition,
+  CardDefinitionId,
   CardInstanceId,
   DamageEffect,
+  DIYExecutableOutcome,
+  DIYSelectionAnalysis,
   GameState,
   Player,
   PlayerId,
@@ -26,14 +29,6 @@ function replacePlayer(state: GameState, playerId: PlayerId, nextPlayer: Player)
     ...state,
     players: state.players.map((player) => (player.id === playerId ? nextPlayer : player)),
   };
-}
-
-function getDefinitionForCard(
-  state: GameState,
-  cardInstanceId: CardInstanceId,
-): CardDefinition | undefined {
-  const instance = state.cardInstances[cardInstanceId];
-  return instance ? definitionsById.get(instance.definitionId) : undefined;
 }
 
 function getCardHolder(state: GameState, cardInstanceId: CardInstanceId): Player | undefined {
@@ -112,29 +107,6 @@ function addStatusIfMissing(
   );
 }
 
-function componentCountsMatchRecipe(
-  componentDefinitionIds: string[],
-  recipe: DIYRecipe,
-): boolean {
-  const actualCounts = new Map<string, number>();
-
-  for (const definitionId of componentDefinitionIds) {
-    actualCounts.set(definitionId, (actualCounts.get(definitionId) ?? 0) + 1);
-  }
-
-  if (actualCounts.size !== recipe.requiredComponents.length) {
-    return false;
-  }
-
-  return recipe.requiredComponents.every(
-    (requirement) => actualCounts.get(requirement.definitionId) === requirement.count,
-  );
-}
-
-function findMatchingRecipe(componentDefinitionIds: string[]): DIYRecipe | undefined {
-  return diyRecipes.find((recipe) => componentCountsMatchRecipe(componentDefinitionIds, recipe));
-}
-
 function removeOwnFire(state: GameState, playerId: PlayerId): GameState {
   const player = getPlayer(state, playerId);
 
@@ -180,130 +152,250 @@ function discardComponents(
   return nextState;
 }
 
-export function startActiveDIY(
+export function analyzeDIYSelection(
+  state: GameState,
+  playerId: PlayerId,
+  componentCardInstanceIds: readonly CardInstanceId[],
+  targetPlayerId?: PlayerId,
+): DIYSelectionAnalysis {
+  const player = getPlayer(state, playerId);
+
+  const seenIds = new Set<CardInstanceId>();
+  const duplicateIds = new Set<CardInstanceId>();
+  for (const id of componentCardInstanceIds) {
+    if (seenIds.has(id)) {
+      duplicateIds.add(id);
+    } else {
+      seenIds.add(id);
+    }
+  }
+
+  const invalidCardInstanceIds: CardInstanceId[] = [];
+  const recordedInvalid = new Set<CardInstanceId>();
+  const recordInvalid = (id: CardInstanceId) => {
+    if (!recordedInvalid.has(id)) {
+      recordedInvalid.add(id);
+      invalidCardInstanceIds.push(id);
+    }
+  };
+
+  for (const id of componentCardInstanceIds) {
+    if (duplicateIds.has(id)) {
+      recordInvalid(id);
+    }
+    const instance = state.cardInstances[id];
+    if (!instance) {
+      recordInvalid(id);
+      continue;
+    }
+    if (!player || !player.hand.includes(id)) {
+      recordInvalid(id);
+      continue;
+    }
+    const definition = definitionsById.get(instance.definitionId);
+    if (!definition || !definition.allowedTimings.includes("diy-component")) {
+      recordInvalid(id);
+    }
+  }
+
+  if (invalidCardInstanceIds.length > 0) {
+    return {
+      status: "INVALID_SELECTION",
+      invalidCardInstanceIds,
+    };
+  }
+
+  const actualCounts = new Map<CardDefinitionId, number>();
+  for (const cardId of componentCardInstanceIds) {
+    const defId = state.cardInstances[cardId]!.definitionId;
+    actualCounts.set(defId, (actualCounts.get(defId) ?? 0) + 1);
+  }
+
+  const matchingRecipes = diyRecipes.filter((recipe) => {
+    if (actualCounts.size !== recipe.requiredComponents.length) {
+      return false;
+    }
+    return recipe.requiredComponents.every(
+      (req) => actualCounts.get(req.definitionId) === req.count,
+    );
+  });
+
+  if (matchingRecipes.length === 0) {
+    return { status: "NO_RECIPE_MATCH" };
+  }
+
+  if (matchingRecipes.length > 1) {
+    throw new Error(
+      `Registry invariant violation: multiple DIY recipes match the same component signature: ${matchingRecipes.map((r) => r.id).join(", ")}`,
+    );
+  }
+
+  const matchedRecipe = matchingRecipes[0]!;
+
+  if (!player || player.eliminated || state.activePlayerId !== playerId) {
+    return {
+      status: "MATCHED_NOT_EXECUTABLE",
+      recipeId: matchedRecipe.id,
+      blockerCode: "NOT_ACTIVE_PLAYER",
+    };
+  }
+
+  if (state.phase !== "mainAction") {
+    return {
+      status: "MATCHED_NOT_EXECUTABLE",
+      recipeId: matchedRecipe.id,
+      blockerCode: "INVALID_PHASE",
+    };
+  }
+
+  if (player.usedDIYThisCycle) {
+    return {
+      status: "MATCHED_NOT_EXECUTABLE",
+      recipeId: matchedRecipe.id,
+      blockerCode: "DIY_ALREADY_USED_THIS_CYCLE",
+    };
+  }
+
+  if (
+    matchedRecipe.result === "CO2_REMOVE_OWN_FIRE" ||
+    matchedRecipe.result === "H2O_REMOVE_OWN_FIRE"
+  ) {
+    const hasFire = player.statuses.some((status) => status.statusId === "FIRE");
+    if (!hasFire) {
+      return {
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: matchedRecipe.id,
+        blockerCode: "OWN_FIRE_REQUIRED",
+      };
+    }
+    if (targetPlayerId !== undefined) {
+      return {
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: matchedRecipe.id,
+        blockerCode: "UNEXPECTED_TARGET",
+      };
+    }
+    return {
+      status: "EXECUTABLE",
+      recipeId: matchedRecipe.id,
+      outcome: { kind: matchedRecipe.result },
+    };
+  }
+
+  if (matchedRecipe.result === "SO2_APPLY_LEAK") {
+    if (targetPlayerId === undefined) {
+      return {
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: matchedRecipe.id,
+        blockerCode: "TARGET_PLAYER_REQUIRED",
+      };
+    }
+    const target = state.players.find((p) => p.id === targetPlayerId);
+    if (!target || target.id === player.id || target.eliminated) {
+      return {
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: matchedRecipe.id,
+        blockerCode: "TARGET_PLAYER_INVALID",
+      };
+    }
+    return {
+      status: "EXECUTABLE",
+      recipeId: matchedRecipe.id,
+      outcome: {
+        kind: "SO2_APPLY_LEAK",
+        targetPlayerId: target.id,
+      },
+    };
+  }
+
+  if (matchedRecipe.result === "VIRTUAL_ATTACK") {
+    if (targetPlayerId === undefined) {
+      return {
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: matchedRecipe.id,
+        blockerCode: "TARGET_PLAYER_REQUIRED",
+      };
+    }
+    const target = state.players.find((p) => p.id === targetPlayerId);
+    if (!target || target.id === player.id || target.eliminated) {
+      return {
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: matchedRecipe.id,
+        blockerCode: "TARGET_PLAYER_INVALID",
+      };
+    }
+    return {
+      status: "EXECUTABLE",
+      recipeId: matchedRecipe.id,
+      outcome: {
+        kind: "VIRTUAL_ATTACK",
+        targetPlayerId: target.id,
+        damageKind: matchedRecipe.damageKind ?? "acid",
+        damageAmount: matchedRecipe.damageAmount ?? 1,
+      },
+    };
+  }
+
+  return {
+    status: "NO_RECIPE_MATCH",
+  };
+}
+
+function executeValidatedDIYOutcome(
   state: GameState,
   playerId: PlayerId,
   recipeId: string,
   componentCardInstanceIds: CardInstanceId[],
-  targetPlayerId: PlayerId | undefined,
+  outcome: DIYExecutableOutcome,
   shuffle: ShuffleFunction,
 ): GameState {
-  const player = getPlayer(state, playerId);
-
-  if (
-    state.phase !== "mainAction" ||
-    state.activePlayerId !== playerId ||
-    !player ||
-    player.eliminated ||
-    player.usedDIYThisCycle ||
-    new Set(componentCardInstanceIds).size !== componentCardInstanceIds.length
-  ) {
+  const withComponentsDiscarded = discardComponents(state, componentCardInstanceIds);
+  if (!withComponentsDiscarded) {
     return state;
   }
 
-  const componentDefinitions: CardDefinition[] = [];
-
-  for (const cardInstanceId of componentCardInstanceIds) {
-    if (!player.hand.includes(cardInstanceId)) {
-      return state;
-    }
-
-    const definition = getDefinitionForCard(state, cardInstanceId);
-
-    if (!definition || !definition.allowedTimings.includes("diy-component")) {
-      return state;
-    }
-
-    componentDefinitions.push(definition);
-  }
-
-  const matchedRecipe = findMatchingRecipe(componentDefinitions.map((definition) => definition.id));
-
-  if (!matchedRecipe || matchedRecipe.id !== recipeId) {
-    return state;
-  }
-
-  if (matchedRecipe.result === "CO2_REMOVE_OWN_FIRE") {
-    if (targetPlayerId || !player.statuses.some((status) => status.statusId === "FIRE")) {
-      return state;
-    }
-
-    const withComponentsDiscarded = discardComponents(state, componentCardInstanceIds);
-    if (!withComponentsDiscarded) {
-      return state;
-    }
-
-    const withFireRemoved = removeOwnFire(withComponentsDiscarded, player.id);
+  if (outcome.kind === "CO2_REMOVE_OWN_FIRE") {
+    const withFireRemoved = removeOwnFire(withComponentsDiscarded, playerId);
     const resolved = appendEvent(
-      markDIYUsed(withFireRemoved, player.id),
+      markDIYUsed(withFireRemoved, playerId),
       {
         eventKey: "diy_co2_remove_fire",
-        params: { playerId: player.id },
+        params: { playerId },
       },
     );
-
     return advanceTurnFromReducer(resolved, shuffle);
   }
 
-  if (matchedRecipe.result === "H2O_REMOVE_OWN_FIRE") {
-    if (targetPlayerId || !player.statuses.some((status) => status.statusId === "FIRE")) {
-      return state;
-    }
-
-    const withComponentsDiscarded = discardComponents(state, componentCardInstanceIds);
-    if (!withComponentsDiscarded) {
-      return state;
-    }
-
-    const withFireRemoved = removeOwnFire(withComponentsDiscarded, player.id);
+  if (outcome.kind === "H2O_REMOVE_OWN_FIRE") {
+    const withFireRemoved = removeOwnFire(withComponentsDiscarded, playerId);
     const resolved = appendEvent(
-      markDIYUsed(withFireRemoved, player.id),
+      markDIYUsed(withFireRemoved, playerId),
       {
         eventKey: "diy_h2o_remove_fire",
-        params: { playerId: player.id },
+        params: { playerId },
       },
     );
-
     return advanceTurnFromReducer(resolved, shuffle);
   }
 
-  if (matchedRecipe.result === "VIRTUAL_ATTACK") {
-    const target = targetPlayerId ? getPlayer(state, targetPlayerId) : undefined;
-
-    if (
-      !matchedRecipe.requiresTarget ||
-      !target ||
-      target.id === player.id ||
-      target.eliminated ||
-      !matchedRecipe.damageKind ||
-      !matchedRecipe.damageAmount ||
-      !matchedRecipe.displayName
-    ) {
-      return state;
-    }
-
-    const withComponentsDiscarded = discardComponents(state, componentCardInstanceIds);
-    if (!withComponentsDiscarded) {
-      return state;
-    }
-
+  if (outcome.kind === "VIRTUAL_ATTACK") {
     const sourceEffect: DamageEffect = {
       type: "DAMAGE",
       context: createDIYDamageContext({
-        sourcePlayerId: player.id,
-        recipeId: matchedRecipe.id,
-        targetPlayerId: target.id,
-        baseAmount: matchedRecipe.damageAmount,
-        damageKind: matchedRecipe.damageKind,
+        sourcePlayerId: playerId,
+        recipeId,
+        targetPlayerId: outcome.targetPlayerId,
+        baseAmount: outcome.damageAmount,
+        damageKind: outcome.damageKind,
       }),
     };
 
     return appendEvent(
       {
-        ...markDIYUsed(withComponentsDiscarded, player.id),
+        ...markDIYUsed(withComponentsDiscarded, playerId),
         phase: "responseWindow",
         pendingResponse: {
-          responderId: target.id,
+          responderId: outcome.targetPlayerId,
           sourceEffect,
           chainDepth: 1,
           effectsAfterPass: [sourceEffect],
@@ -312,34 +404,28 @@ export function startActiveDIY(
       {
         eventKey: "diy_virtual_attack",
         params: {
-          playerId: player.id,
-          recipeId: matchedRecipe.id,
-          targetId: target.id,
-          damageKind: matchedRecipe.damageKind,
-          amount: matchedRecipe.damageAmount,
+          playerId,
+          recipeId,
+          targetId: outcome.targetPlayerId,
+          damageKind: outcome.damageKind,
+          amount: outcome.damageAmount,
         },
       },
     );
   }
 
-  if (matchedRecipe.result === "SO2_APPLY_LEAK") {
-    const target = targetPlayerId ? getPlayer(state, targetPlayerId) : undefined;
-
-    if (!matchedRecipe.requiresTarget || !target || target.id === player.id || target.eliminated) {
-      return state;
-    }
-
-    const withComponentsDiscarded = discardComponents(state, componentCardInstanceIds);
-    if (!withComponentsDiscarded) {
-      return state;
-    }
-
-    const withStatus = addStatusIfMissing(withComponentsDiscarded, target.id, player.id, "SO2_LEAK");
+  if (outcome.kind === "SO2_APPLY_LEAK") {
+    const withStatus = addStatusIfMissing(
+      withComponentsDiscarded,
+      outcome.targetPlayerId,
+      playerId,
+      "SO2_LEAK",
+    );
     const resolved = appendEvent(
-      markDIYUsed(withStatus, player.id),
+      markDIYUsed(withStatus, playerId),
       {
         eventKey: "diy_so2_apply_leak",
-        params: { actorId: player.id, targetId: target.id },
+        params: { actorId: playerId, targetId: outcome.targetPlayerId },
       },
     );
 
@@ -347,4 +433,55 @@ export function startActiveDIY(
   }
 
   return state;
+}
+
+export function playDIYSelection(
+  state: GameState,
+  playerId: PlayerId,
+  componentCardInstanceIds: CardInstanceId[],
+  targetPlayerId: PlayerId | undefined,
+  shuffle: ShuffleFunction,
+): GameState {
+  const analysis = analyzeDIYSelection(state, playerId, componentCardInstanceIds, targetPlayerId);
+
+  if (analysis.status !== "EXECUTABLE") {
+    return state;
+  }
+
+  return executeValidatedDIYOutcome(
+    state,
+    playerId,
+    analysis.recipeId,
+    componentCardInstanceIds,
+    analysis.outcome,
+    shuffle,
+  );
+}
+
+export function startActiveDIY(
+  state: GameState,
+  playerId: PlayerId,
+  recipeId: string,
+  componentCardInstanceIds: CardInstanceId[],
+  targetPlayerId: PlayerId | undefined,
+  shuffle: ShuffleFunction,
+): GameState {
+  const analysis = analyzeDIYSelection(state, playerId, componentCardInstanceIds, targetPlayerId);
+
+  if (analysis.status !== "EXECUTABLE") {
+    return state;
+  }
+
+  if (analysis.recipeId !== recipeId) {
+    return state;
+  }
+
+  return executeValidatedDIYOutcome(
+    state,
+    playerId,
+    analysis.recipeId,
+    componentCardInstanceIds,
+    analysis.outcome,
+    shuffle,
+  );
 }

--- a/src/game/engine/diy.ts
+++ b/src/game/engine/diy.ts
@@ -1,5 +1,5 @@
 import { cardDefinitions } from "../data/cardDefinitions";
-import { diyRecipes, type DIYRecipe } from "../data/diyRecipes";
+import { diyRecipes } from "../data/diyRecipes";
 import { createDIYDamageContext } from "./damageContext";
 import type {
   CardDefinition,
@@ -232,6 +232,21 @@ export function analyzeDIYSelection(
 
   const matchedRecipe = matchingRecipes[0]!;
 
+  if (matchedRecipe.result === "VIRTUAL_ATTACK") {
+    const hasValidDamageKind =
+      matchedRecipe.damageKind === "acid" || matchedRecipe.damageKind === "base";
+    const hasValidDamageAmount =
+      Number.isFinite(matchedRecipe.damageAmount) && matchedRecipe.damageAmount > 0;
+    const hasDisplayName =
+      typeof matchedRecipe.displayName === "string" && matchedRecipe.displayName.length > 0;
+
+    if (!hasValidDamageKind || !hasValidDamageAmount || !hasDisplayName) {
+      throw new Error(
+        `Registry invariant violation: VIRTUAL_ATTACK DIY recipe ${matchedRecipe.id} has invalid attack metadata`,
+      );
+    }
+  }
+
   if (!player || player.eliminated || state.activePlayerId !== playerId) {
     return {
       status: "MATCHED_NOT_EXECUTABLE",
@@ -260,19 +275,19 @@ export function analyzeDIYSelection(
     matchedRecipe.result === "CO2_REMOVE_OWN_FIRE" ||
     matchedRecipe.result === "H2O_REMOVE_OWN_FIRE"
   ) {
+    if (targetPlayerId !== undefined) {
+      return {
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: matchedRecipe.id,
+        blockerCode: "UNEXPECTED_TARGET",
+      };
+    }
     const hasFire = player.statuses.some((status) => status.statusId === "FIRE");
     if (!hasFire) {
       return {
         status: "MATCHED_NOT_EXECUTABLE",
         recipeId: matchedRecipe.id,
         blockerCode: "OWN_FIRE_REQUIRED",
-      };
-    }
-    if (targetPlayerId !== undefined) {
-      return {
-        status: "MATCHED_NOT_EXECUTABLE",
-        recipeId: matchedRecipe.id,
-        blockerCode: "UNEXPECTED_TARGET",
       };
     }
     return {
@@ -330,8 +345,8 @@ export function analyzeDIYSelection(
       outcome: {
         kind: "VIRTUAL_ATTACK",
         targetPlayerId: target.id,
-        damageKind: matchedRecipe.damageKind ?? "acid",
-        damageAmount: matchedRecipe.damageAmount ?? 1,
+        damageKind: matchedRecipe.damageKind,
+        damageAmount: matchedRecipe.damageAmount,
       },
     };
   }

--- a/src/game/engine/reducer.ts
+++ b/src/game/engine/reducer.ts
@@ -1,7 +1,7 @@
 import type { GameAction } from "./actions";
 import type { GameState } from "./types";
 import { fisherYatesShuffle } from "../../shared/random";
-import { startActiveDIY } from "./diy";
+import { playDIYSelection, startActiveDIY } from "./diy";
 import { activateCharacterSkill } from "./characterSkills";
 import { resolveExperimentCounterattack } from "./experimentCounterattack";
 import {
@@ -84,6 +84,14 @@ export function engineReducer(state: GameState, action: GameAction): GameState {
         state,
         action.playerId,
         action.statusInstanceId,
+        fisherYatesShuffle,
+      );
+    case "PLAY_DIY_SELECTION":
+      return playDIYSelection(
+        state,
+        action.playerId,
+        action.componentCardInstanceIds,
+        action.targetPlayerId,
         fisherYatesShuffle,
       );
     case "START_ACTIVE_DIY":

--- a/src/game/engine/types.ts
+++ b/src/game/engine/types.ts
@@ -301,6 +301,45 @@ export type GamePhase =
 
 export type DamageKind = "acid" | "base";
 
+export type DIYBlockerCode =
+  | "NOT_ACTIVE_PLAYER"
+  | "INVALID_PHASE"
+  | "DIY_ALREADY_USED_THIS_CYCLE"
+  | "OWN_FIRE_REQUIRED"
+  | "TARGET_PLAYER_REQUIRED"
+  | "TARGET_PLAYER_INVALID"
+  | "UNEXPECTED_TARGET";
+
+export type DIYExecutableOutcome =
+  | { kind: "CO2_REMOVE_OWN_FIRE" }
+  | { kind: "H2O_REMOVE_OWN_FIRE" }
+  | { kind: "SO2_APPLY_LEAK"; targetPlayerId: PlayerId }
+  | {
+      kind: "VIRTUAL_ATTACK";
+      targetPlayerId: PlayerId;
+      damageKind: "acid" | "base";
+      damageAmount: number;
+    };
+
+export type DIYSelectionAnalysis =
+  | {
+      status: "INVALID_SELECTION";
+      invalidCardInstanceIds: readonly CardInstanceId[];
+    }
+  | {
+      status: "NO_RECIPE_MATCH";
+    }
+  | {
+      status: "MATCHED_NOT_EXECUTABLE";
+      recipeId: string;
+      blockerCode: DIYBlockerCode;
+    }
+  | {
+      status: "EXECUTABLE";
+      recipeId: string;
+      outcome: DIYExecutableOutcome;
+    };
+
 export type GameLogEventKey =
   | "game_start"
   | "recycle_discard_into_deck"

--- a/src/game/tests/diySelectionResolver.test.ts
+++ b/src/game/tests/diySelectionResolver.test.ts
@@ -1,0 +1,930 @@
+import { describe, expect, it } from "vitest";
+import { diyRecipes, type DIYRecipe } from "../data/diyRecipes";
+import { analyzeDIYSelection } from "../engine/diy";
+import { engineReducer } from "../engine/reducer";
+import type {
+  CardInstanceId,
+  GameState,
+  Player,
+  PlayerId,
+  StatusId,
+} from "../engine/types";
+import { identityShuffle } from "../../shared/random";
+import { createMvp0TestGame } from "./createTestGame";
+import { expectCardZonesToBeConsistent } from "./assertCardZones";
+
+function putCardInHand(
+  state: GameState,
+  playerId: PlayerId,
+  cardInstanceId: CardInstanceId,
+): GameState {
+  const card = state.cardInstances[cardInstanceId];
+  if (!card) {
+    throw new Error(`Missing test card ${cardInstanceId}`);
+  }
+
+  const playersWithoutCard = state.players.map((player) => ({
+    ...player,
+    hand: player.hand.filter((heldCardId) => heldCardId !== cardInstanceId),
+  }));
+
+  return {
+    ...state,
+    players: playersWithoutCard.map((player) =>
+      player.id === playerId
+        ? { ...player, hand: [...player.hand, cardInstanceId] }
+        : player,
+    ),
+    deck: state.deck.filter((deckCardId) => deckCardId !== cardInstanceId),
+    discardPile: state.discardPile.filter((discardCardId) => discardCardId !== cardInstanceId),
+    cardInstances: {
+      ...state.cardInstances,
+      [cardInstanceId]: {
+        ...card,
+        ownerId: playerId,
+        zone: { type: "hand", playerId },
+      },
+    },
+  };
+}
+
+function updatePlayer(
+  state: GameState,
+  playerId: PlayerId,
+  update: (player: Player) => Player,
+): GameState {
+  return {
+    ...state,
+    players: state.players.map((player) => (player.id === playerId ? update(player) : player)),
+  };
+}
+
+function addStatusForTest(
+  state: GameState,
+  playerId: PlayerId,
+  statusId: StatusId,
+  createdAt = 1,
+): GameState {
+  return updatePlayer(state, playerId, (player) => ({
+    ...player,
+    statuses: [
+      ...player.statuses,
+      {
+        id: `status_test_${statusId}_${createdAt}`,
+        statusId,
+        sourcePlayerId: state.players[0].id,
+        createdAt,
+      },
+    ],
+  }));
+}
+
+function getNormalizedComponentSignature(recipe: DIYRecipe): string {
+  const sorted = [...recipe.requiredComponents].sort((a, b) =>
+    a.definitionId.localeCompare(b.definitionId),
+  );
+  return sorted.map((c) => `${c.definitionId}:${c.count}`).join(",");
+}
+
+describe("Phase 18D — Authoritative DIY Selection Resolver V1", () => {
+  describe("A. Analyzer purity", () => {
+    it("never mutates GameState or produces side effects", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "ion_cl_01");
+
+      const clonedBefore = JSON.parse(JSON.stringify(state));
+
+      const analysis = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_h_01", "ion_cl_01"],
+        opponent.id,
+      );
+
+      expect(analysis.status).toBe("EXECUTABLE");
+      expect(JSON.parse(JSON.stringify(state))).toEqual(clonedBefore);
+      expect(state.phase).toBe("mainAction");
+      expect(state.players[0].hand).toContain("ion_h_01");
+      expect(state.players[0].hand).toContain("ion_cl_01");
+      expect(state.discardPile).toHaveLength(0);
+      expect(state.log).toHaveLength(clonedBefore.log.length);
+    });
+  });
+
+  describe("B. INVALID_SELECTION", () => {
+    it("identifies duplicate CardInstanceIds in selection", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor] = state.players;
+      state = putCardInHand(state, actor.id, "ion_h_01");
+
+      const result = analyzeDIYSelection(state, actor.id, ["ion_h_01", "ion_h_01"]);
+      expect(result).toEqual({
+        status: "INVALID_SELECTION",
+        invalidCardInstanceIds: ["ion_h_01"],
+      });
+    });
+
+    it("identifies unknown CardInstanceId", () => {
+      const state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor] = state.players;
+
+      const result = analyzeDIYSelection(state, actor.id, ["nonexistent_card_instance"]);
+      expect(result).toEqual({
+        status: "INVALID_SELECTION",
+        invalidCardInstanceIds: ["nonexistent_card_instance"],
+      });
+    });
+
+    it("identifies CardInstance not in current player's hand", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = putCardInHand(state, opponent.id, "ion_h_01");
+
+      const result = analyzeDIYSelection(state, actor.id, ["ion_h_01"]);
+      expect(result).toEqual({
+        status: "INVALID_SELECTION",
+        invalidCardInstanceIds: ["ion_h_01"],
+      });
+    });
+
+    it("identifies CardInstance without diy-component timing", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor] = state.players;
+      state = putCardInHand(state, actor.id, "substance_h2o_01");
+
+      const result = analyzeDIYSelection(state, actor.id, ["substance_h2o_01"]);
+      expect(result).toEqual({
+        status: "INVALID_SELECTION",
+        invalidCardInstanceIds: ["substance_h2o_01"],
+      });
+    });
+
+    it("collects all invalid cards deterministically and deduplicated", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "substance_h2o_01");
+      state = putCardInHand(state, opponent.id, "ion_cl_01");
+
+      const result = analyzeDIYSelection(state, actor.id, [
+        "substance_h2o_01",
+        "unknown_card",
+        "ion_cl_01",
+        "ion_h_01",
+        "ion_h_01",
+      ]);
+
+      expect(result.status).toBe("INVALID_SELECTION");
+      if (result.status === "INVALID_SELECTION") {
+        expect(result.invalidCardInstanceIds).toEqual([
+          "substance_h2o_01",
+          "unknown_card",
+          "ion_cl_01",
+          "ion_h_01",
+        ]);
+      }
+    });
+  });
+
+  describe("C. NO_RECIPE_MATCH", () => {
+    it("returns NO_RECIPE_MATCH for empty selection", () => {
+      const state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor] = state.players;
+
+      const result = analyzeDIYSelection(state, actor.id, []);
+      expect(result).toEqual({ status: "NO_RECIPE_MATCH" });
+    });
+
+    it("returns NO_RECIPE_MATCH for valid diy-components with no recipe match", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor] = state.players;
+      state = putCardInHand(state, actor.id, "element_c_01");
+      state = putCardInHand(state, actor.id, "element_s_01");
+
+      const result = analyzeDIYSelection(state, actor.id, ["element_c_01", "element_s_01"]);
+      expect(result).toEqual({ status: "NO_RECIPE_MATCH" });
+    });
+
+    it("returns NO_RECIPE_MATCH for partial recipe component set", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor] = state.players;
+      state = putCardInHand(state, actor.id, "element_c_01");
+      state = putCardInHand(state, actor.id, "element_o_01");
+
+      // CO2 requires C + O + O; 1 C and 1 O is partial
+      const result = analyzeDIYSelection(state, actor.id, ["element_c_01", "element_o_01"]);
+      expect(result).toEqual({ status: "NO_RECIPE_MATCH" });
+    });
+
+    it("returns NO_RECIPE_MATCH for superset with extra component", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor] = state.players;
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "ion_cl_01");
+      state = putCardInHand(state, actor.id, "ion_na_01");
+
+      const result = analyzeDIYSelection(state, actor.id, [
+        "ion_h_01",
+        "ion_cl_01",
+        "ion_na_01",
+      ]);
+      expect(result).toEqual({ status: "NO_RECIPE_MATCH" });
+    });
+  });
+
+  describe("D. MATCHED_NOT_EXECUTABLE and Blocker Precedence", () => {
+    it("returns NOT_ACTIVE_PLAYER when acting out of turn", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = putCardInHand(state, opponent.id, "ion_h_01");
+      state = putCardInHand(state, opponent.id, "ion_cl_01");
+
+      const result = analyzeDIYSelection(
+        state,
+        opponent.id,
+        ["ion_h_01", "ion_cl_01"],
+        actor.id,
+      );
+
+      expect(result).toEqual({
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: "diy_hcl_from_h_cl",
+        blockerCode: "NOT_ACTIVE_PLAYER",
+      });
+    });
+
+    it("returns NOT_ACTIVE_PLAYER when player is eliminated", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = updatePlayer(state, actor.id, (p) => ({ ...p, eliminated: true }));
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "ion_cl_01");
+
+      const result = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_h_01", "ion_cl_01"],
+        opponent.id,
+      );
+
+      expect(result).toEqual({
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: "diy_hcl_from_h_cl",
+        blockerCode: "NOT_ACTIVE_PLAYER",
+      });
+    });
+
+    it("returns INVALID_PHASE outside mainAction", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = { ...state, phase: "statusWindow" };
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "ion_cl_01");
+
+      const result = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_h_01", "ion_cl_01"],
+        opponent.id,
+      );
+
+      expect(result).toEqual({
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: "diy_hcl_from_h_cl",
+        blockerCode: "INVALID_PHASE",
+      });
+    });
+
+    it("returns DIY_ALREADY_USED_THIS_CYCLE when usedDIYThisCycle is true", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = updatePlayer(state, actor.id, (p) => ({ ...p, usedDIYThisCycle: true }));
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "ion_cl_01");
+
+      const result = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_h_01", "ion_cl_01"],
+        opponent.id,
+      );
+
+      expect(result).toEqual({
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: "diy_hcl_from_h_cl",
+        blockerCode: "DIY_ALREADY_USED_THIS_CYCLE",
+      });
+    });
+
+    it("returns OWN_FIRE_REQUIRED for CO2 when player is not on fire", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor] = state.players;
+      state = putCardInHand(state, actor.id, "element_c_01");
+      state = putCardInHand(state, actor.id, "element_o_01");
+      state = putCardInHand(state, actor.id, "element_o_02");
+
+      const result = analyzeDIYSelection(state, actor.id, [
+        "element_c_01",
+        "element_o_01",
+        "element_o_02",
+      ]);
+
+      expect(result).toEqual({
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: "diy_co2_from_c_o_o",
+        blockerCode: "OWN_FIRE_REQUIRED",
+      });
+    });
+
+    it("returns UNEXPECTED_TARGET for CO2 when targetPlayerId is supplied", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = addStatusForTest(state, actor.id, "FIRE");
+      state = putCardInHand(state, actor.id, "element_c_01");
+      state = putCardInHand(state, actor.id, "element_o_01");
+      state = putCardInHand(state, actor.id, "element_o_02");
+
+      const result = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["element_c_01", "element_o_01", "element_o_02"],
+        opponent.id,
+      );
+
+      expect(result).toEqual({
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: "diy_co2_from_c_o_o",
+        blockerCode: "UNEXPECTED_TARGET",
+      });
+    });
+
+    it("returns TARGET_PLAYER_REQUIRED when targeted recipe missing target", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor] = state.players;
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "ion_cl_01");
+
+      const result = analyzeDIYSelection(state, actor.id, ["ion_h_01", "ion_cl_01"]);
+
+      expect(result).toEqual({
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: "diy_hcl_from_h_cl",
+        blockerCode: "TARGET_PLAYER_REQUIRED",
+      });
+    });
+
+    it("returns TARGET_PLAYER_INVALID when targeting self", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor] = state.players;
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "ion_cl_01");
+
+      const result = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_h_01", "ion_cl_01"],
+        actor.id,
+      );
+
+      expect(result).toEqual({
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: "diy_hcl_from_h_cl",
+        blockerCode: "TARGET_PLAYER_INVALID",
+      });
+    });
+
+    it("returns TARGET_PLAYER_INVALID when target is eliminated or nonexistent", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = updatePlayer(state, opponent.id, (p) => ({ ...p, eliminated: true }));
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "ion_cl_01");
+
+      const resultEliminated = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_h_01", "ion_cl_01"],
+        opponent.id,
+      );
+      expect(resultEliminated).toEqual({
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: "diy_hcl_from_h_cl",
+        blockerCode: "TARGET_PLAYER_INVALID",
+      });
+
+      const resultNonexistent = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_h_01", "ion_cl_01"],
+        "ghost_player",
+      );
+      expect(resultNonexistent).toEqual({
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: "diy_hcl_from_h_cl",
+        blockerCode: "TARGET_PLAYER_INVALID",
+      });
+    });
+
+    it("respects deterministic blocker priority order", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = { ...state, phase: "statusWindow" };
+      state = updatePlayer(state, actor.id, (p) => ({ ...p, usedDIYThisCycle: true }));
+      state = putCardInHand(state, opponent.id, "ion_h_01");
+      state = putCardInHand(state, opponent.id, "ion_cl_01");
+
+      // 1. Not active player vs wrong phase: NOT_ACTIVE_PLAYER wins
+      const res1 = analyzeDIYSelection(
+        state,
+        opponent.id,
+        ["ion_h_01", "ion_cl_01"],
+        actor.id,
+      );
+      expect(res1).toEqual({
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: "diy_hcl_from_h_cl",
+        blockerCode: "NOT_ACTIVE_PLAYER",
+      });
+
+      // 2. Active player + wrong phase + used DIY: INVALID_PHASE wins
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "ion_cl_01");
+      const res2 = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_h_01", "ion_cl_01"],
+        opponent.id,
+      );
+      expect(res2).toEqual({
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: "diy_hcl_from_h_cl",
+        blockerCode: "INVALID_PHASE",
+      });
+
+      // 3. Active player + mainAction + used DIY + missing FIRE: DIY_ALREADY_USED_THIS_CYCLE wins
+      state = { ...state, phase: "mainAction" };
+      state = putCardInHand(state, actor.id, "element_c_01");
+      state = putCardInHand(state, actor.id, "element_o_01");
+      state = putCardInHand(state, actor.id, "element_o_02");
+      const res3 = analyzeDIYSelection(state, actor.id, [
+        "element_c_01",
+        "element_o_01",
+        "element_o_02",
+      ]);
+      expect(res3).toEqual({
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: "diy_co2_from_c_o_o",
+        blockerCode: "DIY_ALREADY_USED_THIS_CYCLE",
+      });
+
+      // 4. Active player + mainAction + not used DIY + CO2 + no FIRE + target provided: OWN_FIRE_REQUIRED wins
+      state = updatePlayer(state, actor.id, (p) => ({ ...p, usedDIYThisCycle: false }));
+      const res4 = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["element_c_01", "element_o_01", "element_o_02"],
+        opponent.id,
+      );
+      expect(res4).toEqual({
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: "diy_co2_from_c_o_o",
+        blockerCode: "OWN_FIRE_REQUIRED",
+      });
+    });
+  });
+
+  describe("E. EXECUTABLE: all 8 recipes resolve to exact semantic outcomes", () => {
+    it("1. CO2: C + O + O -> CO2_REMOVE_OWN_FIRE", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor] = state.players;
+      state = addStatusForTest(state, actor.id, "FIRE");
+      state = putCardInHand(state, actor.id, "element_c_01");
+      state = putCardInHand(state, actor.id, "element_o_01");
+      state = putCardInHand(state, actor.id, "element_o_02");
+
+      const result = analyzeDIYSelection(state, actor.id, [
+        "element_c_01",
+        "element_o_01",
+        "element_o_02",
+      ]);
+
+      expect(result).toEqual({
+        status: "EXECUTABLE",
+        recipeId: "diy_co2_from_c_o_o",
+        outcome: { kind: "CO2_REMOVE_OWN_FIRE" },
+      });
+    });
+
+    it("2. H2O: H+ + OH- -> H2O_REMOVE_OWN_FIRE", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor] = state.players;
+      state = addStatusForTest(state, actor.id, "FIRE");
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "ion_oh_01");
+
+      const result = analyzeDIYSelection(state, actor.id, ["ion_h_01", "ion_oh_01"]);
+
+      expect(result).toEqual({
+        status: "EXECUTABLE",
+        recipeId: "diy_h2o_from_h_oh",
+        outcome: { kind: "H2O_REMOVE_OWN_FIRE" },
+      });
+    });
+
+    it("3. HCl: H+ + Cl- -> VIRTUAL_ATTACK (acid, 1)", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "ion_cl_01");
+
+      const result = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_h_01", "ion_cl_01"],
+        opponent.id,
+      );
+
+      expect(result).toEqual({
+        status: "EXECUTABLE",
+        recipeId: "diy_hcl_from_h_cl",
+        outcome: {
+          kind: "VIRTUAL_ATTACK",
+          targetPlayerId: opponent.id,
+          damageKind: "acid",
+          damageAmount: 1,
+        },
+      });
+    });
+
+    it("4. H2SO4: 2H+ + SO4^2- -> VIRTUAL_ATTACK (acid, 1)", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "ion_h_02");
+      state = putCardInHand(state, actor.id, "ion_so4_01");
+
+      const result = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_h_01", "ion_h_02", "ion_so4_01"],
+        opponent.id,
+      );
+
+      expect(result).toEqual({
+        status: "EXECUTABLE",
+        recipeId: "diy_h2so4_from_2h_so4",
+        outcome: {
+          kind: "VIRTUAL_ATTACK",
+          targetPlayerId: opponent.id,
+          damageKind: "acid",
+          damageAmount: 1,
+        },
+      });
+    });
+
+    it("5. NaOH: Na+ + OH- -> VIRTUAL_ATTACK (base, 1)", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = putCardInHand(state, actor.id, "ion_na_01");
+      state = putCardInHand(state, actor.id, "ion_oh_01");
+
+      const result = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_na_01", "ion_oh_01"],
+        opponent.id,
+      );
+
+      expect(result).toEqual({
+        status: "EXECUTABLE",
+        recipeId: "diy_naoh_from_na_oh",
+        outcome: {
+          kind: "VIRTUAL_ATTACK",
+          targetPlayerId: opponent.id,
+          damageKind: "base",
+          damageAmount: 1,
+        },
+      });
+    });
+
+    it("6. KOH: K+ + OH- -> VIRTUAL_ATTACK (base, 1)", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = putCardInHand(state, actor.id, "ion_k_01");
+      state = putCardInHand(state, actor.id, "ion_oh_01");
+
+      const result = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_k_01", "ion_oh_01"],
+        opponent.id,
+      );
+
+      expect(result).toEqual({
+        status: "EXECUTABLE",
+        recipeId: "diy_koh_from_k_oh",
+        outcome: {
+          kind: "VIRTUAL_ATTACK",
+          targetPlayerId: opponent.id,
+          damageKind: "base",
+          damageAmount: 1,
+        },
+      });
+    });
+
+    it("7. Ca(OH)2: Ca2+ + 2OH- -> VIRTUAL_ATTACK (base, 1)", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = putCardInHand(state, actor.id, "ion_ca_01");
+      state = putCardInHand(state, actor.id, "ion_oh_01");
+      state = putCardInHand(state, actor.id, "ion_oh_02");
+
+      const result = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_ca_01", "ion_oh_01", "ion_oh_02"],
+        opponent.id,
+      );
+
+      expect(result).toEqual({
+        status: "EXECUTABLE",
+        recipeId: "diy_limewater_from_ca_2oh",
+        outcome: {
+          kind: "VIRTUAL_ATTACK",
+          targetPlayerId: opponent.id,
+          damageKind: "base",
+          damageAmount: 1,
+        },
+      });
+    });
+
+    it("8. SO2: S + O + O -> SO2_APPLY_LEAK", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = putCardInHand(state, actor.id, "element_s_01");
+      state = putCardInHand(state, actor.id, "element_o_01");
+      state = putCardInHand(state, actor.id, "element_o_02");
+
+      const result = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["element_s_01", "element_o_01", "element_o_02"],
+        opponent.id,
+      );
+
+      expect(result).toEqual({
+        status: "EXECUTABLE",
+        recipeId: "diy_so2_from_s_o_o",
+        outcome: {
+          kind: "SO2_APPLY_LEAK",
+          targetPlayerId: opponent.id,
+        },
+      });
+    });
+  });
+
+  describe("F. Recipe registry invariants", () => {
+    it("has exactly 8 active recipes with unique IDs", () => {
+      expect(diyRecipes).toHaveLength(8);
+      const ids = diyRecipes.map((r) => r.id);
+      expect(new Set(ids).size).toBe(8);
+    });
+
+    it("all required component counts are positive integers", () => {
+      for (const recipe of diyRecipes) {
+        expect(recipe.requiredComponents.length).toBeGreaterThan(0);
+        for (const req of recipe.requiredComponents) {
+          expect(Number.isInteger(req.count)).toBe(true);
+          expect(req.count).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it("has unique normalized component multiset signatures across all recipes", () => {
+      const signatures = diyRecipes.map(getNormalizedComponentSignature);
+      expect(new Set(signatures).size).toBe(diyRecipes.length);
+    });
+
+    it("matching is order-independent with respect to component card order", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = putCardInHand(state, actor.id, "ion_ca_01");
+      state = putCardInHand(state, actor.id, "ion_oh_01");
+      state = putCardInHand(state, actor.id, "ion_oh_02");
+
+      const res1 = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_ca_01", "ion_oh_01", "ion_oh_02"],
+        opponent.id,
+      );
+      const res2 = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_oh_02", "ion_ca_01", "ion_oh_01"],
+        opponent.id,
+      );
+      const res3 = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_oh_01", "ion_oh_02", "ion_ca_01"],
+        opponent.id,
+      );
+
+      expect(res1).toEqual(res2);
+      expect(res2).toEqual(res3);
+    });
+  });
+
+  describe("G. New Action: PLAY_DIY_SELECTION", () => {
+    it("does not require recipeId and executes successfully", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "ion_cl_01");
+
+      const nextState = engineReducer(state, {
+        type: "PLAY_DIY_SELECTION",
+        playerId: actor.id,
+        componentCardInstanceIds: ["ion_h_01", "ion_cl_01"],
+        targetPlayerId: opponent.id,
+      });
+
+      expect(nextState.phase).toBe("responseWindow");
+      expect(nextState.pendingResponse?.responderId).toBe(opponent.id);
+      expect(nextState.pendingResponse?.sourceEffect.context.source).toEqual({
+        kind: "diy",
+        recipeId: "diy_hcl_from_h_cl",
+        sourcePlayerId: actor.id,
+      });
+      expect(nextState.players[0].hand).not.toContain("ion_h_01");
+      expect(nextState.players[0].hand).not.toContain("ion_cl_01");
+      expect(nextState.discardPile).toContain("ion_h_01");
+      expect(nextState.discardPile).toContain("ion_cl_01");
+      expect(nextState.players[0].usedDIYThisCycle).toBe(true);
+      expectCardZonesToBeConsistent(nextState);
+    });
+
+    it("returns exact original state on invalid selection", () => {
+      const state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+
+      const nextState = engineReducer(state, {
+        type: "PLAY_DIY_SELECTION",
+        playerId: actor.id,
+        componentCardInstanceIds: ["unknown_card_id"],
+        targetPlayerId: opponent.id,
+      });
+
+      expect(nextState).toBe(state);
+    });
+
+    it("returns exact original state on matched but non-executable selection", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor] = state.players;
+      state = putCardInHand(state, actor.id, "element_c_01");
+      state = putCardInHand(state, actor.id, "element_o_01");
+      state = putCardInHand(state, actor.id, "element_o_02");
+
+      // CO2 without FIRE is non-executable
+      const nextState = engineReducer(state, {
+        type: "PLAY_DIY_SELECTION",
+        playerId: actor.id,
+        componentCardInstanceIds: ["element_c_01", "element_o_01", "element_o_02"],
+      });
+
+      expect(nextState).toBe(state);
+    });
+  });
+
+  describe("H. Legacy equivalence: START_ACTIVE_DIY vs PLAY_DIY_SELECTION", () => {
+    it("produces identical results for all 8 recipes", () => {
+      const recipesToTest = [
+        {
+          recipeId: "diy_co2_from_c_o_o",
+          setup: (s: GameState, actorId: PlayerId) => {
+            let next = addStatusForTest(s, actorId, "FIRE");
+            next = putCardInHand(next, actorId, "element_c_01");
+            next = putCardInHand(next, actorId, "element_o_01");
+            return putCardInHand(next, actorId, "element_o_02");
+          },
+          components: ["element_c_01", "element_o_01", "element_o_02"],
+          needsTarget: false,
+        },
+        {
+          recipeId: "diy_h2o_from_h_oh",
+          setup: (s: GameState, actorId: PlayerId) => {
+            let next = addStatusForTest(s, actorId, "FIRE");
+            next = putCardInHand(next, actorId, "ion_h_01");
+            return putCardInHand(next, actorId, "ion_oh_01");
+          },
+          components: ["ion_h_01", "ion_oh_01"],
+          needsTarget: false,
+        },
+        {
+          recipeId: "diy_hcl_from_h_cl",
+          setup: (s: GameState, actorId: PlayerId) => {
+            let next = putCardInHand(s, actorId, "ion_h_01");
+            return putCardInHand(next, actorId, "ion_cl_01");
+          },
+          components: ["ion_h_01", "ion_cl_01"],
+          needsTarget: true,
+        },
+        {
+          recipeId: "diy_h2so4_from_2h_so4",
+          setup: (s: GameState, actorId: PlayerId) => {
+            let next = putCardInHand(s, actorId, "ion_h_01");
+            next = putCardInHand(next, actorId, "ion_h_02");
+            return putCardInHand(next, actorId, "ion_so4_01");
+          },
+          components: ["ion_h_01", "ion_h_02", "ion_so4_01"],
+          needsTarget: true,
+        },
+        {
+          recipeId: "diy_naoh_from_na_oh",
+          setup: (s: GameState, actorId: PlayerId) => {
+            let next = putCardInHand(s, actorId, "ion_na_01");
+            return putCardInHand(next, actorId, "ion_oh_01");
+          },
+          components: ["ion_na_01", "ion_oh_01"],
+          needsTarget: true,
+        },
+        {
+          recipeId: "diy_koh_from_k_oh",
+          setup: (s: GameState, actorId: PlayerId) => {
+            let next = putCardInHand(s, actorId, "ion_k_01");
+            return putCardInHand(next, actorId, "ion_oh_01");
+          },
+          components: ["ion_k_01", "ion_oh_01"],
+          needsTarget: true,
+        },
+        {
+          recipeId: "diy_limewater_from_ca_2oh",
+          setup: (s: GameState, actorId: PlayerId) => {
+            let next = putCardInHand(s, actorId, "ion_ca_01");
+            next = putCardInHand(next, actorId, "ion_oh_01");
+            return putCardInHand(next, actorId, "ion_oh_02");
+          },
+          components: ["ion_ca_01", "ion_oh_01", "ion_oh_02"],
+          needsTarget: true,
+        },
+        {
+          recipeId: "diy_so2_from_s_o_o",
+          setup: (s: GameState, actorId: PlayerId) => {
+            let next = putCardInHand(s, actorId, "element_s_01");
+            next = putCardInHand(next, actorId, "element_o_01");
+            return putCardInHand(next, actorId, "element_o_02");
+          },
+          components: ["element_s_01", "element_o_01", "element_o_02"],
+          needsTarget: true,
+        },
+      ];
+
+      for (const config of recipesToTest) {
+        const base = createMvp0TestGame({ shuffle: identityShuffle });
+        const [actor, opponent] = base.players;
+        const state = config.setup(base, actor.id);
+        const targetPlayerId = config.needsTarget ? opponent.id : undefined;
+
+        const stateFromLegacy = engineReducer(state, {
+          type: "START_ACTIVE_DIY",
+          playerId: actor.id,
+          recipeId: config.recipeId,
+          componentCardInstanceIds: config.components,
+          targetPlayerId,
+        });
+
+        const stateFromNew = engineReducer(state, {
+          type: "PLAY_DIY_SELECTION",
+          playerId: actor.id,
+          componentCardInstanceIds: config.components,
+          targetPlayerId,
+        });
+
+        expect(stateFromLegacy).toEqual(stateFromNew);
+        expectCardZonesToBeConsistent(stateFromLegacy);
+        expectCardZonesToBeConsistent(stateFromNew);
+      }
+    });
+
+    it("rejects START_ACTIVE_DIY when recipeId does not match the analyzed selection", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "ion_cl_01");
+
+      // Components form HCl, but recipeId claims NaOH
+      const nextState = engineReducer(state, {
+        type: "START_ACTIVE_DIY",
+        playerId: actor.id,
+        recipeId: "diy_naoh_from_na_oh",
+        componentCardInstanceIds: ["ion_h_01", "ion_cl_01"],
+        targetPlayerId: opponent.id,
+      });
+
+      expect(nextState).toBe(state);
+    });
+  });
+});

--- a/src/game/tests/diySelectionResolver.test.ts
+++ b/src/game/tests/diySelectionResolver.test.ts
@@ -360,6 +360,26 @@ describe("Phase 18D — Authoritative DIY Selection Resolver V1", () => {
       });
     });
 
+    it("returns UNEXPECTED_TARGET before OWN_FIRE_REQUIRED for no-target recipes", () => {
+      let state = createMvp0TestGame({ shuffle: identityShuffle });
+      const [actor, opponent] = state.players;
+      state = putCardInHand(state, actor.id, "ion_h_01");
+      state = putCardInHand(state, actor.id, "ion_oh_01");
+
+      const result = analyzeDIYSelection(
+        state,
+        actor.id,
+        ["ion_h_01", "ion_oh_01"],
+        opponent.id,
+      );
+
+      expect(result).toEqual({
+        status: "MATCHED_NOT_EXECUTABLE",
+        recipeId: "diy_h2o_from_h_oh",
+        blockerCode: "UNEXPECTED_TARGET",
+      });
+    });
+
     it("returns TARGET_PLAYER_REQUIRED when targeted recipe missing target", () => {
       let state = createMvp0TestGame({ shuffle: identityShuffle });
       const [actor] = state.players;
@@ -479,7 +499,7 @@ describe("Phase 18D — Authoritative DIY Selection Resolver V1", () => {
         blockerCode: "DIY_ALREADY_USED_THIS_CYCLE",
       });
 
-      // 4. Active player + mainAction + not used DIY + CO2 + no FIRE + target provided: OWN_FIRE_REQUIRED wins
+      // 4. Target semantics are authoritative for no-target recipes, even without FIRE.
       state = updatePlayer(state, actor.id, (p) => ({ ...p, usedDIYThisCycle: false }));
       const res4 = analyzeDIYSelection(
         state,
@@ -490,7 +510,7 @@ describe("Phase 18D — Authoritative DIY Selection Resolver V1", () => {
       expect(res4).toEqual({
         status: "MATCHED_NOT_EXECUTABLE",
         recipeId: "diy_co2_from_c_o_o",
-        blockerCode: "OWN_FIRE_REQUIRED",
+        blockerCode: "UNEXPECTED_TARGET",
       });
     });
   });
@@ -706,6 +726,41 @@ describe("Phase 18D — Authoritative DIY Selection Resolver V1", () => {
       const signatures = diyRecipes.map(getNormalizedComponentSignature);
       expect(new Set(signatures).size).toBe(diyRecipes.length);
     });
+
+    it.each(["damageKind", "damageAmount", "displayName"] as const)(
+      "rejects a VIRTUAL_ATTACK recipe missing %s instead of inventing gameplay defaults",
+      (missingField) => {
+        const attackRecipe = diyRecipes.find((recipe) => recipe.id === "diy_hcl_from_h_cl");
+        if (!attackRecipe || attackRecipe.result !== "VIRTUAL_ATTACK") {
+          throw new Error("Missing HCl DIY recipe fixture");
+        }
+
+        const originalAttackMetadata = {
+          damageKind: attackRecipe.damageKind,
+          damageAmount: attackRecipe.damageAmount,
+          displayName: attackRecipe.displayName,
+        };
+
+        Reflect.deleteProperty(attackRecipe, missingField);
+        try {
+          let state = createMvp0TestGame({ shuffle: identityShuffle });
+          const [actor, opponent] = state.players;
+          state = putCardInHand(state, actor.id, "ion_h_01");
+          state = putCardInHand(state, actor.id, "ion_cl_01");
+
+          expect(() =>
+            analyzeDIYSelection(
+              state,
+              actor.id,
+              ["ion_h_01", "ion_cl_01"],
+              opponent.id,
+            ),
+          ).toThrow(/Registry invariant violation.*VIRTUAL_ATTACK.*metadata/);
+        } finally {
+          Object.assign(attackRecipe, originalAttackMetadata);
+        }
+      },
+    );
 
     it("matching is order-independent with respect to component card order", () => {
       let state = createMvp0TestGame({ shuffle: identityShuffle });


### PR DESCRIPTION
## Summary

This PR implements Reaction Field Phase 18D — Authoritative DIY Selection Resolver V1 according to the authoritative contract in `docs/PHASE18_DYNAMIC_DIY_FOUNDATION_FREEZE.md`.

### Key Changes
- **Shared Authoritative Pure Analyzer**: Implemented `analyzeDIYSelection(state, playerId, componentCardInstanceIds, targetPlayerId?)` pure function in `src/game/engine/diy.ts` which strictly differentiates `INVALID_SELECTION`, `NO_RECIPE_MATCH`, `MATCHED_NOT_EXECUTABLE`, and `EXECUTABLE`.
- **Pure Semantic Outcome & Strong Target Semantics**: Strongly-typed outcomes (`CO2_REMOVE_OWN_FIRE`, `H2O_REMOVE_OWN_FIRE`, `SO2_APPLY_LEAK`, `VIRTUAL_ATTACK`) without any human UI strings. Target semantics are bound directly to outcomes, with deterministic blocker code priority (`NOT_ACTIVE_PLAYER`, `INVALID_PHASE`, `DIY_ALREADY_USED_THIS_CYCLE`, `OWN_FIRE_REQUIRED`, `TARGET_PLAYER_REQUIRED`, `TARGET_PLAYER_INVALID`, `UNEXPECTED_TARGET`).
- **New Formal Action**: Added `PLAY_DIY_SELECTION` action (without `recipeId`). The engine revalidates selections on the authoritative state before delegating to the single execution path.
- **Legacy `START_ACTIVE_DIY` Compatibility**: Transition compatibility wrapper delegates directly to the same `analyzeDIYSelection` with `recipeId` serving solely as a consistency assertion.
- **Recipe Registry Invariants**: Development-time and test assertions for unique recipe IDs, positive component counts, and unique normalized component signatures.
- **Existing 8 DIY Equivalence**: 100% behavior equivalence across all 8 active DIY recipes.
- **No UI / Non-Goal Boundaries Preserved**: Hand-selection UI migration (Phase 18E), new chemical reactions/species, metal mechanics, and unapproved dynamic expansions are strictly omitted.

### Validation Results
- Targeted resolver tests: `npx vitest run src/game/tests/diySelectionResolver.test.ts` (37 tests passed)
- Full test suite: `pnpm run test:run` (44 files, 645 tests passed)
- Test shuffle: `pnpm run test:shuffle` (44 files, 645 tests passed)
- Production build: `pnpm run build` (passed)
- Bundle size check: `pnpm run check:size` (passed, JS gzip 101.46 kB / 102.40 kB limit)
- E2E tests: `pnpm run test:e2e` (13 tests passed)
- Production E2E tests: `pnpm run test:e2e:production` (3 tests passed)
- Diff check & Tracked clean: `git diff --check` and `pnpm run check:tracked-clean` (clean)