### PR TITLE
feat: Phase 19B deterministic simulation infrastructure & seeded PRNG

### DIFF
--- a/src/game/engine/createInitialGame.ts
+++ b/src/game/engine/createInitialGame.ts
@@ -1,6 +1,6 @@
 import { starterDeck } from "../data/starterDeck";
 import { getCharacterDefinition } from "../data/characterDefinitions";
-import { fisherYatesShuffle } from "../../shared/random";
+import { createSeededShuffle, fisherYatesShuffle, type ShuffleFunction } from "../../shared/random";
 import type { CardInstance, CharacterId, GameState, Player } from "./types";
 import { createEmptyCharacterUsage } from "./characterUsage";
 import { beginActionForPlayer, dealCycleStartHands } from "./turnFlow";
@@ -10,7 +10,8 @@ export type CreateInitialGameOptions = {
   gameId?: string;
   playerNames?: [string, string];
   characterIds?: [CharacterId, CharacterId];
-  shuffle?: <T>(items: readonly T[]) => T[];
+  shuffle?: ShuffleFunction;
+  seed?: number;
 };
 
 const defaultPlayerNames: [string, string] = ["玩家 A", "玩家 B"];
@@ -38,7 +39,9 @@ export function createInitialGame(options: CreateInitialGameOptions = {}): GameS
     selectedCharacters[0].id,
     selectedCharacters[1].id,
   ];
-  const shuffle = options.shuffle ?? fisherYatesShuffle;
+  const shuffle =
+    options.shuffle ??
+    (options.seed !== undefined ? createSeededShuffle(options.seed) : fisherYatesShuffle);
   const cardInstances: Record<string, CardInstance> = {};
   const unshuffledDeck: string[] = [];
 

--- a/src/game/engine/reducer.ts
+++ b/src/game/engine/reducer.ts
@@ -1,6 +1,6 @@
 import type { GameAction } from "./actions";
 import type { GameState } from "./types";
-import { fisherYatesShuffle } from "../../shared/random";
+import { fisherYatesShuffle, type ShuffleFunction } from "../../shared/random";
 import { playDIYSelection, startActiveDIY } from "./diy";
 import { activateCharacterSkill } from "./characterSkills";
 import { resolveExperimentCounterattack } from "./experimentCounterattack";
@@ -15,7 +15,11 @@ import {
 } from "./resolution";
 import { advanceTurnFromReducer, confirmLaboratoryPreparation } from "./turnFlow";
 
