### PR TITLE
feat: Phase 19C NATBA-0 Random Legal Bot & self-play runner

### DIFF
--- a/src/game/natba/index.ts
+++ b/src/game/natba/index.ts
@@ -1,0 +1,15 @@
+export { natba0RandomLegalPolicy } from "./natba0Policy";
+export {
+  allDefaultCharacterIds,
+  runBatchSelfPlay,
+  runSelfPlayGame,
+} from "./selfPlayRunner";
+export type {
+  BatchSelfPlayOptions,
+  CharacterMatchupRecord,
+  CharacterStatsRecord,
+  NATBAPolicy,
+  SelfPlayBatchSummary,
+  SelfPlayGameResult,
+  SelfPlayOptions,
+} from "./types";

--- a/src/game/natba/natba0Policy.ts
+++ b/src/game/natba/natba0Policy.ts
@@ -1,0 +1,42 @@
+import type { RandomSource } from "../../shared/random";
+import type { GameAction } from "../engine/actions";
+import type { AIObservation } from "../engine/aiObservation";
+import type { DecisionContext } from "../engine/decisionContext";
+import type { NATBAPolicy } from "./types";
+
+export const natba0RandomLegalPolicy: NATBAPolicy = (
+  _observation: AIObservation,
+  context: DecisionContext,
+  random: RandomSource = Math.random,
+): GameAction | undefined => {
+  if (context.kind === "finite-actions") {
+    if (context.legalActions.length === 0) {
+      return undefined;
+    }
+    const selectedIndex = Math.floor(random() * context.legalActions.length);
+    const clampedIndex = Math.min(
+      Math.max(0, selectedIndex),
+      context.legalActions.length - 1,
+    );
+    return context.legalActions[clampedIndex];
+  }
+
+  if (context.kind === "laboratory-preparation") {
+    const candidates = [...context.candidateCardInstanceIds];
+    for (let index = candidates.length - 1; index > 0; index -= 1) {
+      const swapIndex = Math.floor(random() * (index + 1));
+      [candidates[index], candidates[swapIndex]] = [
+        candidates[swapIndex],
+        candidates[index],
+      ];
+    }
+    const keptCardInstanceIds = candidates.slice(0, context.keepCount);
+    return {
+      type: "CONFIRM_LABORATORY_PREPARATION",
+      playerId: context.playerId,
+      keptCardInstanceIds,
+    };
+  }
+
+  return undefined;
+};

