### PR TITLE
fix: address Codex audit findings from Phase 19B/19C

### DIFF
--- a/src/game/engine/createInitialGame.ts
+++ b/src/game/engine/createInitialGame.ts
@@ -1,17 +1,32 @@
 import { starterDeck } from "../data/starterDeck";
 import { getCharacterDefinition } from "../data/characterDefinitions";
 import { createSeededShuffle, fisherYatesShuffle, type ShuffleFunction } from "../../shared/random";
+import type { GameAction } from "./actions";
 import type { CardInstance, CharacterId, GameState, Player } from "./types";
 import { createEmptyCharacterUsage } from "./characterUsage";
 import { beginActionForPlayer, dealCycleStartHands } from "./turnFlow";
 import { createLogPresentationContext } from "./logEvents";
+import { engineReducer } from "./reducer";
 
 export type CreateInitialGameOptions = {
   gameId?: string;
   playerNames?: [string, string];
   characterIds?: [CharacterId, CharacterId];
   shuffle?: ShuffleFunction;
+  /**
+   * Seeds only the opening deck shuffle and deal inside `createInitialGame`.
+   * Later `engineReducer(state, action)` calls still default to `Math.random`
+   * unless the same `shuffle` is passed as the third argument, or the caller
+   * uses `createSeededEngine` which binds one shuffle to both operations.
+   */
   seed?: number;
+};
+
+export type SeededEngine = {
+  readonly seed: number;
+  readonly shuffle: ShuffleFunction;
+  createGame(options?: Omit<CreateInitialGameOptions, "seed" | "shuffle">): GameState;
+  reduce(state: GameState, action: GameAction): GameState;
 };
 
 const defaultPlayerNames: [string, string] = ["玩家 A", "玩家 B"];
@@ -105,4 +120,18 @@ export function createInitialGame(options: CreateInitialGameOptions = {}): GameS
   }
 
   return beginActionForPlayer(state, state.startingPlayerId);
+}
+
+export function createSeededEngine(seed: number): SeededEngine {
+  const shuffle = createSeededShuffle(seed);
+  return {
+    seed,
+    shuffle,
+    createGame(options = {}) {
+      return createInitialGame({ ...options, shuffle });
+    },
+    reduce(state, action) {
+      return engineReducer(state, action, shuffle);
+    },
+  };
 }

--- a/src/game/natba/selfPlayRunner.ts
+++ b/src/game/natba/selfPlayRunner.ts
@@ -7,7 +7,7 @@ import {
 import type { GameAction } from "../engine/actions";
 import { getAIObservation } from "../engine/aiObservation";
 import { createInitialGame } from "../engine/createInitialGame";
-import { getDecisionContext } from "../engine/decisionContext";
+import { getDecisionContext, type DecisionContext } from "../engine/decisionContext";
 import { engineReducer } from "../engine/reducer";
 import type { CharacterId, GameState } from "../engine/types";
 import { natba0RandomLegalPolicy } from "./natba0Policy";
@@ -58,6 +58,8 @@ export function runSelfPlayGame(options: SelfPlayOptions = {}): SelfPlayGameResu
   });
 
   const actionLog: GameAction[] = [];
+  const phasesVisited: Record<string, number> = {};
+  const cardDefinitionPlayCounts: Record<string, number> = {};
   let illegalActionAttempts = 0;
   let deadlocked = false;
   let steps = 0;
@@ -73,15 +75,23 @@ export function runSelfPlayGame(options: SelfPlayOptions = {}): SelfPlayGameResu
       break;
     }
 
+    recordVisitedPhase(phasesVisited, context);
+
     const decisionPlayerId = context.playerId;
     const observation = getAIObservation(state, decisionPlayerId);
     const isPlayer1 = decisionPlayerId === state.players[0]?.id;
     const activePolicy: NATBAPolicy = isPlayer1 ? policyPlayer1 : policyPlayer2;
 
     const action = activePolicy(observation, context, decisionRandom);
