### PR TITLE
feat: Phase 19E NATBA-1 heuristic tactician

### DIFF
--- a/src/game/natba/index.ts
+++ b/src/game/natba/index.ts
@@ -1,4 +1,5 @@
 export { natba0RandomLegalPolicy } from "./natba0Policy";
+export { natba1HeuristicPolicy } from "./natba1HeuristicPolicy";
 export {
   allDefaultCharacterIds,
   runBatchSelfPlay,

--- a/src/game/natba/natba1HeuristicPolicy.ts
+++ b/src/game/natba/natba1HeuristicPolicy.ts
@@ -1,0 +1,474 @@
+import type { RandomSource } from "../../shared/random";
+import { cardDefinitionsById } from "../data/cardDefinitions";
+import type { GameAction } from "../engine/actions";
+import type { AIObservation, AIObservationOpponent } from "../engine/aiObservation";
+import type { DecisionContext } from "../engine/decisionContext";
+import type { CardDefinition, CardInstanceId, CharacterId } from "../engine/types";
+import type { NATBAPolicy } from "./types";
+
+function getCardDefinition(
+  cardInstanceId: CardInstanceId | undefined,
+  observation: AIObservation,
+): CardDefinition | undefined {
+  if (!cardInstanceId) {
+    return undefined;
+  }
+  const selfHandIndex = observation.self.hand.indexOf(cardInstanceId);
+  if (selfHandIndex !== -1 && observation.self.handCards[selfHandIndex]) {
+    return observation.self.handCards[selfHandIndex];
+  }
+  const discardCard = observation.discardPileCards.find(
+    (card) => card.cardInstanceId === cardInstanceId,
+  );
+  if (discardCard) {
+    return discardCard.definition;
+  }
+  if (cardDefinitionsById.has(cardInstanceId)) {
+    return cardDefinitionsById.get(cardInstanceId);
+  }
+  const lastUnderscore = cardInstanceId.lastIndexOf("_");
+  if (lastUnderscore !== -1) {
+    const candidateDefId = cardInstanceId.slice(0, lastUnderscore);
+    if (cardDefinitionsById.has(candidateDefId)) {
+      return cardDefinitionsById.get(candidateDefId);
+    }
+  }
+  return undefined;
+}
+
+export function scoreFiniteAction(
+  action: GameAction,
+  observation: AIObservation,
+): number {
+  const self = observation.self;
+  const opponents = observation.opponents;
+  const primaryOpponent: AIObservationOpponent | undefined =
+    opponents.find((op) => op.playerId !== self.playerId && !op.eliminated) ??
+    opponents[0];
+
+  const opponentHp = primaryOpponent ? primaryOpponent.hp : 10;
+  const opponentHandCount = primaryOpponent ? primaryOpponent.handCount : 0;
+  const opponentHasSo2 = primaryOpponent
+    ? primaryOpponent.statuses.some((s) => s.statusId === "SO2_LEAK")
+    : false;
+  const selfHasFire = self.statuses.some((s) => s.statusId === "FIRE");
+  const missingHp = Math.max(0, self.maxHp - self.hp);
+
+  switch (action.type) {
+    case "PASS_ACTION": {
+      return 10;
+    }
+
+    case "PASS_RESPONSE": {
+      return 0;
+    }
+
+    case "PASS_STATUS_HANDLING": {
+      return 0;
+    }
+
+    case "RESPOND_WITH_CARD": {
+      let score = 160;
+      const def = getCardDefinition(action.cardInstanceId, observation);
+      if (def) {
+        if (def.id === "substance_na2co3" || def.id === "ion_co3") {
+          score += 40;
+        } else if (def.type === "ion") {
+          score += 25;
+        } else {
+          score += 5;
+        }
+      }
+      if (self.hp <= 3) {
+        score += 80;
+      }
+      return score;
+    }
+
+    case "HANDLE_STATUS_WITH_CARD": {
+      let score = 190;
+      const def = getCardDefinition(action.cardInstanceId, observation);
+      if (def) {
+        if (def.id === "substance_h2o" || def.id === "substance_co2") {
+          score += 35;
+        } else if (def.id === "ion_oh") {
+          score += 25;
+        }
+      }
+      if (self.hp <= 4) {
+        score += 80;
+      }
+      return score;
+    }
+
+    case "RESOLVE_EXPERIMENT_COUNTERATTACK": {
+      if (action.option === "recover") {
+        let score = 150;
+        if (missingHp >= 2) {
+          score += 40;
+        }
+        if (self.hp <= 3) {
+          score += 60;
+        }
+        if (self.hp === self.maxHp) {
+          score = 0;
+        }
+        return score;
+      }
+      if (action.option === "acid-base-pursuit") {
+        let score = 180;
+        if (opponentHp <= 2) {
+          score += 70;
+        }
+        if (self.hp === self.maxHp) {
+          score += 30;
+        }
+        return score;
+      }
+      return 0;
+    }
+
+    case "PLAY_CARD": {
+      const def = getCardDefinition(action.cardInstanceId, observation);
+      if (!def) {
+        return 40;
+      }
+
+      if (def.id === "substance_o2" || action.targetPlayerId === self.playerId) {
+        if (missingHp >= 2) {
+          return 130 + (self.hp <= 3 ? 50 : 0);
+        }
+        if (missingHp === 1) {
+          return 70;
+        }
+        return 0;
+      }
+
+      if (def.id === "substance_so2") {
+        if (!opponentHasSo2) {
+          return 120 + (opponentHp <= 3 ? 30 : 0);
+        }
+        return 20;
+      }
+
+      let score = 115;
+      if (opponentHp <= 2) {
+        score += 80;
+      } else if (opponentHp <= 4) {
+        score += 40;
+      }
+
+      if (opponentHandCount === 0) {
+        score += 40;
+      } else if (opponentHandCount <= 2) {
+        score += 20;
+      }
+
+      if (self.characterId === "acid_king" && def.tags.includes("strong-acid")) {
+        score += 80;
+      } else if (self.characterId === "caustic_soda_captain" && def.tags.includes("strong-alkali")) {
+        score += 40;
+      } else if (
+        self.characterId === "sulfuric_acid_factory_director" &&
+        def.id === "substance_h2so4_dilute"
+      ) {
+        score += 35;
+      }
+
+      return score;
+    }
+
+    case "PLAY_REFERENCE_CARD": {
+      // 桌面基准牌纯垫牌，不产生伤害，打分低于 PASS 与进攻动作
+      return 5;
+    }
+
+    case "PLAY_DIY_SELECTION": {
+      const compDefs = action.componentCardInstanceIds
+        .map((id) => getCardDefinition(id, observation))
+        .filter((d): d is CardDefinition => Boolean(d));
+
+      const hasC = compDefs.some((d) => d.id === "element_c");
+      const hasO = compDefs.some((d) => d.id === "element_o");
+      const hasS = compDefs.some((d) => d.id === "element_s");
+      const hasH = compDefs.some((d) => d.id === "ion_h");
+      const hasOH = compDefs.some((d) => d.id === "ion_oh");
+
+      if ((hasC && hasO) || (hasH && hasOH && !action.targetPlayerId)) {
+        if (selfHasFire) {
+          return 180;
+        }
+        return 0;
+      }
+
+      if (hasS && hasO) {
+        if (!opponentHasSo2) {
+          return 125;
+        }
+        return 20;
+      }
+
+      let score = 135;
+      if (opponentHp <= 2) {
+        score += 80;
+      }
+      if (opponentHandCount === 0) {
+        score += 35;
+      }
+      if (self.characterId === "chemistry_enthusiast" && !self.usedDIYThisCycle) {
+        score += 60;
+      }
+      return score;
+    }
+
+    case "ACTIVATE_CHARACTER_SKILL": {
+      switch (action.skillId) {
+        case "extra_lesson":
+        case "emergency_supply":
+          return 160;
+
+        case "alkali_recovery":
+          if (missingHp >= 2) {
+            return 130;
+          }
+          if (missingHp === 1) {
+            return 80;
+          }
+          return 10;
+
+        case "exhaust_discharge":
+          if (!opponentHasSo2) {
+            return 125;
+          }
+          return 25;
+
+        case "exhaust_leak":
+          return 135 + (opponentHp <= 2 ? 60 : 0);
+
+        case "exothermic_accident":
+          if (opponentHp <= 1) {
+            return 300;
+          }
+          if (self.hp <= 1 && opponentHp > 1) {
+            return -100;
+          }
+          return 140;
+
+        case "lab_fire":
+          if (selfHasFire) {
+            return 110;
+          }
+          if (self.hp >= 6 || opponentHp <= 3) {
+            return 100;
+          }
+          if (self.hp <= 3) {
+            return -30;
+          }
+          return 75;
+
+        default:
+          return 60;
+      }
+    }
+
+    default:
+      return 0;
+  }
+}
+
+export function evaluateCandidateCard(
+  def: CardDefinition,
+  alreadyKept: readonly CardDefinition[],
+  selfCharacterId: CharacterId,
+): number {
+  let score = 35;
+
+  if (def.tags.includes("strong-acid")) {
+    score = 130;
+  } else if (def.tags.includes("strong-alkali")) {
+    score = 125;
+  } else if (def.id === "substance_o2") {
+    score = 95;
+  } else if (def.id === "substance_so2") {
+    score = 90;
+  } else if (def.id === "ion_h" || def.id === "ion_oh") {
+    score = 80;
+  } else if (def.tags.includes("carbonate")) {
+    score = 70;
+  } else if (def.tags.includes("fire-extinguish")) {
+    score = 55;
+  }
+
+  if (selfCharacterId === "acid_king" && (def.tags.includes("acid") || def.id === "ion_h")) {
+    score += 35;
+  } else if (selfCharacterId === "caustic_soda_captain" && (def.tags.includes("base") || def.id === "ion_oh")) {
+    score += 35;
+  } else if (
+    selfCharacterId === "sulfuric_acid_factory_director" &&
+    (def.id === "substance_h2so4_dilute" || def.id === "ion_so4")
+  ) {
+    score += 30;
+  }
+
+  const sameDefCount = alreadyKept.filter((k) => k.id === def.id).length;
+  const sameTypeExtinguishCount = alreadyKept.filter((k) =>
+    k.tags.includes("fire-extinguish"),
+  ).length;
+
+  if (def.tags.includes("fire-extinguish")) {
+    if (sameTypeExtinguishCount === 1) {
+      score -= 25;
+    } else if (sameTypeExtinguishCount >= 2) {
+      score -= 60;
+    }
+  }
+
+  if (def.id === "substance_o2" && sameDefCount >= 2) {
+    score -= 40;
+  }
+  if (def.id === "substance_so2" && sameDefCount >= 2) {
+    score -= 50;
+  }
+
+  if (
+    def.id === "ion_h" &&
+    alreadyKept.some(
+      (k) => k.id === "ion_oh" || k.id === "ion_cl" || k.id === "ion_so4",
+    )
+  ) {
+    score += 25;
+  }
+  if (
+    def.id === "ion_oh" &&
+    alreadyKept.some(
+      (k) =>
+        k.id === "ion_h" ||
+        k.id === "ion_na" ||
+        k.id === "ion_k" ||
+        k.id === "ion_ca",
+    )
+  ) {
+    score += 25;
+  }
+  if (def.id === "element_s" && alreadyKept.some((k) => k.id === "element_o")) {
+    score += 20;
+  }
+  if (def.id === "element_o" && alreadyKept.some((k) => k.id === "element_s")) {
+    score += 15;
+  }
+
+  return score;
+}
+
+export function selectLaboratoryPreparationCards(
+  candidateCardInstanceIds: readonly CardInstanceId[],
+  keepCount: number,
+  observation: AIObservation,
+  random: RandomSource,
+): CardInstanceId[] {
+  const candidates = [...candidateCardInstanceIds];
+  const keptCardInstanceIds: CardInstanceId[] = [];
+  const keptDefinitions: CardDefinition[] = [];
+
+  while (keptCardInstanceIds.length < keepCount && candidates.length > 0) {
+    let bestScore = Number.NEGATIVE_INFINITY;
+    const bestCandidates: number[] = [];
+
+    for (let index = 0; index < candidates.length; index += 1) {
+      const cardId = candidates[index];
+      const def = getCardDefinition(cardId, observation) ?? {
+        id: cardId,
+        name: "Unknown",
+        type: "substance" as const,
+        formula: "Unknown",
+        tags: [],
+        allowedTimings: [],
+        rulesText: "",
+      };
+
+      const score = evaluateCandidateCard(def, keptDefinitions, observation.self.characterId);
+      if (score > bestScore) {
+        bestScore = score;
+        bestCandidates.length = 0;
+        bestCandidates.push(index);
+      } else if (score === bestScore) {
+        bestCandidates.push(index);
+      }
+    }
+
+    let bestIndex = 0;
+    if (bestCandidates.length > 1) {
+      const pick = Math.floor(random() * bestCandidates.length);
+      bestIndex = bestCandidates[Math.min(Math.max(0, pick), bestCandidates.length - 1)];
+    } else {
+      bestIndex = bestCandidates[0] ?? 0;
+    }
+
+    const [selectedCardId] = candidates.splice(bestIndex, 1);
+    keptCardInstanceIds.push(selectedCardId);
+    const selectedDef = getCardDefinition(selectedCardId, observation);
+    if (selectedDef) {
+      keptDefinitions.push(selectedDef);
+    }
+  }
+
+  return keptCardInstanceIds;
+}
+
+export const natba1HeuristicPolicy: NATBAPolicy = (
+  observation: AIObservation,
+  context: DecisionContext,
+  random: RandomSource = Math.random,
+): GameAction | undefined => {
+  if (context.kind === "finite-actions") {
+    if (context.legalActions.length === 0) {
+      return undefined;
+    }
+
+    let highestScore = Number.NEGATIVE_INFINITY;
+    const bestActions: GameAction[] = [];
+
+    for (const action of context.legalActions) {
+      const score = scoreFiniteAction(action, observation);
+      if (score > highestScore) {
+        highestScore = score;
+        bestActions.length = 0;
+        bestActions.push(action);
+      } else if (score === highestScore) {
+        bestActions.push(action);
+      }
+    }
+
+    if (bestActions.length === 0) {
+      return context.legalActions[0];
+    }
+
+    if (bestActions.length === 1) {
+      return bestActions[0];
+    }
+
+    const selectedIndex = Math.floor(random() * bestActions.length);
+    const clampedIndex = Math.min(
+      Math.max(0, selectedIndex),
+      bestActions.length - 1,
+    );
+    return bestActions[clampedIndex];
+  }
+
+  if (context.kind === "laboratory-preparation") {
+    const keptCardInstanceIds = selectLaboratoryPreparationCards(
+      context.candidateCardInstanceIds,
+      context.keepCount,
+      observation,
+      random,
+    );
+
+    return {
+      type: "CONFIRM_LABORATORY_PREPARATION",
+      playerId: context.playerId,
+      keptCardInstanceIds,
+    };
+  }
+
+  return undefined;
+};

--- a/src/game/tests/natba1Policy.test.ts
+++ b/src/game/tests/natba1Policy.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+import { identityShuffle, createMulberry32 } from "../../shared/random";
+import type { GameAction } from "../engine/actions";
+import { getAIObservation } from "../engine/aiObservation";
+import { createInitialGame } from "../engine/createInitialGame";
+import { getDecisionContext } from "../engine/decisionContext";
+import { validateGameAction } from "../engine/legalActions";
+import { engineReducer } from "../engine/reducer";
+import type { GameState } from "../engine/types";
+import { natba1HeuristicPolicy } from "../natba/natba1HeuristicPolicy";
+
+function confirmPreparation(state: GameState): GameState {
+  const pending = state.pendingLaboratoryPreparation;
+  if (!pending) {
+    return state;
+  }
+  return engineReducer(state, {
+    type: "CONFIRM_LABORATORY_PREPARATION",
+    playerId: pending.playerId,
+    keptCardInstanceIds: pending.candidateCardInstanceIds.slice(0, 10),
+  });
+}
+
+function createReadyMainGameState(
+  charA: "caustic_soda_captain" | "acid_king" | "laboratory_teacher" | "chemical_factory_ceo" = "caustic_soda_captain",
+  charB: "acid_king" | "chemical_factory_ceo" = "acid_king",
+): GameState {
+  const state = createInitialGame({
+    characterIds: [charA, charB],
+    shuffle: identityShuffle,
+  });
+  return confirmPreparation(state);
+}
+
+describe("Phase 19E — NATBA-1 Heuristic Policy", () => {
+  it("returns undefined when decision context is none or game-over", () => {
+    const dummyState = createReadyMainGameState();
+    const observation = getAIObservation(dummyState, "player_1");
+
+    expect(
+      natba1HeuristicPolicy(observation, { kind: "none" }, Math.random),
+    ).toBeUndefined();
+    expect(
+      natba1HeuristicPolicy(
+        observation,
+        { kind: "game-over", winnerPlayerId: "player_1" },
+        Math.random,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("selects a strictly legal action from finite-actions decision context in mainAction", () => {
+    const state = createReadyMainGameState();
+    const context = getDecisionContext(state);
+    expect(context.kind).toBe("finite-actions");
+    if (context.kind !== "finite-actions") return;
+
+    const observation = getAIObservation(state, context.playerId);
+    const prng = createMulberry32(12345);
+
+    for (let i = 0; i < 50; i += 1) {
+      const action = natba1HeuristicPolicy(observation, context, prng);
+      expect(action).toBeDefined();
+      if (!action) return;
+
+      expect(context.legalActions).toContainEqual(action);
+      expect(validateGameAction(state, action)).toBe(true);
+      expect(action.type).not.toBe("START_ACTIVE_DIY");
+    }
+  });
+
+  it("selects exactly 10 distinct candidate cards in laboratory-preparation context and prioritizes high-value cards", () => {
+    const state = createInitialGame({
+      gameId: "test_prep_natba1",
+      characterIds: ["laboratory_teacher", "chemical_factory_ceo"],
+      shuffle: identityShuffle,
+    });
+    const context = getDecisionContext(state);
+    expect(context.kind).toBe("laboratory-preparation");
+    if (context.kind !== "laboratory-preparation") return;
+
+    const observation = getAIObservation(state, context.playerId);
+    const prng = createMulberry32(67890);
+
+    const action = natba1HeuristicPolicy(observation, context, prng);
+    expect(action).toBeDefined();
+    if (!action) return;
+
+    expect(action.type).toBe("CONFIRM_LABORATORY_PREPARATION");
+    if (action.type !== "CONFIRM_LABORATORY_PREPARATION") return;
+
+    expect(action.playerId).toBe(context.playerId);
+    expect(action.keptCardInstanceIds).toHaveLength(10);
+    const uniqueKept = new Set(action.keptCardInstanceIds);
+    expect(uniqueKept.size).toBe(10);
+    for (const cardId of action.keptCardInstanceIds) {
+      expect(context.candidateCardInstanceIds).toContain(cardId);
+    }
+    expect(validateGameAction(state, action)).toBe(true);
+  });
+
+  it("prioritizes responding with card over pass in responseWindow", () => {
+    let state = createReadyMainGameState();
+    const p1 = state.players[0];
+    const p2 = state.players[1];
+
+    const hclCardId = Object.keys(state.cardInstances).find(
+      (id) => state.cardInstances[id].definitionId === "substance_hcl_dilute",
+    )!;
+    const naohCardId = Object.keys(state.cardInstances).find(
+      (id) => state.cardInstances[id].definitionId === "substance_naoh_dilute",
+    )!;
+
+    state = {
+      ...state,
+      tableReference: undefined,
+      cardInstances: {
+        ...state.cardInstances,
+        [hclCardId]: {
+          ...state.cardInstances[hclCardId],
+          ownerId: p1.id,
+          zone: { type: "hand", playerId: p1.id },
+        },
+        [naohCardId]: {
+          ...state.cardInstances[naohCardId],
+          ownerId: p2.id,
+          zone: { type: "hand", playerId: p2.id },
+        },
+      },
+      players: [
+        { ...p1, hand: [hclCardId] },
+        { ...p2, hand: [naohCardId] },
+      ],
+    };
+
+    const responseState = engineReducer(state, {
+      type: "PLAY_CARD",
+      playerId: p1.id,
+      cardInstanceId: hclCardId,
+      targetPlayerId: p2.id,
+    });
+
+    expect(responseState.phase).toBe("responseWindow");
+    const context = getDecisionContext(responseState);
+    expect(context.kind).toBe("finite-actions");
+    if (context.kind !== "finite-actions") return;
+
+    const observation = getAIObservation(responseState, p2.id);
+    const prng = createMulberry32(445566);
+
+    const action = natba1HeuristicPolicy(observation, context, prng);
+    expect(action).toBeDefined();
+    if (!action) return;
+
+    expect(action.type).toBe("RESPOND_WITH_CARD");
+    expect(validateGameAction(responseState, action)).toBe(true);
+  });
+
+  it("prioritizes handling status over pass in statusWindow", () => {
+    let state = createReadyMainGameState();
+    const p1 = state.players[0];
+    const h2oCardId = Object.keys(state.cardInstances).find(
+      (id) => state.cardInstances[id].definitionId === "substance_h2o",
+    )!;
+
+    const fireStatus = {
+      id: "status_fire_01",
+      statusId: "FIRE" as const,
+      sourcePlayerId: p1.id,
+      createdAt: 1,
+    };
+
+    const statusState: GameState = {
+      ...state,
+      phase: "statusWindow",
+      activePlayerId: p1.id,
+      cardInstances: {
+        ...state.cardInstances,
+        [h2oCardId]: {
+          ...state.cardInstances[h2oCardId],
+          ownerId: p1.id,
+          zone: { type: "hand", playerId: p1.id },
+        },
+      },
+      players: [
+        { ...p1, hand: [h2oCardId], statuses: [fireStatus] },
+        state.players[1],
+      ],
+      pendingStatusHandling: {
+        playerId: p1.id,
+        statusInstanceId: fireStatus.id,
+      },
+    };
+
+    const context = getDecisionContext(statusState);
+    expect(context.kind).toBe("finite-actions");
+    if (context.kind !== "finite-actions") return;
+
+    const observation = getAIObservation(statusState, p1.id);
+    const prng = createMulberry32(778899);
+
+    const action = natba1HeuristicPolicy(observation, context, prng);
+    expect(action).toBeDefined();
+    if (!action) return;
+
+    expect(action.type).toBe("HANDLE_STATUS_WITH_CARD");
+    expect(validateGameAction(statusState, action)).toBe(true);
+  });
+
+  it("prioritizes extra_lesson skill when teacher hand size is low", () => {
+    const state = createInitialGame({
+      characterIds: ["laboratory_teacher", "chemical_factory_ceo"],
+      shuffle: identityShuffle,
+    });
+    const readyState = confirmPreparation(state);
+    const teacher = readyState.players[0];
+    const reducedTeacherState: GameState = {
+      ...readyState,
+      players: [
+        { ...teacher, hand: teacher.hand.slice(0, 2) },
+        readyState.players[1],
+      ],
+    };
+
+    const context = getDecisionContext(reducedTeacherState);
+    expect(context.kind).toBe("finite-actions");
+    if (context.kind !== "finite-actions") return;
+
+    const observation = getAIObservation(reducedTeacherState, teacher.id);
+    const prng = createMulberry32(112233);
+
+    const action = natba1HeuristicPolicy(observation, context, prng);
+    expect(action).toBeDefined();
+    if (!action) return;
+
+    expect(action.type).toBe("ACTIVATE_CHARACTER_SKILL");
+    if (action.type === "ACTIVATE_CHARACTER_SKILL") {
+      expect(action.skillId).toBe("extra_lesson");
+    }
+  });
+
+  it("produces deterministic decision sequences given the same PRNG seed", () => {
+    const state = createReadyMainGameState();
+    const context = getDecisionContext(state);
+    const observation = getAIObservation(state, "player_1");
+
+    const runA = () => {
+      const prng = createMulberry32(424242);
+      const actions: (GameAction | undefined)[] = [];
+      for (let i = 0; i < 10; i += 1) {
+        actions.push(natba1HeuristicPolicy(observation, context, prng));
+      }
+      return actions;
+    };
+
+    const actions1 = runA();
+    const actions2 = runA();
+
+    expect(actions1).toEqual(actions2);
+  });
+});

--- a/src/game/tests/natbaSelfPlay.test.ts
+++ b/src/game/tests/natbaSelfPlay.test.ts
@@ -3,6 +3,7 @@ import type { DecisionContext } from "../engine/decisionContext";
 import {
   allDefaultCharacterIds,
   natba0RandomLegalPolicy,
+  natba1HeuristicPolicy,
   runBatchSelfPlay,
   runSelfPlayGame,
   type NATBAPolicy,
@@ -281,3 +282,105 @@ describe("Phase 19C — NATBA-0 Self-Play & Deterministic Replay", () => {
     expect(hasActiveOrResponseActions).toBe(true);
   });
 });
+
+describe("Phase 19E — NATBA-1 Heuristic Policy Self-Play & Win-Rate Benchmark", () => {
+  it("replays full NATBA-1 vs NATBA-1 game deterministically with bit-identical final states and logs", () => {
+    const seed = 543216789;
+    const run1 = runSelfPlayGame({
+      gameId: "natba1_replay_test",
+      seed,
+      characterIds: ["laboratory_teacher", "chemistry_enthusiast"],
+      policyPlayer1: natba1HeuristicPolicy,
+      policyPlayer2: natba1HeuristicPolicy,
+    });
+
+    const run2 = runSelfPlayGame({
+      gameId: "natba1_replay_test",
+      seed,
+      characterIds: ["laboratory_teacher", "chemistry_enthusiast"],
+      policyPlayer1: natba1HeuristicPolicy,
+      policyPlayer2: natba1HeuristicPolicy,
+    });
+    expect(run1.completed).toBe(true);
+    expect(run2.completed).toBe(true);
+    expect(run1.deadlocked).toBe(false);
+    expect(run2.deadlocked).toBe(false);
+    expect(run1.illegalActionAttempts).toBe(0);
+    expect(run2.illegalActionAttempts).toBe(0);
+
+    expect(run1.totalSteps).toBe(run2.totalSteps);
+    expect(run1.actionLog).toEqual(run2.actionLog);
+    expect(run1.finalState).toEqual(run2.finalState);
+    expect(JSON.stringify(run1.finalState)).toBe(JSON.stringify(run2.finalState));
+    expect(run1.finalState.log).toEqual(run2.finalState.log);
+  });
+
+  it("completes clean NATBA-1 self-play matches across all 7 playable characters with zero illegal actions", () => {
+    const testPairs = [
+      ["laboratory_teacher", "chemical_factory_ceo"] as const,
+      ["clumsy_party_secretary", "caustic_soda_captain"] as const,
+      ["acid_king", "chemistry_enthusiast"] as const,
+      ["sulfuric_acid_factory_director", "laboratory_teacher"] as const,
+      ["caustic_soda_captain", "acid_king"] as const,
+      ["chemistry_enthusiast", "clumsy_party_secretary"] as const,
+      ["chemical_factory_ceo", "sulfuric_acid_factory_director"] as const,
+    ];
+
+    for (let index = 0; index < testPairs.length; index += 1) {
+      const pair = testPairs[index];
+      const result = runSelfPlayGame({
+        gameId: `natba1_char_test_${index}`,
+        seed: 2000 + index * 41,
+        characterIds: pair,
+        policyPlayer1: natba1HeuristicPolicy,
+        policyPlayer2: natba1HeuristicPolicy,
+        maxSteps: 1000,
+      });
+
+      expect(result.completed).toBe(true);
+      expect(result.deadlocked).toBe(false);
+      expect(result.illegalActionAttempts).toBe(0);
+      expect(result.totalSteps).toBeGreaterThan(0);
+      expect(result.finalState.phase).toBe("gameOver");
+    }
+  });
+
+  it("demonstrates significant win-rate superiority of NATBA-1 over NATBA-0 baseline in paired matchups", () => {
+    const summaryP1Heuristic = runBatchSelfPlay({
+      gameCount: 50,
+      baseSeed: 20260901,
+      policyPlayer1: natba1HeuristicPolicy,
+      policyPlayer2: natba0RandomLegalPolicy,
+      maxStepsPerGame: 1000,
+    });
+
+    const summaryP2Heuristic = runBatchSelfPlay({
+      gameCount: 50,
+      baseSeed: 20260901,
+      policyPlayer1: natba0RandomLegalPolicy,
+      policyPlayer2: natba1HeuristicPolicy,
+      maxStepsPerGame: 1000,
+    });
+
+    expect(summaryP1Heuristic.totalIllegalActionAttempts).toBe(0);
+    expect(summaryP1Heuristic.totalDeadlocks).toBe(0);
+    expect(summaryP1Heuristic.abortedGames).toBe(0);
+
+    expect(summaryP2Heuristic.totalIllegalActionAttempts).toBe(0);
+    expect(summaryP2Heuristic.totalDeadlocks).toBe(0);
+    expect(summaryP2Heuristic.abortedGames).toBe(0);
+
+    const totalHeuristicWins =
+      summaryP1Heuristic.winsPlayer1 + summaryP2Heuristic.winsPlayer2;
+    const totalRandomWins =
+      summaryP1Heuristic.winsPlayer2 + summaryP2Heuristic.winsPlayer1;
+    const totalCompleted =
+      100 - (summaryP1Heuristic.draws + summaryP2Heuristic.draws);
+
+    const overallHeuristicWinRate = totalHeuristicWins / totalCompleted;
+
+    expect(overallHeuristicWinRate).toBeGreaterThanOrEqual(0.7);
+    expect(totalHeuristicWins).toBeGreaterThan(totalRandomWins * 2);
+  });
+});
+


### PR DESCRIPTION
## Summary

Phase 19E implements **NATBA-1 Heuristic Tactician** per `docs/PHASE19_NATBA_FOUNDATION_FREEZE.md` §3 / §18.

### Key Changes

1. **`natba1HeuristicPolicy`** (`src/game/natba/natba1HeuristicPolicy.ts`)
   - Scores Engine-provided legal actions only (finite-actions + laboratory-preparation)
   - Explicit, explainable weights: survival/status handling, response priority, offense, role synergy, draw/recovery skills, prep card value
   - Deterministic tie-break via `RandomSource`
   - Fair `AIObservation` only; never generates `START_ACTIVE_DIY` / `metal-counterattack`

2. **Tests**
   - `natba1Policy.test.ts` — legality, windows, skills, seed determinism
   - Self-play: NATBA-1 vs NATBA-0 win-rate edge (≥70% target in batch); NATBA-1 mirror zero illegal / zero deadlock

### Verification

| Check | Result |
| :--- | :--- |
| `pnpm run test:run` | 54 files / 746 tests ✅ |
| `pnpm run test:shuffle` | 746 tests ✅ |
| `pnpm run build` | ✅ |
| `pnpm run check:size` | JS gzip 101,700 / 108,000 ✅ |

### Notes
- NATBA-0 unchanged as baseline
- Zero rule / card-pool / skill value changes
- Rules version remains `MVP0-P10`