--- a/src/game/natba/selfPlayRunner.ts
+++ b/src/game/natba/selfPlayRunner.ts
@@ -1,0 +1,302 @@
+import {
+  createFisherYatesShuffle,
+  createMulberry32,
+  type RandomSource,
+  type ShuffleFunction,
+} from "../../shared/random";
+import type { GameAction } from "../engine/actions";
+import { getAIObservation } from "../engine/aiObservation";
+import { createInitialGame } from "../engine/createInitialGame";
+import { getDecisionContext } from "../engine/decisionContext";
+import { engineReducer } from "../engine/reducer";
+import type { CharacterId, GameState } from "../engine/types";
+import { natba0RandomLegalPolicy } from "./natba0Policy";
+import type {
+  BatchSelfPlayOptions,
+  CharacterMatchupRecord,
+  CharacterStatsRecord,
+  NATBAPolicy,
+  SelfPlayBatchSummary,
+  SelfPlayGameResult,
+  SelfPlayOptions,
+} from "./types";
+
+export const allDefaultCharacterIds: readonly CharacterId[] = [
+  "laboratory_teacher",
+  "chemical_factory_ceo",
+  "clumsy_party_secretary",
+  "caustic_soda_captain",
+  "acid_king",
+  "chemistry_enthusiast",
+  "sulfuric_acid_factory_director",
+];
+
+export function runSelfPlayGame(options: SelfPlayOptions = {}): SelfPlayGameResult {
+  const {
+    gameId = `self_play_${options.seed ?? Math.floor(Math.random() * 1000000)}`,
+    seed,
+    characterIds = ["laboratory_teacher", "chemical_factory_ceo"],
+    policyPlayer1 = natba0RandomLegalPolicy,
+    policyPlayer2 = natba0RandomLegalPolicy,
+    maxSteps = 1000,
+  } = options;
+
+  let shuffle: ShuffleFunction | undefined = undefined;
+  let decisionRandom: RandomSource = Math.random;
+
+  if (seed !== undefined) {
+    const shufflePrng = createMulberry32((seed ^ 0xa5a5a5a5) >>> 0);
+    shuffle = createFisherYatesShuffle(shufflePrng);
+    decisionRandom = createMulberry32((seed ^ 0x5a5a5a5a) >>> 0);
+  }
+
+  let state: GameState = createInitialGame({
+    gameId,
+    seed,
+    shuffle,
+    characterIds: [characterIds[0], characterIds[1]],
+  });
+
+  const actionLog: GameAction[] = [];
+  let illegalActionAttempts = 0;
+  let deadlocked = false;
+  let steps = 0;
+
+  while (steps < maxSteps && state.phase !== "gameOver") {
+    const context = getDecisionContext(state);
+    if (context.kind === "game-over") {
+      break;
+    }
+
+    if (context.kind === "none") {
+      deadlocked = true;
+      break;
+    }
+
+    const decisionPlayerId = context.playerId;
+    const observation = getAIObservation(state, decisionPlayerId);
+    const isPlayer1 = decisionPlayerId === state.players[0]?.id;
+    const activePolicy: NATBAPolicy = isPlayer1 ? policyPlayer1 : policyPlayer2;
+
+    const action = activePolicy(observation, context, decisionRandom);
+    if (!action) {
+      deadlocked = true;
+      break;
+    }
+
+    actionLog.push(action);
+    const nextState = engineReducer(state, action, shuffle);
+
+    if (nextState === state) {
+      illegalActionAttempts += 1;
+      deadlocked = true;
+      break;
+    }
+
+    state = nextState;
+    steps += 1;
+  }
+
+  if (steps >= maxSteps && state.phase !== "gameOver") {
+    deadlocked = true;
+  }
+
+  const completed =
+    state.phase === "gameOver" && !deadlocked && illegalActionAttempts === 0;
+
+  return {
+    gameId: state.id,
+    winnerPlayerId: state.winnerPlayerId,
+    isDraw: state.isDraw,
+    totalSteps: steps,
+    cycles: state.cycleNumber,
+    rounds: state.roundInCycle,
+    actionLog,
+    finalState: state,
+    completed,
+    illegalActionAttempts,
+    deadlocked,
+    characterPlayer1: characterIds[0],
+    characterPlayer2: characterIds[1],
+  };
+}
+
+function buildDefaultCharacterPairs(): [CharacterId, CharacterId][] {
+  const pairs: [CharacterId, CharacterId][] = [];
+  for (const charA of allDefaultCharacterIds) {
+    for (const charB of allDefaultCharacterIds) {
+      pairs.push([charA, charB]);
+    }
+  }
+  return pairs;
+}
+
+function createInitialCharacterStats(): Record<CharacterId, CharacterStatsRecord> {
+  const stats = {} as Record<CharacterId, CharacterStatsRecord>;
+  for (const charId of allDefaultCharacterIds) {
+    stats[charId] = { matches: 0, wins: 0, winRate: 0 };
+  }
+  return stats;
+}
+
+function createInitialMatchupMatrix(): Record<
+  CharacterId,
+  Record<CharacterId, CharacterMatchupRecord>
+> {
+  const matrix = {} as Record<
+    CharacterId,
+    Record<CharacterId, CharacterMatchupRecord>
+  >;
+  for (const charA of allDefaultCharacterIds) {
+    matrix[charA] = {} as Record<CharacterId, CharacterMatchupRecord>;
+    for (const charB of allDefaultCharacterIds) {
+      matrix[charA][charB] = { matches: 0, winsP1: 0, winsP2: 0, draws: 0 };
+    }
+  }
+  return matrix;
+}
+
+export function runBatchSelfPlay(
+  options: BatchSelfPlayOptions,
+): SelfPlayBatchSummary {
+  const {
+    gameCount,
+    baseSeed = 20260821,
+    characterPairs,
+    policyPlayer1 = natba0RandomLegalPolicy,
+    policyPlayer2 = natba0RandomLegalPolicy,
+    maxStepsPerGame = 1000,
+  } = options;
+
+  const pairs =
+    characterPairs && characterPairs.length > 0
+      ? characterPairs
+      : buildDefaultCharacterPairs();
+
+  let winsPlayer1 = 0;
+  let winsPlayer2 = 0;
+  let draws = 0;
+  let totalStepsSum = 0;
+  let minSteps = Number.POSITIVE_INFINITY;
+  let maxSteps = 0;
+  let totalCyclesSum = 0;
+  let totalRoundsSum = 0;
+  let totalIllegalActionAttempts = 0;
+  let totalDeadlocks = 0;
+
+  const actionTypeCounts: Record<string, number> = {};
+  const phasesVisited: Record<string, number> = {};
+
+  const characterStats = createInitialCharacterStats();
+  const matchupMatrix = createInitialMatchupMatrix();
+
+  for (let index = 0; index < gameCount; index += 1) {
+    const pair = pairs[index % pairs.length];
+    const char1 = pair[0];
+    const char2 = pair[1];
+    const seed =
+      baseSeed !== undefined
+        ? (baseSeed + index * 1013) >>> 0
+        : undefined;
+
+    const result = runSelfPlayGame({
+      gameId: `batch_game_${index + 1}`,
+      seed,
+      characterIds: [char1, char2],
+      policyPlayer1,
+      policyPlayer2,
+      maxSteps: maxStepsPerGame,
+    });
+
+    totalStepsSum += result.totalSteps;
+    if (result.totalSteps < minSteps) {
+      minSteps = result.totalSteps;
+    }
+    if (result.totalSteps > maxSteps) {
+      maxSteps = result.totalSteps;
+    }
+    totalCyclesSum += result.cycles;
+    totalRoundsSum += result.rounds;
+    totalIllegalActionAttempts += result.illegalActionAttempts;
+    if (result.deadlocked) {
+      totalDeadlocks += 1;
+    }
+
+    for (const action of result.actionLog) {
+      actionTypeCounts[action.type] = (actionTypeCounts[action.type] ?? 0) + 1;
+    }
+
+    if (!matchupMatrix[char1]) {
+      matchupMatrix[char1] = {} as Record<CharacterId, CharacterMatchupRecord>;
+    }
+    if (!matchupMatrix[char1][char2]) {
+      matchupMatrix[char1][char2] = { matches: 0, winsP1: 0, winsP2: 0, draws: 0 };
+    }
+    const matchup = matchupMatrix[char1][char2];
+    matchup.matches += 1;
+
+    if (!characterStats[char1]) {
+      characterStats[char1] = { matches: 0, wins: 0, winRate: 0 };
+    }
+    if (!characterStats[char2]) {
+      characterStats[char2] = { matches: 0, wins: 0, winRate: 0 };
+    }
+    characterStats[char1].matches += 1;
+    characterStats[char2].matches += 1;
+
+    if (result.isDraw) {
+      draws += 1;
+      matchup.draws += 1;
+    } else if (result.winnerPlayerId === "player_1") {
+      winsPlayer1 += 1;
+      matchup.winsP1 += 1;
+      characterStats[char1].wins += 1;
+    } else if (result.winnerPlayerId === "player_2") {
+      winsPlayer2 += 1;
+      matchup.winsP2 += 1;
+      characterStats[char2].wins += 1;
+    }
+
+    for (const logEntry of result.finalState.log) {
+      if (
+        logEntry.params &&
+        typeof logEntry.params === "object" &&
+        "phase" in logEntry.params
+      ) {
+        const phaseValue = (logEntry.params as { phase?: unknown }).phase;
+        if (phaseValue !== undefined) {
+          const phaseName = String(phaseValue);
+          phasesVisited[phaseName] = (phasesVisited[phaseName] ?? 0) + 1;
+        }
+      }
+    }
+  }
+
+  for (const charId of Object.keys(characterStats) as CharacterId[]) {
+    const stat = characterStats[charId];
+    if (stat && stat.matches > 0) {
+      stat.winRate = Number((stat.wins / stat.matches).toFixed(4));
+    }
+  }
+
+  return {
+    totalGames: gameCount,
+    winsPlayer1,
+    winsPlayer2,
+    draws,
+    firstPlayerWinRate: Number((winsPlayer1 / gameCount).toFixed(4)),
+    secondPlayerWinRate: Number((winsPlayer2 / gameCount).toFixed(4)),
+    drawRate: Number((draws / gameCount).toFixed(4)),
+    characterStats,
+    matchupMatrix,
+    averageSteps: Number((totalStepsSum / gameCount).toFixed(2)),
+    minSteps: minSteps === Number.POSITIVE_INFINITY ? 0 : minSteps,
+    maxSteps,
+    averageCycles: Number((totalCyclesSum / gameCount).toFixed(2)),
+    averageRounds: Number((totalRoundsSum / gameCount).toFixed(2)),
+    actionTypeCounts,
+    phasesVisited,
+    totalIllegalActionAttempts,
+    totalDeadlocks,
+  };
+}