-    if (!action) {
+    if (!action || !isPolicyActionLegal(context, action)) {
+      illegalActionAttempts += action ? 1 : 0;
       deadlocked = true;
       break;
+    }
+
+    for (const definitionId of collectPlayedCardDefinitionIds(action, state)) {
+      cardDefinitionPlayCounts[definitionId] =
+        (cardDefinitionPlayCounts[definitionId] ?? 0) + 1;
     }
 
     actionLog.push(action);
@@ -110,7 +120,7 @@ export function runSelfPlayGame(options: SelfPlayOptions = {}): SelfPlayGameResu
     isDraw: state.isDraw,
     totalSteps: steps,
     cycles: state.cycleNumber,
-    rounds: state.roundInCycle,
+    rounds: elapsedRounds(state),
     actionLog,
     finalState: state,
     completed,
@@ -118,7 +128,118 @@ export function runSelfPlayGame(options: SelfPlayOptions = {}): SelfPlayGameResu
     deadlocked,
     characterPlayer1: characterIds[0],
     characterPlayer2: characterIds[1],
+    phasesVisited,
+    cardDefinitionPlayCounts,
   };
+}
+
+function elapsedRounds(state: GameState): number {
+  return (state.cycleNumber - 1) * state.settings.roundsPerCycle + state.roundInCycle;
+}
+
+function recordVisitedPhase(
+  phasesVisited: Record<string, number>,
+  context: DecisionContext,
+): void {
+  if (context.kind !== "finite-actions" && context.kind !== "laboratory-preparation") {
+    return;
+  }
+  phasesVisited[context.phase] = (phasesVisited[context.phase] ?? 0) + 1;
+}
+
+function isSameGameAction(left: GameAction, right: GameAction): boolean {
+  const leftRecord = left as unknown as Record<string, unknown>;
+  const rightRecord = right as unknown as Record<string, unknown>;
+  const leftKeys = Object.keys(leftRecord);
+  const rightKeys = Object.keys(rightRecord);
+  if (leftKeys.length !== rightKeys.length) {
+    return false;
+  }
+  return leftKeys.every((key) => isSameActionValue(leftRecord[key], rightRecord[key]));
+}
+
+function isSameActionValue(left: unknown, right: unknown): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return left.length === right.length && left.every((item, index) => item === right[index]);
+  }
+  return false;
+}
+
+function isPolicyActionLegal(context: DecisionContext, action: GameAction): boolean {
+  if (action.type === "START_ACTIVE_DIY") {
+    return false;
+  }
+
+  if (context.kind === "finite-actions") {
+    return context.legalActions.some((legal) => isSameGameAction(legal, action));
+  }
+
+  if (context.kind === "laboratory-preparation") {
+    if (action.type !== "CONFIRM_LABORATORY_PREPARATION") {
+      return false;
+    }
+    if (action.playerId !== context.playerId) {
+      return false;
+    }
+    if (action.keptCardInstanceIds.length !== context.keepCount) {
+      return false;
+    }
+    const uniqueKept = new Set(action.keptCardInstanceIds);
+    if (uniqueKept.size !== context.keepCount) {
+      return false;
+    }
+    const candidates = new Set(context.candidateCardInstanceIds);
+    return action.keptCardInstanceIds.every((cardId) => candidates.has(cardId));
+  }
+
+  return false;
+}
+
+function collectPlayedCardDefinitionIds(
+  action: GameAction,
+  state: GameState,
+): readonly string[] {
+  const definitionIds: string[] = [];
+  const pushInstance = (cardInstanceId: string | undefined) => {
+    if (!cardInstanceId) {
+      return;
+    }
+    const definitionId = state.cardInstances[cardInstanceId]?.definitionId;
+    if (definitionId) {
+      definitionIds.push(definitionId);
+    }
+  };
+
+  switch (action.type) {
+    case "PLAY_CARD":
+    case "PLAY_REFERENCE_CARD":
+    case "RESPOND_WITH_CARD":
+    case "HANDLE_STATUS_WITH_CARD":
+      pushInstance(action.cardInstanceId);
+      break;
+    case "ACTIVATE_CHARACTER_SKILL":
+      if (action.skillId === "alkali_recovery") {
+        pushInstance(action.cardInstanceId);
+      }
+      break;
+    case "RESOLVE_EXPERIMENT_COUNTERATTACK":
+      if (action.option === "acid-base-pursuit" || action.option === "metal-counterattack") {
+        pushInstance(action.cardInstanceId);
+      }
+      break;
+    case "PLAY_DIY_SELECTION":
+      for (const cardInstanceId of action.componentCardInstanceIds) {
+        pushInstance(cardInstanceId);
+      }
+      break;
+    default:
+      break;
+  }
+
+  return definitionIds;
 }
 
 function buildDefaultCharacterPairs(): [CharacterId, CharacterId][] {
@@ -156,6 +277,22 @@ function createInitialMatchupMatrix(): Record<
   return matrix;
 }
 