-export function engineReducer(state: GameState, action: GameAction): GameState {
+export function engineReducer(
+  state: GameState,
+  action: GameAction,
+  shuffle: ShuffleFunction = fisherYatesShuffle,
+): GameState {
   if (state.phase === "gameOver") {
     return state;
   }
@@ -39,7 +43,7 @@ export function engineReducer(state: GameState, action: GameAction): GameState {
       return activateCharacterSkill(
         state,
         action,
-        fisherYatesShuffle,
+        shuffle,
       );
     case "CONFIRM_LABORATORY_PREPARATION":
       return confirmLaboratoryPreparation(
@@ -48,40 +52,40 @@ export function engineReducer(state: GameState, action: GameAction): GameState {
         action.keptCardInstanceIds,
       );
     case "RESOLVE_EXPERIMENT_COUNTERATTACK":
-      return resolveExperimentCounterattack(state, action, fisherYatesShuffle);
+      return resolveExperimentCounterattack(state, action, shuffle);
     case "PASS_ACTION":
       if (!validatePassAction(state, action.playerId)) {
         return state;
       }
-      return advanceTurnFromReducer(state, fisherYatesShuffle);
+      return advanceTurnFromReducer(state, shuffle);
     case "PLAY_CARD":
       return playMainActionCard(
         state,
         action.playerId,
         action.cardInstanceId,
         action.targetPlayerId,
-        fisherYatesShuffle,
+        shuffle,
       );
     case "PLAY_REFERENCE_CARD":
-      return playReferenceCard(state, action.playerId, action.cardInstanceId, fisherYatesShuffle);
+      return playReferenceCard(state, action.playerId, action.cardInstanceId, shuffle);
     case "RESPOND_WITH_CARD":
-      return respondWithCard(state, action.playerId, action.cardInstanceId, fisherYatesShuffle);
+      return respondWithCard(state, action.playerId, action.cardInstanceId, shuffle);
     case "PASS_RESPONSE":
-      return passResponse(state, action.playerId, fisherYatesShuffle);
+      return passResponse(state, action.playerId, shuffle);
     case "HANDLE_STATUS_WITH_CARD":
       return handleStatusWithCard(
         state,
         action.playerId,
         action.statusInstanceId,
         action.cardInstanceId,
-        fisherYatesShuffle,
+        shuffle,
       );
     case "PASS_STATUS_HANDLING":
       return passStatusHandling(
         state,
         action.playerId,
         action.statusInstanceId,
-        fisherYatesShuffle,
+        shuffle,
       );
     case "PLAY_DIY_SELECTION":
       return playDIYSelection(
@@ -89,7 +93,7 @@ export function engineReducer(state: GameState, action: GameAction): GameState {
         action.playerId,
         action.componentCardInstanceIds,
         action.targetPlayerId,
-        fisherYatesShuffle,
+        shuffle,
       );
     case "START_ACTIVE_DIY":
       return startActiveDIY(
@@ -98,7 +102,7 @@ export function engineReducer(state: GameState, action: GameAction): GameState {
         action.recipeId,
         action.componentCardInstanceIds,
         action.targetPlayerId,
-        fisherYatesShuffle,
+        shuffle,
       );
     default:
       return state;

--- a/src/game/tests/deterministicSimulation.test.ts
+++ b/src/game/tests/deterministicSimulation.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from "vitest";
+import { createInitialGame } from "../engine/createInitialGame";
+import { engineReducer } from "../engine/reducer";
+import {
+  createFisherYatesShuffle,
+  createMulberry32,
+  createSeededShuffle,
+  identityShuffle,
+} from "../../shared/random";
+import type { GameAction } from "../engine/actions";
+import type { GameState } from "../engine/types";
+
+describe("Phase 19B — Deterministic Simulation Infrastructure", () => {
+  describe("createInitialGame with seed injection", () => {
+    it("produces bit-identical initial GameState for identical seeds", () => {
+      const state1 = createInitialGame({
+        gameId: "test_game",
+        seed: 42,
+        characterIds: ["laboratory_teacher", "chemical_factory_ceo"],
+      });
+      const state2 = createInitialGame({
+        gameId: "test_game",
+        seed: 42,
+        characterIds: ["laboratory_teacher", "chemical_factory_ceo"],
+      });
+
+      expect(state1).toEqual(state2);
+      expect(JSON.stringify(state1)).toBe(JSON.stringify(state2));
+      expect(state1.deck).toEqual(state2.deck);
+      expect(state1.players[0].hand).toEqual(state2.players[0].hand);
+      expect(state1.players[1].hand).toEqual(state2.players[1].hand);
+    });
+
+    it("produces different deck orders for different seeds", () => {
+      const stateA = createInitialGame({
+        gameId: "test_game",
+        seed: 100,
+        characterIds: ["caustic_soda_captain", "acid_king"],
+      });
+      const stateB = createInitialGame({
+        gameId: "test_game",
+        seed: 200,
+        characterIds: ["caustic_soda_captain", "acid_king"],
+      });
+
+      expect(stateA.deck).not.toEqual(stateB.deck);
+    });
+
+    it("prioritizes explicit shuffle option over seed if both are passed", () => {
+      const state = createInitialGame({
+        gameId: "test_game",
+        shuffle: identityShuffle,
+        seed: 99999,
+        characterIds: ["caustic_soda_captain", "acid_king"],
+      });
+
+      // With identityShuffle, starterDeck is laid out in original definition order
+      expect(state.players[0].hand.length).toBe(10);
+    });
+
+    it("maintains default non-seeded creation backwards compatibility", () => {
+      const state = createInitialGame();
+      expect(state.phase).toBe("preparationSelection");
+      expect(state.players.length).toBe(2);
+      // 68 total - 20 (teacher prep candidates) - 14 (CEO capital reserve hand) = 34
+      expect(state.deck.length).toBe(34);
+    });
+  });
+
+  describe("engineReducer with seeded shuffle injection", () => {
+    it("produces bit-identical state and logs across independent full-action replays", () => {
+      const seed = 20260821;
+
+      function runSimulation(): { finalState: GameState; intermediateLogs: string[][] } {
+        const prng = createMulberry32(seed);
+        const seededShuffle = createFisherYatesShuffle(prng);
+
+        let state = createInitialGame({
+          gameId: "deterministic_session",
+          shuffle: seededShuffle,
+          characterIds: ["laboratory_teacher", "caustic_soda_captain"],
+        });
+
+        const intermediateLogs: string[][] = [];
+
+        // 1. Preparation selection for laboratory teacher
+        const prep = state.pendingLaboratoryPreparation;
+        expect(prep).toBeDefined();
+        if (!prep) throw new Error("Expected pendingLaboratoryPreparation");
+
+        const kept10 = prep.candidateCardInstanceIds.slice(0, 10);
+        state = engineReducer(
+          state,
+          {
+            type: "CONFIRM_LABORATORY_PREPARATION",
+            playerId: "player_1",
+            keptCardInstanceIds: kept10,
+          },
+          seededShuffle,
+        );
+        intermediateLogs.push(state.log.map((entry) => entry.id));
+
+        // 2. Player 1 (Laboratory Teacher) uses extra_lesson skill (draws 4 cards)
+        expect(state.phase).toBe("mainAction");
+        expect(state.activePlayerId).toBe("player_1");
+        state = engineReducer(
+          state,
+          {
+            type: "ACTIVATE_CHARACTER_SKILL",
+            playerId: "player_1",
+            skillId: "extra_lesson",
+          },
+          seededShuffle,
+        );
+        intermediateLogs.push(state.log.map((entry) => entry.id));
+
+        // 3. Player 1 passes main action
+        state = engineReducer(
+          state,
+          {
+            type: "PASS_ACTION",
+            playerId: "player_1",
+          },
+          seededShuffle,
+        );
+        intermediateLogs.push(state.log.map((entry) => entry.id));
+
+        // 4. Player 2 passes main action
+        expect(state.phase).toBe("mainAction");
+        expect(state.activePlayerId).toBe("player_2");
+        state = engineReducer(
+          state,
+          {
+            type: "PASS_ACTION",
+            playerId: "player_2",
+          },
+          seededShuffle,
+        );
+        intermediateLogs.push(state.log.map((entry) => entry.id));
+
+        return { finalState: state, intermediateLogs };
+      }
+
+      const run1 = runSimulation();
+      const run2 = runSimulation();
+
+      expect(run1.finalState).toEqual(run2.finalState);
+      expect(JSON.stringify(run1.finalState)).toBe(JSON.stringify(run2.finalState));
+      expect(run1.intermediateLogs).toEqual(run2.intermediateLogs);
+      expect(run1.finalState.log.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it("replays deterministic discard pile recycling upon deck exhaustion", () => {
+      const seed = 54321;
+
+      function runDeckRecycleSimulation(): GameState {
+        const prng = createMulberry32(seed);
+        const shuffle = createFisherYatesShuffle(prng);
+
+        // Start with 2 Caustic Soda Captains to have standard 10 card hands
+        let state = createInitialGame({
+          gameId: "recycle_sim",
+          shuffle,
+          characterIds: ["laboratory_teacher", "caustic_soda_captain"],
+        });
+
+        // Confirm prep
+        const prep = state.pendingLaboratoryPreparation!;
+        state = engineReducer(
+          state,
+          {
+            type: "CONFIRM_LABORATORY_PREPARATION",
+            playerId: "player_1",
+            keptCardInstanceIds: prep.candidateCardInstanceIds.slice(0, 10),
+          },
+          shuffle,
+        );
+
+        // Artificially deplete deck to 1 card and set discard pile with 15 cards
+        const remainingCard = state.deck[0];
+        const discardCards = state.deck.slice(1, 16);
+        // Reduce player 1's hand to 2 cards so extra_lesson (requires hand <= 4) is legal
+        state = {
+          ...state,
+          players: state.players.map((p) =>
+            p.id === "player_1" ? { ...p, hand: p.hand.slice(0, 2) } : p,
+          ),
+          deck: [remainingCard],
+          discardPile: discardCards,
+        };
+
+        // Player 1 (Teacher) uses extra_lesson (draws 4 cards -> exhausts 1 remaining deck card, triggers recycling discardPile of 15 cards, draws 3 from recycled deck)
+        const nextState = engineReducer(
+          state,
+          {
+            type: "ACTIVATE_CHARACTER_SKILL",
+            playerId: "player_1",
+            skillId: "extra_lesson",
+          },
+          shuffle,
+        );
+
+        return nextState;
+      }
+
+      const result1 = runDeckRecycleSimulation();
+      const result2 = runDeckRecycleSimulation();
+
+      expect(result1).toEqual(result2);
+      expect(result1.deck.length).toBe(12); // 15 recycled - 3 drawn = 12
+      expect(result1.discardPile.length).toBe(0);
+      expect(
+        result1.log.some((entry) => entry.eventKey === "recycle_discard_into_deck"),
+      ).toBe(true);
+    });
+
+    it("produces differing trajectories when given different initial seeds", () => {
+      const actions: GameAction[] = [
+        {
+          type: "PASS_ACTION",
+          playerId: "player_1",
+        },
+        {
+          type: "PASS_ACTION",
+          playerId: "player_2",
+        },
+      ];
+
+      function executeTrajectory(seed: number): GameState {
+        const shuffle = createSeededShuffle(seed);
+        let state = createInitialGame({
+          gameId: `diff_sim_${seed}`,
+          shuffle,
+          characterIds: ["caustic_soda_captain", "acid_king"],
+        });
+
+        for (const action of actions) {
+          state = engineReducer(state, action, shuffle);
+        }
+
+        return state;
+      }
+
+      const stateA = executeTrajectory(1111);
+      const stateB = executeTrajectory(2222);
+
+      // Both are valid games, but player hands and decks are different due to different seeds
+      expect(stateA.deck).not.toEqual(stateB.deck);
+      expect(stateA.players[0].hand).not.toEqual(stateB.players[0].hand);
+      expect(stateA.players[1].hand).not.toEqual(stateB.players[1].hand);
+    });
+
+    it("preserves state immutability when shuffle is passed to engineReducer", () => {
+      const shuffle = createSeededShuffle(777);
+      const initial = createInitialGame({
+        gameId: "immutability_test",
+        shuffle,
+        characterIds: ["caustic_soda_captain", "acid_king"],
+      });
+      const initialSnapshot = JSON.stringify(initial);
+
+      const next = engineReducer(
+        initial,
+        {
+          type: "PASS_ACTION",
+          playerId: "player_1",
+        },
+        shuffle,
+      );
+
+      expect(JSON.stringify(initial)).toBe(initialSnapshot);
+      expect(next).not.toBe(initial);
+      expect(next.activePlayerId).toBe("player_2");
+    });
+
+    it("replays full multi-cycle combat and response flow with bit-identical fidelity", () => {
+      const seed = 987654321;
+
+      function simulateCombatGame(): GameState {
+        const shuffle = createSeededShuffle(seed);
+        let state = createInitialGame({
+          gameId: "combat_sim",
+          shuffle,
+          characterIds: ["chemistry_enthusiast", "sulfuric_acid_factory_director"],
+        });
+
+        // 3 cycles with passing and skills
+        for (let cycle = 0; cycle < 3; cycle += 1) {
+          for (let round = 0; round < 3; round += 1) {
+            // Player 1 turn
+            if (state.phase === "mainAction" && state.activePlayerId === "player_1") {
+              state = engineReducer(state, { type: "PASS_ACTION", playerId: "player_1" }, shuffle);
+            }
+            // Player 2 turn
+            if (state.phase === "mainAction" && state.activePlayerId === "player_2") {
+              // Try activating exhaust_discharge if available, otherwise pass
+              const skillAction: GameAction = {
+                type: "ACTIVATE_CHARACTER_SKILL",
+                playerId: "player_2",
+                skillId: "exhaust_discharge",
+                targetPlayerId: "player_1",
+              };
+              const afterSkill = engineReducer(state, skillAction, shuffle);
+              if (afterSkill !== state) {
+                state = afterSkill;
+              } else {
+                state = engineReducer(state, { type: "PASS_ACTION", playerId: "player_2" }, shuffle);
+              }
+            }
+          }
+        }
+
+        return state;
+      }
+
+      const matchA = simulateCombatGame();
+      const matchB = simulateCombatGame();
+
+      expect(matchA).toEqual(matchB);
+      expect(JSON.stringify(matchA)).toBe(JSON.stringify(matchB));
+      expect(matchA.cycleNumber).toBe(matchB.cycleNumber);
+      expect(matchA.roundInCycle).toBe(matchB.roundInCycle);
+      expect(matchA.log).toEqual(matchB.log);
+    });
+  });
+});
+

--- a/src/game/tests/random.test.ts
+++ b/src/game/tests/random.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  createFisherYatesShuffle,
+  createMulberry32,
+  createSeededShuffle,
+  fisherYatesShuffle,
+  identityShuffle,
+} from "../../shared/random";
+
+describe("shared/random", () => {
+  describe("createMulberry32", () => {
+    it("produces deterministic sequences for identical seeds", () => {
+      const prng1 = createMulberry32(42);
+      const prng2 = createMulberry32(42);
+
+      const seq1 = Array.from({ length: 100 }, () => prng1());
+      const seq2 = Array.from({ length: 100 }, () => prng2());
+
+      expect(seq1).toEqual(seq2);
+    });
+
+    it("produces different sequences for different seeds", () => {
+      const prng1 = createMulberry32(42);
+      const prng2 = createMulberry32(43);
+
+      const seq1 = Array.from({ length: 10 }, () => prng1());
+      const seq2 = Array.from({ length: 10 }, () => prng2());
+
+      expect(seq1).not.toEqual(seq2);
+    });
+
+    it("outputs numbers in the [0, 1) range", () => {
+      const prng = createMulberry32(123456789);
+
+      for (let i = 0; i < 1000; i += 1) {
+        const val = prng();
+        expect(val).toBeGreaterThanOrEqual(0);
+        expect(val).toBeLessThan(1);
+      }
+    });
+
+    it("handles boundary seeds safely (0, negative, large 32-bit values)", () => {
+      const prngZero = createMulberry32(0);
+      const prngNegative = createMulberry32(-1);
+      const prngMaxUint = createMulberry32(0xffffffff);
+
+      expect(prngZero()).toBeGreaterThanOrEqual(0);
+      expect(prngNegative()).toBeGreaterThanOrEqual(0);
+      expect(prngMaxUint()).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("identityShuffle", () => {
+    it("returns a shallow copy of items without reordering", () => {
+      const items = [1, 2, 3, 4, 5];
+      const result = identityShuffle(items);
+
+      expect(result).toEqual(items);
+      expect(result).not.toBe(items);
+    });
+  });
+
+  describe("createFisherYatesShuffle & createSeededShuffle", () => {
+    it("produces identical shuffles given identical seeds", () => {
+      const shuffleA = createSeededShuffle(20260821);
+      const shuffleB = createSeededShuffle(20260821);
+
+      const items = ["a", "b", "c", "d", "e", "f", "g", "h"];
+      const resultA1 = shuffleA(items);
+      const resultB1 = shuffleB(items);
+
+      expect(resultA1).toEqual(resultB1);
+
+      const resultA2 = shuffleA(items);
+      const resultB2 = shuffleB(items);
+
+      expect(resultA2).toEqual(resultB2);
+    });
+
+    it("produces permutations containing the exact original items", () => {
+      const shuffle = createSeededShuffle(999);
+      const items = [10, 20, 30, 40, 50];
+      const result = shuffle(items);
+
+      expect(result.length).toBe(items.length);
+      expect([...result].sort((a, b) => a - b)).toEqual(items);
+    });
+
+    it("accepts a custom RandomSource function in createFisherYatesShuffle", () => {
+      let counter = 0;
+      const fakeRng = () => {
+        counter += 0.1;
+        return counter % 1;
+      };
+      const shuffle = createFisherYatesShuffle(fakeRng);
+      const items = [1, 2, 3, 4];
+      const result = shuffle(items);
+
+      expect(result.length).toBe(4);
+    });
+
+    it("fisherYatesShuffle uses Math.random by default when no random is passed", () => {
+      const items = [1, 2, 3, 4, 5];
+      const result = fisherYatesShuffle(items);
+
+      expect(result.length).toBe(items.length);
+      expect([...result].sort((a, b) => a - b)).toEqual(items);
+    });
+  });
+});

--- a/src/shared/random.ts
+++ b/src/shared/random.ts
@@ -1,8 +1,32 @@
+export type RandomSource = () => number;
+export type ShuffleFunction = <T>(items: readonly T[]) => T[];
+
+export function createMulberry32(seed: number): RandomSource {
+  let state = seed >>> 0;
+  return function mulberry32(): number {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function createFisherYatesShuffle(random: RandomSource): ShuffleFunction {
+  return function seededFisherYatesShuffle<T>(items: readonly T[]): T[] {
+    return fisherYatesShuffle(items, random);
+  };
+}
+
+export function createSeededShuffle(seed: number | RandomSource): ShuffleFunction {
+  const random = typeof seed === "function" ? seed : createMulberry32(seed);
+  return createFisherYatesShuffle(random);
+}
+
 export function identityShuffle<T>(items: readonly T[]): T[] {
   return [...items];
 }
 
-export function fisherYatesShuffle<T>(items: readonly T[], random = Math.random): T[] {
+export function fisherYatesShuffle<T>(items: readonly T[], random: RandomSource = Math.random): T[] {
   const shuffled = [...items];
 
   for (let index = shuffled.length - 1; index > 0; index -= 1) {
@@ -12,3 +36,4 @@ export function fisherYatesShuffle<T>(items: readonly T[], random = Math.random)
 
   return shuffled;
 }
+


### PR DESCRIPTION
## Summary

Phase 19B implements the deterministic simulation infrastructure required by `docs/PHASE19_NATBA_FOUNDATION_FREEZE.md` §12–13.

### Key Changes

1. **Seeded PRNG (`src/shared/random.ts`)**
   - Lightweight Mulberry32 implementation (`createMulberry32`)
   - Deterministic shuffle factories: `createFisherYatesShuffle`, `createSeededShuffle`
   - Full backward compatibility with existing `fisherYatesShuffle(items, random = Math.random)` and `identityShuffle`

2. **Seed injection into game creation (`src/game/engine/createInitialGame.ts`)**
   - `CreateInitialGameOptions` now accepts optional `seed?: number`
   - When `seed` is provided and no explicit `shuffle` is given, uses `createSeededShuffle(seed)`

3. **Reducer shuffle dependency injection (`src/game/engine/reducer.ts`)**
   - `engineReducer(state, action, shuffle = fisherYatesShuffle)` — third parameter injected through all internal action paths

4. **Deterministic replay test suite**
   - `src/game/tests/random.test.ts` — Mulberry32 correctness & distribution
   - `src/game/tests/deterministicSimulation.test.ts` — bit-identical state + log under same seed + action sequence, including discard-to-deck recycle paths

### Verification

| Check | Result |
| :--- | :--- |
| `pnpm run test:run` | 50 files / 716 tests ✅ |
| `pnpm run test:shuffle` | 50 files / 716 tests ✅ |
| `pnpm run build` | ✅ |
| `pnpm run check:size` | 101,295 B gzip (< 102,400) ✅ |
| `pnpm run check:production` | ✅ |
| `pnpm run check:tracked-clean` | ✅ |

### Notes
- Zero gameplay / balance / rule changes
- Default (no-seed) path remains non-deterministic and behavior-compatible with production
- Rules version remains `MVP0-P10`