--- a/src/game/natba/types.ts
+++ b/src/game/natba/types.ts
@@ -1,0 +1,79 @@
+import type { RandomSource } from "../../shared/random";
+import type { GameAction } from "../engine/actions";
+import type { AIObservation } from "../engine/aiObservation";
+import type { DecisionContext } from "../engine/decisionContext";
+import type { CharacterId, GameState, PlayerId } from "../engine/types";
+
+export type NATBAPolicy = (
+  observation: AIObservation,
+  context: DecisionContext,
+  random: RandomSource,
+) => GameAction | undefined;
+
+export type SelfPlayOptions = {
+  readonly gameId?: string;
+  readonly seed?: number;
+  readonly characterIds?: readonly [CharacterId, CharacterId];
+  readonly policyPlayer1?: NATBAPolicy;
+  readonly policyPlayer2?: NATBAPolicy;
+  readonly maxSteps?: number;
+};
+
+export type SelfPlayGameResult = {
+  readonly gameId: string;
+  readonly winnerPlayerId?: PlayerId;
+  readonly isDraw?: boolean;
+  readonly totalSteps: number;
+  readonly cycles: number;
+  readonly rounds: number;
+  readonly actionLog: readonly GameAction[];
+  readonly finalState: GameState;
+  readonly completed: boolean;
+  readonly illegalActionAttempts: number;
+  readonly deadlocked: boolean;
+  readonly characterPlayer1: CharacterId;
+  readonly characterPlayer2: CharacterId;
+};
+
+export type BatchSelfPlayOptions = {
+  readonly gameCount: number;
+  readonly baseSeed?: number;
+  readonly characterPairs?: readonly (readonly [CharacterId, CharacterId])[];
+  readonly policyPlayer1?: NATBAPolicy;
+  readonly policyPlayer2?: NATBAPolicy;
+  readonly maxStepsPerGame?: number;
+};
+
+export type CharacterMatchupRecord = {
+  matches: number;
+  winsP1: number;
+  winsP2: number;
+  draws: number;
+};
+
+export type CharacterStatsRecord = {
+  matches: number;
+  wins: number;
+  winRate: number;
+};
+
+export type SelfPlayBatchSummary = {
+  readonly totalGames: number;
+  readonly winsPlayer1: number;
+  readonly winsPlayer2: number;
+  readonly draws: number;
+  readonly firstPlayerWinRate: number;
+  readonly secondPlayerWinRate: number;
+  readonly drawRate: number;
+  readonly characterStats: Record<CharacterId, CharacterStatsRecord>;
+  readonly matchupMatrix: Record<CharacterId, Record<CharacterId, CharacterMatchupRecord>>;
+  readonly averageSteps: number;
+  readonly minSteps: number;
+  readonly maxSteps: number;
+  readonly averageCycles: number;
+  readonly averageRounds: number;
+  readonly actionTypeCounts: Record<string, number>;
+  readonly phasesVisited: Record<string, number>;
+  readonly totalIllegalActionAttempts: number;
+  readonly totalDeadlocks: number;
+};