+function ratio(numerator: number, denominator: number, digits: number): number {
+  if (denominator <= 0) {
+    return 0;
+  }
+  return Number((numerator / denominator).toFixed(digits));
+}
+
+function mergeCounts(
+  target: Record<string, number>,
+  source: Record<string, number>,
+): void {
+  for (const [key, count] of Object.entries(source)) {
+    target[key] = (target[key] ?? 0) + count;
+  }
+}
+
 export function runBatchSelfPlay(
   options: BatchSelfPlayOptions,
 ): SelfPlayBatchSummary {
@@ -168,6 +305,34 @@ export function runBatchSelfPlay(
     maxStepsPerGame = 1000,
   } = options;
 
+  const characterStats = createInitialCharacterStats();
+  const matchupMatrix = createInitialMatchupMatrix();
+
+  if (gameCount <= 0) {
+    return {
+      totalGames: 0,
+      winsPlayer1: 0,
+      winsPlayer2: 0,
+      draws: 0,
+      abortedGames: 0,
+      firstPlayerWinRate: 0,
+      secondPlayerWinRate: 0,
+      drawRate: 0,
+      characterStats,
+      matchupMatrix,
+      averageSteps: 0,
+      minSteps: 0,
+      maxSteps: 0,
+      averageCycles: 0,
+      averageRounds: 0,
+      actionTypeCounts: {},
+      cardDefinitionPlayCounts: {},
+      phasesVisited: {},
+      totalIllegalActionAttempts: 0,
+      totalDeadlocks: 0,
+    };
+  }
+
   const pairs =
     characterPairs && characterPairs.length > 0
       ? characterPairs
@@ -176,6 +341,7 @@ export function runBatchSelfPlay(
   let winsPlayer1 = 0;
   let winsPlayer2 = 0;
   let draws = 0;
+  let abortedGames = 0;
   let totalStepsSum = 0;
   let minSteps = Number.POSITIVE_INFINITY;
   let maxSteps = 0;
@@ -185,10 +351,8 @@ export function runBatchSelfPlay(
   let totalDeadlocks = 0;
 
   const actionTypeCounts: Record<string, number> = {};
+  const cardDefinitionPlayCounts: Record<string, number> = {};
   const phasesVisited: Record<string, number> = {};
-
-  const characterStats = createInitialCharacterStats();
-  const matchupMatrix = createInitialMatchupMatrix();
 
   for (let index = 0; index < gameCount; index += 1) {
     const pair = pairs[index % pairs.length];
@@ -225,6 +389,13 @@ export function runBatchSelfPlay(
     for (const action of result.actionLog) {
       actionTypeCounts[action.type] = (actionTypeCounts[action.type] ?? 0) + 1;
     }
+    mergeCounts(cardDefinitionPlayCounts, result.cardDefinitionPlayCounts);
+    mergeCounts(phasesVisited, result.phasesVisited);
+
+    if (!result.completed) {
+      abortedGames += 1;
+      continue;
+    }
 
     if (!matchupMatrix[char1]) {
       matchupMatrix[char1] = {} as Record<CharacterId, CharacterMatchupRecord>;
@@ -256,45 +427,35 @@ export function runBatchSelfPlay(
       matchup.winsP2 += 1;
       characterStats[char2].wins += 1;
     }
-
-    for (const logEntry of result.finalState.log) {
-      if (
-        logEntry.params &&
-        typeof logEntry.params === "object" &&
-        "phase" in logEntry.params
-      ) {
-        const phaseValue = (logEntry.params as { phase?: unknown }).phase;
-        if (phaseValue !== undefined) {
-          const phaseName = String(phaseValue);
-          phasesVisited[phaseName] = (phasesVisited[phaseName] ?? 0) + 1;
-        }
-      }
-    }
   }
 
   for (const charId of Object.keys(characterStats) as CharacterId[]) {
     const stat = characterStats[charId];
     if (stat && stat.matches > 0) {
-      stat.winRate = Number((stat.wins / stat.matches).toFixed(4));
+      stat.winRate = ratio(stat.wins, stat.matches, 4);
     }
   }
+
+  const completedGames = gameCount - abortedGames;
 
   return {
     totalGames: gameCount,
     winsPlayer1,
     winsPlayer2,
     draws,
-    firstPlayerWinRate: Number((winsPlayer1 / gameCount).toFixed(4)),
-    secondPlayerWinRate: Number((winsPlayer2 / gameCount).toFixed(4)),
-    drawRate: Number((draws / gameCount).toFixed(4)),
+    abortedGames,
+    firstPlayerWinRate: ratio(winsPlayer1, completedGames, 4),
+    secondPlayerWinRate: ratio(winsPlayer2, completedGames, 4),
+    drawRate: ratio(draws, completedGames, 4),
     characterStats,
     matchupMatrix,
-    averageSteps: Number((totalStepsSum / gameCount).toFixed(2)),
+    averageSteps: ratio(totalStepsSum, gameCount, 2),
     minSteps: minSteps === Number.POSITIVE_INFINITY ? 0 : minSteps,
     maxSteps,
-    averageCycles: Number((totalCyclesSum / gameCount).toFixed(2)),
-    averageRounds: Number((totalRoundsSum / gameCount).toFixed(2)),
+    averageCycles: ratio(totalCyclesSum, gameCount, 2),
+    averageRounds: ratio(totalRoundsSum, gameCount, 2),
     actionTypeCounts,
+    cardDefinitionPlayCounts,
     phasesVisited,
     totalIllegalActionAttempts,
     totalDeadlocks,

--- a/src/game/natba/types.ts
+++ b/src/game/natba/types.ts
@@ -33,6 +33,8 @@ export type SelfPlayGameResult = {
   readonly deadlocked: boolean;
   readonly characterPlayer1: CharacterId;
   readonly characterPlayer2: CharacterId;
+  readonly phasesVisited: Record<string, number>;
+  readonly cardDefinitionPlayCounts: Record<string, number>;
 };
 
 export type BatchSelfPlayOptions = {
@@ -62,6 +64,7 @@ export type SelfPlayBatchSummary = {
   readonly winsPlayer1: number;
   readonly winsPlayer2: number;
   readonly draws: number;
+  readonly abortedGames: number;
   readonly firstPlayerWinRate: number;
   readonly secondPlayerWinRate: number;
   readonly drawRate: number;
@@ -73,6 +76,7 @@ export type SelfPlayBatchSummary = {
   readonly averageCycles: number;
   readonly averageRounds: number;
   readonly actionTypeCounts: Record<string, number>;
+  readonly cardDefinitionPlayCounts: Record<string, number>;
   readonly phasesVisited: Record<string, number>;
   readonly totalIllegalActionAttempts: number;
   readonly totalDeadlocks: number;

--- a/src/game/tests/deterministicSimulation.test.ts
+++ b/src/game/tests/deterministicSimulation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { createInitialGame } from "../engine/createInitialGame";
+import { createInitialGame, createSeededEngine } from "../engine/createInitialGame";
+import { getDecisionContext } from "../engine/decisionContext";
 import { engineReducer } from "../engine/reducer";
 import {
   createFisherYatesShuffle,
@@ -9,6 +10,7 @@ import {
 } from "../../shared/random";
 import type { GameAction } from "../engine/actions";
 import type { GameState } from "../engine/types";
+import { expectCardZonesToBeConsistent } from "./assertCardZones";
 
 describe("Phase 19B — Deterministic Simulation Infrastructure", () => {
   describe("createInitialGame with seed injection", () => {
@@ -153,53 +155,97 @@ describe("Phase 19B — Deterministic Simulation Infrastructure", () => {
     it("replays deterministic discard pile recycling upon deck exhaustion", () => {
       const seed = 54321;
 
-      function runDeckRecycleSimulation(): GameState {
-        const prng = createMulberry32(seed);
-        const shuffle = createFisherYatesShuffle(prng);
+      function assignConsistentZones(
+        state: GameState,
+        p1Hand: string[],
+        p2Hand: string[],
+        deck: string[],
+        discardPile: string[],
+      ): GameState {
+        const cardInstances = { ...state.cardInstances };
+        for (const id of p1Hand) {
+          cardInstances[id] = {
+            ...cardInstances[id],
+            ownerId: "player_1",
+            zone: { type: "hand", playerId: "player_1" },
+          };
+        }
+        for (const id of p2Hand) {
+          cardInstances[id] = {
+            ...cardInstances[id],
+            ownerId: "player_2",
+            zone: { type: "hand", playerId: "player_2" },
+          };
+        }
+        for (const id of deck) {
+          cardInstances[id] = {
+            ...cardInstances[id],
+            ownerId: undefined,
+            zone: { type: "deck" },
+          };
+        }
+        for (const id of discardPile) {
+          cardInstances[id] = {
+            ...cardInstances[id],
+            ownerId: undefined,
+            zone: { type: "discard" },
+          };
+        }
+        return {
+          ...state,
+          cardInstances,
+          deck,
+          discardPile,
+          players: state.players.map((player) => {
+            if (player.id === "player_1") {
+              return { ...player, hand: p1Hand };
+            }
+            if (player.id === "player_2") {
+              return { ...player, hand: p2Hand };
+            }
+            return player;
+          }),
+        };
+      }
 
-        // Start with 2 Caustic Soda Captains to have standard 10 card hands
-        let state = createInitialGame({
+      function runDeckRecycleSimulation(): GameState {
+        const engine = createSeededEngine(seed);
+        let state = engine.createGame({
           gameId: "recycle_sim",
-          shuffle,
           characterIds: ["laboratory_teacher", "caustic_soda_captain"],
         });
 
-        // Confirm prep
         const prep = state.pendingLaboratoryPreparation!;
-        state = engineReducer(
+        state = engine.reduce(state, {
+          type: "CONFIRM_LABORATORY_PREPARATION",
+          playerId: "player_1",
+          keptCardInstanceIds: prep.candidateCardInstanceIds.slice(0, 10),
+        });
+
+        const p1Hand = state.players[0].hand.slice(0, 2);
+        const occupied = new Set([...p1Hand, ...state.players[1].hand]);
+        const rest = Object.keys(state.cardInstances).filter((id) => !occupied.has(id));
+        const deck = rest.slice(0, 1);
+        const discardPile = rest.slice(1, 16);
+        const extras = rest.slice(16);
+        state = assignConsistentZones(
           state,
-          {
-            type: "CONFIRM_LABORATORY_PREPARATION",
-            playerId: "player_1",
-            keptCardInstanceIds: prep.candidateCardInstanceIds.slice(0, 10),
-          },
-          shuffle,
+          p1Hand,
+          [...state.players[1].hand, ...extras],
+          deck,
+          discardPile,
         );
+        expectCardZonesToBeConsistent(state);
+        expect(state.deck).toHaveLength(1);
+        expect(state.discardPile).toHaveLength(15);
+        expect(state.players[0].hand).toHaveLength(2);
 
-        // Artificially deplete deck to 1 card and set discard pile with 15 cards
-        const remainingCard = state.deck[0];
-        const discardCards = state.deck.slice(1, 16);
-        // Reduce player 1's hand to 2 cards so extra_lesson (requires hand <= 4) is legal
-        state = {
-          ...state,
-          players: state.players.map((p) =>
-            p.id === "player_1" ? { ...p, hand: p.hand.slice(0, 2) } : p,
-          ),
-          deck: [remainingCard],
-          discardPile: discardCards,
-        };
-
-        // Player 1 (Teacher) uses extra_lesson (draws 4 cards -> exhausts 1 remaining deck card, triggers recycling discardPile of 15 cards, draws 3 from recycled deck)
-        const nextState = engineReducer(
-          state,
-          {
-            type: "ACTIVATE_CHARACTER_SKILL",
-            playerId: "player_1",
-            skillId: "extra_lesson",
-          },
-          shuffle,
-        );
-
+        const nextState = engine.reduce(state, {
+          type: "ACTIVATE_CHARACTER_SKILL",
+          playerId: "player_1",
+          skillId: "extra_lesson",
+        });
+        expectCardZonesToBeConsistent(nextState);
         return nextState;
       }
 
@@ -207,11 +253,30 @@ describe("Phase 19B — Deterministic Simulation Infrastructure", () => {
       const result2 = runDeckRecycleSimulation();
 
       expect(result1).toEqual(result2);
-      expect(result1.deck.length).toBe(12); // 15 recycled - 3 drawn = 12
+      expect(result1.deck.length).toBe(12);
       expect(result1.discardPile.length).toBe(0);
       expect(
         result1.log.some((entry) => entry.eventKey === "recycle_discard_into_deck"),
       ).toBe(true);
+    });
+
+    it("binds createInitialGame seed through later reducer shuffles via createSeededEngine", () => {
+      function runSeededSession(): GameState {
+        const engine = createSeededEngine(424242);
+        let state = engine.createGame({
+          gameId: "seeded_session",
+          characterIds: ["caustic_soda_captain", "acid_king"],
+        });
+        state = engine.reduce(state, { type: "PASS_ACTION", playerId: "player_1" });
+        state = engine.reduce(state, { type: "PASS_ACTION", playerId: "player_2" });
+        return state;
+      }
+
+      const run1 = runSeededSession();
+      const run2 = runSeededSession();
+      expect(run1).toEqual(run2);
+      expect(JSON.stringify(run1)).toBe(JSON.stringify(run2));
+      expect(run1.roundInCycle).toBe(2);
     });
 
     it("produces differing trajectories when given different initial seeds", () => {
@@ -277,37 +342,56 @@ describe("Phase 19B — Deterministic Simulation Infrastructure", () => {
       const seed = 987654321;
 
       function simulateCombatGame(): GameState {
-        const shuffle = createSeededShuffle(seed);
-        let state = createInitialGame({
+        const engine = createSeededEngine(seed);
+        let state = engine.createGame({
           gameId: "combat_sim",
-          shuffle,
           characterIds: ["chemistry_enthusiast", "sulfuric_acid_factory_director"],
         });
 
-        // 3 cycles with passing and skills
-        for (let cycle = 0; cycle < 3; cycle += 1) {
-          for (let round = 0; round < 3; round += 1) {
-            // Player 1 turn
-            if (state.phase === "mainAction" && state.activePlayerId === "player_1") {
-              state = engineReducer(state, { type: "PASS_ACTION", playerId: "player_1" }, shuffle);
-            }
-            // Player 2 turn
-            if (state.phase === "mainAction" && state.activePlayerId === "player_2") {
-              // Try activating exhaust_discharge if available, otherwise pass
-              const skillAction: GameAction = {
-                type: "ACTIVATE_CHARACTER_SKILL",
-                playerId: "player_2",
-                skillId: "exhaust_discharge",
-                targetPlayerId: "player_1",
-              };
-              const afterSkill = engineReducer(state, skillAction, shuffle);
-              if (afterSkill !== state) {
-                state = afterSkill;
-              } else {
-                state = engineReducer(state, { type: "PASS_ACTION", playerId: "player_2" }, shuffle);
-              }
-            }
+        let steps = 0;
+        while (steps < 200 && state.phase !== "gameOver" && state.cycleNumber < 4) {
+          const context = getDecisionContext(state);
+          if (context.kind === "none" || context.kind === "game-over") {
+            break;
           }
+
+          let action: GameAction | undefined;
+          if (context.kind === "laboratory-preparation") {
+            action = {
+              type: "CONFIRM_LABORATORY_PREPARATION",
+              playerId: context.playerId,
+              keptCardInstanceIds: context.candidateCardInstanceIds.slice(
+                0,
+                context.keepCount,
+              ),
+            };
+          } else {
+            const exhaust = context.legalActions.find(
+              (candidate) =>
+                candidate.type === "ACTIVATE_CHARACTER_SKILL" &&
+                candidate.skillId === "exhaust_discharge",
+            );
+            const passOrRecover = context.legalActions.find(
+              (candidate) =>
+                candidate.type === "PASS_ACTION" ||
+                candidate.type === "PASS_RESPONSE" ||
+                candidate.type === "PASS_STATUS_HANDLING" ||
+                (candidate.type === "RESOLVE_EXPERIMENT_COUNTERATTACK" &&
+                  candidate.option === "recover"),
+            );
+            action = exhaust ?? passOrRecover ?? context.legalActions[0];
+          }
+
+          if (!action) {
+            break;
+          }
+
+          const nextState = engine.reduce(state, action);
+          if (nextState === state) {
+            break;
+          }
+          state = nextState;
+          steps += 1;
         }
 
         return state;
@@ -321,6 +405,14 @@ describe("Phase 19B — Deterministic Simulation Infrastructure", () => {
       expect(matchA.cycleNumber).toBe(matchB.cycleNumber);
       expect(matchA.roundInCycle).toBe(matchB.roundInCycle);
       expect(matchA.log).toEqual(matchB.log);
+      expect(matchA.cycleNumber >= 3 || matchA.phase === "gameOver").toBe(true);
+      expect(
+        matchA.log.some(
+          (entry) =>
+            entry.eventKey === "status_window_start" ||
+            entry.eventKey === "skill_exhaust_discharge",
+        ),
+      ).toBe(true);
     });
   });
 });

--- a/src/game/tests/natba0Policy.test.ts
+++ b/src/game/tests/natba0Policy.test.ts
@@ -64,6 +64,9 @@ describe("Phase 19C — NATBA-0 Random Legal Policy", () => {
       expect(context.legalActions).toContainEqual(action);
       expect(validateGameAction(state, action)).toBe(true);
       expect(action.type).not.toBe("START_ACTIVE_DIY");
+      expect(context.legalActions.some((legal) => legal.type === "START_ACTIVE_DIY")).toBe(
+        false,
+      );
     }
   });
 

--- a/src/game/tests/natbaSelfPlay.test.ts
+++ b/src/game/tests/natbaSelfPlay.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
+import type { DecisionContext } from "../engine/decisionContext";
 import {
   allDefaultCharacterIds,
+  natba0RandomLegalPolicy,
   runBatchSelfPlay,
   runSelfPlayGame,
+  type NATBAPolicy,
 } from "../natba";
 
 describe("Phase 19C — NATBA-0 Self-Play & Deterministic Replay", () => {
@@ -32,6 +35,12 @@ describe("Phase 19C — NATBA-0 Self-Play & Deterministic Replay", () => {
     expect(run1.finalState).toEqual(run2.finalState);
     expect(JSON.stringify(run1.finalState)).toBe(JSON.stringify(run2.finalState));
     expect(run1.finalState.log).toEqual(run2.finalState.log);
+    expect(run1.rounds).toBe(
+      (run1.finalState.cycleNumber - 1) * run1.finalState.settings.roundsPerCycle +
+        run1.finalState.roundInCycle,
+    );
+    expect(run1.rounds).toBeGreaterThan(run1.finalState.roundInCycle);
+    expect(run1.phasesVisited.mainAction).toBeGreaterThan(0);
   });
 
   it("completes clean self-play matches across all 7 playable characters with zero illegal actions", () => {
@@ -72,6 +81,7 @@ describe("Phase 19C — NATBA-0 Self-Play & Deterministic Replay", () => {
     });
 
     expect(summary.totalGames).toBe(gameCount);
+    expect(summary.abortedGames).toBe(0);
     expect(summary.winsPlayer1 + summary.winsPlayer2 + summary.draws).toBe(
       gameCount,
     );
@@ -113,6 +123,116 @@ describe("Phase 19C — NATBA-0 Self-Play & Deterministic Replay", () => {
 
     // Verify no legacy actions were ever generated
     expect(summary.actionTypeCounts.START_ACTIVE_DIY).toBeUndefined();
+    expect(summary.phasesVisited.mainAction).toBeGreaterThan(0);
+    expect(Object.keys(summary.cardDefinitionPlayCounts).length).toBeGreaterThan(0);
+  });
+
+  it("rejects policy actions outside the current decision context before dispatch", () => {
+    const startActiveDiyPolicy: NATBAPolicy = () => ({
+      type: "START_ACTIVE_DIY",
+      playerId: "player_1",
+      recipeId: "diy_hcl_from_h_cl",
+      componentCardInstanceIds: [],
+    });
+
+    const diyResult = runSelfPlayGame({
+      gameId: "illegal_diy",
+      seed: 11,
+      characterIds: ["caustic_soda_captain", "acid_king"],
+      policyPlayer1: startActiveDiyPolicy,
+      policyPlayer2: startActiveDiyPolicy,
+    });
+    expect(diyResult.completed).toBe(false);
+    expect(diyResult.illegalActionAttempts).toBe(1);
+    expect(diyResult.actionLog).toEqual([]);
+    expect(diyResult.actionLog.some((action) => action.type === "START_ACTIVE_DIY")).toBe(
+      false,
+    );
+
+    const wrongKeepCountPolicy: NATBAPolicy = (observation, context, random) => {
+      if (context.kind === "laboratory-preparation") {
+        return {
+          type: "CONFIRM_LABORATORY_PREPARATION",
+          playerId: context.playerId,
+          keptCardInstanceIds: context.candidateCardInstanceIds.slice(0, 3),
+        };
+      }
+      return natba0RandomLegalPolicy(observation, context, random);
+    };
+
+    const prepResult = runSelfPlayGame({
+      gameId: "illegal_prep",
+      seed: 12,
+      characterIds: ["laboratory_teacher", "chemical_factory_ceo"],
+      policyPlayer1: wrongKeepCountPolicy,
+      policyPlayer2: wrongKeepCountPolicy,
+    });
+    expect(prepResult.completed).toBe(false);
+    expect(prepResult.illegalActionAttempts).toBe(1);
+    expect(prepResult.actionLog).toEqual([]);
+    expect(prepResult.finalState.phase).toBe("preparationSelection");
+
+    const outsiderFinitePolicy: NATBAPolicy = (
+      _observation,
+      context: DecisionContext,
+    ) => {
+      if (context.kind !== "finite-actions") {
+        return undefined;
+      }
+      return {
+        type: "PASS_ACTION",
+        playerId: context.playerId === "player_1" ? "player_2" : "player_1",
+      };
+    };
+
+    const finiteResult = runSelfPlayGame({
+      gameId: "illegal_finite",
+      seed: 13,
+      characterIds: ["caustic_soda_captain", "acid_king"],
+      policyPlayer1: outsiderFinitePolicy,
+      policyPlayer2: outsiderFinitePolicy,
+    });
+    expect(finiteResult.completed).toBe(false);
+    expect(finiteResult.illegalActionAttempts).toBe(1);
+    expect(finiteResult.actionLog).toEqual([]);
+  });
+
+  it("returns zero-valued batch statistics when gameCount is 0", () => {
+    const summary = runBatchSelfPlay({ gameCount: 0, baseSeed: 1 });
+    expect(summary.totalGames).toBe(0);
+    expect(summary.abortedGames).toBe(0);
+    expect(summary.firstPlayerWinRate).toBe(0);
+    expect(summary.secondPlayerWinRate).toBe(0);
+    expect(summary.drawRate).toBe(0);
+    expect(summary.averageSteps).toBe(0);
+    expect(summary.averageCycles).toBe(0);
+    expect(summary.averageRounds).toBe(0);
+    expect(summary.minSteps).toBe(0);
+    expect(summary.maxSteps).toBe(0);
+    expect(summary.phasesVisited).toEqual({});
+    expect(summary.cardDefinitionPlayCounts).toEqual({});
+  });
+
+  it("excludes aborted games from character win-rate denominators", () => {
+    const summary = runBatchSelfPlay({
+      gameCount: 4,
+      baseSeed: 99,
+      maxStepsPerGame: 1,
+      characterPairs: [
+        ["laboratory_teacher", "chemical_factory_ceo"],
+        ["caustic_soda_captain", "acid_king"],
+      ],
+    });
+
+    expect(summary.abortedGames).toBe(4);
+    expect(summary.winsPlayer1 + summary.winsPlayer2 + summary.draws).toBe(0);
+    expect(summary.firstPlayerWinRate).toBe(0);
+    expect(summary.totalDeadlocks).toBe(4);
+    for (const charId of allDefaultCharacterIds) {
+      expect(summary.characterStats[charId].matches).toBe(0);
+      expect(summary.characterStats[charId].wins).toBe(0);
+      expect(summary.characterStats[charId].winRate).toBe(0);
+    }
   });
 
   it("covers all 5 decision phases across structured self-play scenarios", () => {


### PR DESCRIPTION
## Summary

Addresses all Codex P1/P2 findings from Phase 19B (PR #24) and Phase 19C (PR #25).

### P1
1. **Seed continuity** — `createSeededEngine(seed)` binds the same shuffle to `createGame` + `reduce`. Default `engineReducer(state, action)` remains non-deterministic (API compatible). `createInitialGame({ seed })` still only seeds opening shuffle.
2. **Rounds telemetry** — self-play now reports elapsed rounds as `(cycleNumber - 1) * roundsPerCycle + roundInCycle`.
3. **Policy action revalidation** — before reducer: finite actions must be structurally in `context.legalActions`; laboratory preparation validates keep count / uniqueness / candidates; `START_ACTIVE_DIY` always rejected.

### P2
- Multi-cycle replay tests drive status / response / counterattack via `getDecisionContext`
- Recycle fixtures keep `CardInstance.zone` consistent with hand/deck/discard
- `phasesVisited` recorded from `context.phase` in the runner loop
- Empty batch (`gameCount <= 0`) returns zero stats (no NaN)
- Incomplete games tracked as `abortedGames`; win-rate denominators use completed games only
- `cardDefinitionPlayCounts` accumulates play frequencies by definition id

### Verification
| Check | Result |
| :--- | :--- |
| `pnpm run test:run` | 736 passed |
| `pnpm run test:shuffle` | 736 passed |
| `pnpm run build` | ✅ |
| `pnpm run check:size` | JS gzip 101,701 / 108,000 |

No rule / card pool / skill value changes.