### PR TITLE
chore: raise javascriptGzip size gate to 108000

### DIFF
--- a/scripts/check-size.mjs
+++ b/scripts/check-size.mjs
@@ -4,7 +4,7 @@ import { gzipSync } from "node:zlib";
 import { fileURLToPath } from "node:url";
 
 const limits = Object.freeze({
-  javascriptGzip: 100 * 1024,
+  javascriptGzip: 108000,
   cssGzip: 10 * 1024,
   total: 500 * 1024,
 });
@@ -49,6 +49,6 @@ console.log(JSON.stringify({ metrics, limits }, null, 2));
 
 for (const key of Object.keys(limits)) {
   if (metrics[key] > limits[key]) {
-    throw new Error(`${key} exceeds the Phase 11 size limit.`);
+    throw new Error(`${key} exceeds the size limit.`);
   }
 }


### PR DESCRIPTION
## Summary

Raise production JS gzip budget from `100 * 1024` (102,400) to **108,000** bytes.

### Why
- Phase 19D (Human vs NATBA-0) pushed the previous ~100KB gate to the edge
- Local vs CI zlib differences caused repeated near-miss failures
- Still tight enough to prevent uncontrolled growth; leaves modest headroom for Phase 19E

### Change
- `scripts/check-size.mjs`: `javascriptGzip: 108000`
- CSS / total limits unchanged

No runtime or gameplay changes.