--- a/src/game/tests/natba0Policy.test.ts
+++ b/src/game/tests/natba0Policy.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from "vitest";
+import { identityShuffle, createMulberry32 } from "../../shared/random";
+import type { GameAction } from "../engine/actions";
+import { getAIObservation } from "../engine/aiObservation";
+import { createInitialGame } from "../engine/createInitialGame";
+import { getDecisionContext } from "../engine/decisionContext";
+import { validateGameAction } from "../engine/legalActions";
+import { engineReducer } from "../engine/reducer";
+import type { GameState } from "../engine/types";
+import { natba0RandomLegalPolicy } from "../natba/natba0Policy";
+
+function confirmPreparation(state: GameState): GameState {
+  const pending = state.pendingLaboratoryPreparation;
+  if (!pending) {
+    return state;
+  }
+  return engineReducer(state, {
+    type: "CONFIRM_LABORATORY_PREPARATION",
+    playerId: pending.playerId,
+    keptCardInstanceIds: pending.candidateCardInstanceIds.slice(0, 10),
+  });
+}
+
+function createReadyMainGameState(): GameState {
+  const state = createInitialGame({
+    characterIds: ["caustic_soda_captain", "acid_king"],
+    shuffle: identityShuffle,
+  });
+  return confirmPreparation(state);
+}
+
+describe("Phase 19C — NATBA-0 Random Legal Policy", () => {
+  it("returns undefined when decision context is none or game-over", () => {
+    const dummyState = createReadyMainGameState();
+    const observation = getAIObservation(dummyState, "player_1");
+
+    expect(
+      natba0RandomLegalPolicy(observation, { kind: "none" }, Math.random),
+    ).toBeUndefined();
+    expect(
+      natba0RandomLegalPolicy(
+        observation,
+        { kind: "game-over", winnerPlayerId: "player_1" },
+        Math.random,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("selects a strictly legal action from finite-actions decision context in mainAction", () => {
+    const state = createReadyMainGameState();
+    const context = getDecisionContext(state);
+    expect(context.kind).toBe("finite-actions");
+    if (context.kind !== "finite-actions") return;
+
+    const observation = getAIObservation(state, context.playerId);
+    const prng = createMulberry32(12345);
+
+    // Call policy 50 times with PRNG and verify every chosen action is in legalActions and validated by engine
+    for (let i = 0; i < 50; i += 1) {
+      const action = natba0RandomLegalPolicy(observation, context, prng);
+      expect(action).toBeDefined();
+      if (!action) return;
+
+      expect(context.legalActions).toContainEqual(action);
+      expect(validateGameAction(state, action)).toBe(true);
+      expect(action.type).not.toBe("START_ACTIVE_DIY");
+    }
+  });
+
+  it("selects exactly 10 distinct candidate cards in laboratory-preparation context", () => {
+    const state = createInitialGame({
+      gameId: "test_prep",
+      characterIds: ["laboratory_teacher", "chemical_factory_ceo"],
+      shuffle: identityShuffle,
+    });
+    const context = getDecisionContext(state);
+    expect(context.kind).toBe("laboratory-preparation");
+    if (context.kind !== "laboratory-preparation") return;
+
+    const observation = getAIObservation(state, context.playerId);
+    const prng = createMulberry32(67890);
+
+    for (let i = 0; i < 20; i += 1) {
+      const action = natba0RandomLegalPolicy(observation, context, prng);
+      expect(action).toBeDefined();
+      if (!action) return;
+
+      expect(action.type).toBe("CONFIRM_LABORATORY_PREPARATION");
+      if (action.type !== "CONFIRM_LABORATORY_PREPARATION") return;
+
+      expect(action.playerId).toBe(context.playerId);
+      expect(action.keptCardInstanceIds).toHaveLength(10);
+      const uniqueKept = new Set(action.keptCardInstanceIds);
+      expect(uniqueKept.size).toBe(10);
+      for (const cardId of action.keptCardInstanceIds) {
+        expect(context.candidateCardInstanceIds).toContain(cardId);
+      }
+      expect(validateGameAction(state, action)).toBe(true);
+    }
+  });
+
+  it("selects a legal response in responseWindow", () => {
+    let state = createReadyMainGameState();
+    const p1 = state.players[0];
+    const p2 = state.players[1];
+
+    const hclCardId = Object.keys(state.cardInstances).find(
+      (id) => state.cardInstances[id].definitionId === "substance_hcl_dilute",
+    )!;
+    const naohCardId = Object.keys(state.cardInstances).find(
+      (id) => state.cardInstances[id].definitionId === "substance_naoh_dilute",
+    )!;
+
+    state = {
+      ...state,
+      tableReference: undefined,
+      cardInstances: {
+        ...state.cardInstances,
+        [hclCardId]: {
+          ...state.cardInstances[hclCardId],
+          ownerId: p1.id,
+          zone: { type: "hand", playerId: p1.id },
+        },
+        [naohCardId]: {
+          ...state.cardInstances[naohCardId],
+          ownerId: p2.id,
+          zone: { type: "hand", playerId: p2.id },
+        },
+      },
+      players: [
+        { ...p1, hand: [hclCardId] },
+        { ...p2, hand: [naohCardId] },
+      ],
+    };
+
+    // p1 attacks p2 with HCl to create formal responseWindow
+    const responseState = engineReducer(state, {
+      type: "PLAY_CARD",
+      playerId: p1.id,
+      cardInstanceId: hclCardId,
+      targetPlayerId: p2.id,
+    });
+
+    expect(responseState.phase).toBe("responseWindow");
+    const context = getDecisionContext(responseState);
+    expect(context.kind).toBe("finite-actions");
+    if (context.kind !== "finite-actions") return;
+
+    const observation = getAIObservation(responseState, p2.id);
+    const prng = createMulberry32(445566);
+
+    for (let i = 0; i < 20; i += 1) {
+      const action = natba0RandomLegalPolicy(observation, context, prng);
+      expect(action).toBeDefined();
+      if (!action) return;
+
+      expect(context.legalActions).toContainEqual(action);
+      expect(validateGameAction(responseState, action)).toBe(true);
+      expect(
+        action.type === "RESPOND_WITH_CARD" || action.type === "PASS_RESPONSE",
+      ).toBe(true);
+    }
+  });
+
+  it("selects a legal status handling in statusWindow", () => {
+    let state = createReadyMainGameState();
+    const p1 = state.players[0];
+    const fireStatus = {
+      id: "status_fire_01",
+      statusId: "FIRE" as const,
+      sourcePlayerId: p1.id,
+      createdAt: 1,
+    };
+
+    const statusState: GameState = {
+      ...state,
+      phase: "statusWindow",
+      activePlayerId: p1.id,
+      players: [{ ...p1, statuses: [fireStatus] }, state.players[1]],
+      pendingStatusHandling: {
+        playerId: p1.id,
+        statusInstanceId: fireStatus.id,
+      },
+    };
+
+    const context = getDecisionContext(statusState);
+    expect(context.kind).toBe("finite-actions");
+    if (context.kind !== "finite-actions") return;
+
+    const observation = getAIObservation(statusState, p1.id);
+    const prng = createMulberry32(778899);
+
+    for (let i = 0; i < 20; i += 1) {
+      const action = natba0RandomLegalPolicy(observation, context, prng);
+      expect(action).toBeDefined();
+      if (!action) return;
+
+      expect(context.legalActions).toContainEqual(action);
+      expect(validateGameAction(statusState, action)).toBe(true);
+      expect(
+        action.type === "HANDLE_STATUS_WITH_CARD" ||
+          action.type === "PASS_STATUS_HANDLING",
+      ).toBe(true);
+    }
+  });
+
+  it("selects a legal counterattack in experimentCounterattackWindow and never generates metal-counterattack", () => {
+    let state = createReadyMainGameState();
+    const responder = {
+      ...state.players[0],
+      characterId: "chemistry_enthusiast" as const,
+      hp: 10,
+      maxHp: 15,
+    };
+    const attacker = state.players[1];
+
+    const counterState: GameState = {
+      ...state,
+      phase: "experimentCounterattackWindow",
+      players: [responder, attacker],
+      pendingExperimentCounterattack: {
+        responderPlayerId: responder.id,
+        attackerPlayerId: attacker.id,
+        originalDamageContext: {
+          targetPlayerId: responder.id,
+          baseAmount: 1,
+          source: {
+            kind: "card",
+            sourcePlayerId: attacker.id,
+            cardInstanceId: "card_attack_01",
+            cardDefinitionId: "substance_hcl_dilute",
+          },
+          tags: ["acid"],
+          responsePolicy: "acid-base",
+        },
+        responseType: "acid-base",
+        legalOptions: ["recover"],
+        legalMetalCardInstanceIds: [],
+        legalPursuitCardInstanceIds: [],
+        continuation: { kind: "single-response" },
+      },
+    };
+
+    const context = getDecisionContext(counterState);
+    expect(context.kind).toBe("finite-actions");
+    if (context.kind !== "finite-actions") return;
+
+    const observation = getAIObservation(counterState, responder.id);
+    const prng = createMulberry32(990011);
+
+    for (let i = 0; i < 20; i += 1) {
+      const action = natba0RandomLegalPolicy(observation, context, prng);
+      expect(action).toBeDefined();
+      if (!action) return;
+
+      expect(context.legalActions).toContainEqual(action);
+      expect(validateGameAction(counterState, action)).toBe(true);
+      expect(action.type).toBe("RESOLVE_EXPERIMENT_COUNTERATTACK");
+      if (action.type === "RESOLVE_EXPERIMENT_COUNTERATTACK") {
+        expect((action as any).option).not.toBe("metal-counterattack");
+      }
+    }
+  });
+
+  it("produces deterministic decision sequences given the same PRNG seed", () => {
+    const state = createReadyMainGameState();
+    const context = getDecisionContext(state);
+    const observation = getAIObservation(state, "player_1");
+
+    const runA = () => {
+      const prng = createMulberry32(424242);
+      const actions: (GameAction | undefined)[] = [];
+      for (let i = 0; i < 10; i += 1) {
+        actions.push(natba0RandomLegalPolicy(observation, context, prng));
+      }
+      return actions;
+    };
+
+    const actions1 = runA();
+    const actions2 = runA();
+
+    expect(actions1).toEqual(actions2);
+  });
+});

--- a/src/game/tests/natbaSelfPlay.test.ts
+++ b/src/game/tests/natbaSelfPlay.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  allDefaultCharacterIds,
+  runBatchSelfPlay,
+  runSelfPlayGame,
+} from "../natba";
+
+describe("Phase 19C — NATBA-0 Self-Play & Deterministic Replay", () => {
+  it("replays full AI vs AI game deterministically with bit-identical final states and logs", () => {
+    const seed = 987654321;
+    const run1 = runSelfPlayGame({
+      gameId: "replay_test",
+      seed,
+      characterIds: ["laboratory_teacher", "chemistry_enthusiast"],
+    });
+
+    const run2 = runSelfPlayGame({
+      gameId: "replay_test",
+      seed,
+      characterIds: ["laboratory_teacher", "chemistry_enthusiast"],
+    });
+
+    expect(run1.completed).toBe(true);
+    expect(run2.completed).toBe(true);
+    expect(run1.deadlocked).toBe(false);
+    expect(run2.deadlocked).toBe(false);
+    expect(run1.illegalActionAttempts).toBe(0);
+    expect(run2.illegalActionAttempts).toBe(0);
+
+    expect(run1.totalSteps).toBe(run2.totalSteps);
+    expect(run1.actionLog).toEqual(run2.actionLog);
+    expect(run1.finalState).toEqual(run2.finalState);
+    expect(JSON.stringify(run1.finalState)).toBe(JSON.stringify(run2.finalState));
+    expect(run1.finalState.log).toEqual(run2.finalState.log);
+  });
+
+  it("completes clean self-play matches across all 7 playable characters with zero illegal actions", () => {
+    // Test matches pairing each character with different opponents
+    const testPairs = [
+      ["laboratory_teacher", "chemical_factory_ceo"] as const,
+      ["clumsy_party_secretary", "caustic_soda_captain"] as const,
+      ["acid_king", "chemistry_enthusiast"] as const,
+      ["sulfuric_acid_factory_director", "laboratory_teacher"] as const,
+      ["caustic_soda_captain", "acid_king"] as const,
+      ["chemistry_enthusiast", "clumsy_party_secretary"] as const,
+      ["chemical_factory_ceo", "sulfuric_acid_factory_director"] as const,
+    ];
+
+    for (let index = 0; index < testPairs.length; index += 1) {
+      const pair = testPairs[index];
+      const result = runSelfPlayGame({
+        gameId: `char_test_${index}`,
+        seed: 1000 + index * 37,
+        characterIds: pair,
+        maxSteps: 1000,
+      });
+
+      expect(result.completed).toBe(true);
+      expect(result.deadlocked).toBe(false);
+      expect(result.illegalActionAttempts).toBe(0);
+      expect(result.totalSteps).toBeGreaterThan(0);
+      expect(result.finalState.phase).toBe("gameOver");
+    }
+  });
+
+  it("runs batch self-play and collects valid telemetry without deadlock or illegal action", () => {
+    const gameCount = 50;
+    const summary = runBatchSelfPlay({
+      gameCount,
+      baseSeed: 20260821,
+      maxStepsPerGame: 1000,
+    });
+
+    expect(summary.totalGames).toBe(gameCount);
+    expect(summary.winsPlayer1 + summary.winsPlayer2 + summary.draws).toBe(
+      gameCount,
+    );
+    expect(
+      Number(
+        (
+          summary.firstPlayerWinRate +
+          summary.secondPlayerWinRate +
+          summary.drawRate
+        ).toFixed(4),
+      ),
+    ).toBe(1);
+
+    expect(summary.totalIllegalActionAttempts).toBe(0);
+    expect(summary.totalDeadlocks).toBe(0);
+    expect(summary.averageSteps).toBeGreaterThan(0);
+    expect(summary.minSteps).toBeGreaterThan(0);
+    expect(summary.maxSteps).toBeGreaterThanOrEqual(summary.minSteps);
+    expect(summary.averageCycles).toBeGreaterThan(0);
+    expect(summary.averageRounds).toBeGreaterThan(0);
+
+    // Verify all character statistics are tracked
+    for (const charId of allDefaultCharacterIds) {
+      const charStat = summary.characterStats[charId];
+      expect(charStat).toBeDefined();
+      expect(charStat.matches).toBeGreaterThanOrEqual(0);
+      expect(charStat.winRate).toBeGreaterThanOrEqual(0);
+      expect(charStat.winRate).toBeLessThanOrEqual(1);
+    }
+
+    // Verify action types include common game actions
+    expect(summary.actionTypeCounts.PASS_ACTION).toBeGreaterThan(0);
+    expect(
+      (summary.actionTypeCounts.PLAY_CARD ?? 0) +
+        (summary.actionTypeCounts.PLAY_REFERENCE_CARD ?? 0) +
+        (summary.actionTypeCounts.PLAY_DIY_SELECTION ?? 0) +
+        (summary.actionTypeCounts.ACTIVATE_CHARACTER_SKILL ?? 0),
+    ).toBeGreaterThan(0);
+
+    // Verify no legacy actions were ever generated
+    expect(summary.actionTypeCounts.START_ACTIVE_DIY).toBeUndefined();
+  });
+
+  it("covers all 5 decision phases across structured self-play scenarios", () => {
+    // 1. preparationSelection: covered when laboratory_teacher is present
+    const prepGame = runSelfPlayGame({
+      seed: 42,
+      characterIds: ["laboratory_teacher", "chemical_factory_ceo"],
+    });
+    expect(
+      prepGame.actionLog.some(
+        (action) => action.type === "CONFIRM_LABORATORY_PREPARATION",
+      ),
+    ).toBe(true);
+
+    // 2. mainAction: universally covered in all games
+    expect(
+      prepGame.actionLog.some((action) => action.type === "PASS_ACTION"),
+    ).toBe(true);
+
+    // 3. statusWindow & responseWindow & experimentCounterattackWindow:
+    // Run batch of matches with chemistry_enthusiast, clumsy_party_secretary and sulfuric_acid_factory_director
+    const tacticalSummary = runBatchSelfPlay({
+      gameCount: 30,
+      baseSeed: 55555,
+      characterPairs: [
+        ["clumsy_party_secretary", "caustic_soda_captain"],
+        ["sulfuric_acid_factory_director", "chemistry_enthusiast"],
+        ["chemistry_enthusiast", "acid_king"],
+        ["laboratory_teacher", "clumsy_party_secretary"],
+      ],
+    });
+
+    expect(tacticalSummary.totalIllegalActionAttempts).toBe(0);
+    expect(tacticalSummary.totalDeadlocks).toBe(0);
+
+    // Verify active actions were generated
+    const hasActiveOrResponseActions =
+      (tacticalSummary.actionTypeCounts.RESPOND_WITH_CARD ?? 0) > 0 ||
+      (tacticalSummary.actionTypeCounts.PASS_RESPONSE ?? 0) > 0 ||
+      (tacticalSummary.actionTypeCounts.HANDLE_STATUS_WITH_CARD ?? 0) > 0 ||
+      (tacticalSummary.actionTypeCounts.PASS_STATUS_HANDLING ?? 0) > 0 ||
+      (tacticalSummary.actionTypeCounts.ACTIVATE_CHARACTER_SKILL ?? 0) > 0 ||
+      (tacticalSummary.actionTypeCounts.RESOLVE_EXPERIMENT_COUNTERATTACK ?? 0) >
+        0;
+
+    expect(hasActiveOrResponseActions).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 19C implements **NATBA-0 Random Legal Bot** per `docs/PHASE19_NATBA_FOUNDATION_FREEZE.md` §16.

### Key Deliverables

1. **NATBA-0 Policy** (`src/game/natba/natba0Policy.ts`)
   - Pure random selection inside Engine-provided legal space only
   - Supports both `finite-actions` and `laboratory-preparation` structured decision spaces
   - Strictly excludes `START_ACTIVE_DIY` and `metal-counterattack`
   - Consumes only fair `AIObservation` (no opponent hand content / future deck order)

2. **Headless Self-Play Runner** (`src/game/natba/selfPlayRunner.ts`)
   - Dual PRNG isolation (Shuffle PRNG + Decision PRNG) for full determinism
   - Illegal-action and deadlock circuit breakers
   - Batch self-play with local-only stats: win/loss/draw, first/second-hand rates, 7-character matchup matrix, action distribution, cycle/round counts

3. **Test Suite**
   - `natba0Policy.test.ts` — all 5 decision windows + exclusion rules + seed determinism
   - `natbaSelfPlay.test.ts` — bit-identical single-game replay, full 7-character matchups, 50-game batch with zero deadlocks / zero illegal actions

### Verification

| Check | Result |
| :--- | :--- |
| `pnpm run test:run` | 52 files / 727 tests ✅ |
| `pnpm run test:shuffle` | 52 files / 727 tests ✅ |
| `pnpm run build` | ✅ |
| `pnpm run check:size` | JS Gzip 101.3 KB (< 102.4 KB) ✅ |
| `pnpm run check:production` | ✅ |

### Notes
- Zero gameplay / balance / rule changes
- Rules version remains `MVP0-P10`
- No UI / human-vs-AI integration (deferred to Phase 19D)
- No heuristic evaluation (deferred to Phase 19E)