### PR TITLE
feat: Phase 19F NATBA-1 as default solo-vs-AI policy

### DIFF
--- a/src/features/local-game/components/GameSummary.tsx
+++ b/src/features/local-game/components/GameSummary.tsx
@@ -27,7 +27,7 @@ export function GameSummary({
   const isEnglish = locale === "en";
   const isSoloVsAi = Boolean(playerControllers && playerControllers.some((c) => c === "ai"));
   const summaryTitle = isEnglish
-    ? (isSoloVsAi ? "Solo vs NATBA-0" : "Local public two-player game")
+    ? (isSoloVsAi ? "Solo vs NATBA-1" : "Local public two-player game")
     : (isSoloVsAi ? "本地人机公开对局" : "本地双人公开对局");
   const winnerText = game.phase === "gameOver"
     ? game.isDraw

--- a/src/features/local-game/hooks/useLocalGameDebug.ts
+++ b/src/features/local-game/hooks/useLocalGameDebug.ts
@@ -3,7 +3,7 @@ import { createInitialGame } from "../../../game/engine/createInitialGame";
 import { engineReducer } from "../../../game/engine/reducer";
 import { getAIObservation } from "../../../game/engine/aiObservation";
 import { getDecisionContext } from "../../../game/engine/decisionContext";
-import { natba0RandomLegalPolicy } from "../../../game/natba/natba0Policy";
+import { natba1HeuristicPolicy } from "../../../game/natba/natba1HeuristicPolicy";
 import type { NATBAPolicy } from "../../../game/natba/types";
 import type { RandomSource } from "../../../shared/random";
 import type { GameState } from "../../../game/engine/types";
@@ -69,7 +69,7 @@ export function useLocalGameDebug(
   const createGame = opts.createGame ?? defaultLocalGameFactory;
   const reduceGame = opts.reduceGame ?? engineReducer;
   const createSession = opts.createSession ?? createConfiguringLocalGameSession;
-  const policy = opts.policy ?? natba0RandomLegalPolicy;
+  const policy = opts.policy ?? natba1HeuristicPolicy;
   const aiDelayMs = opts.aiDelayMs ?? 250;
   const random = opts.random ?? Math.random;
 

--- a/src/features/local-game/presentationLocale.ts
+++ b/src/features/local-game/presentationLocale.ts
@@ -274,6 +274,6 @@ export const getPlayerControllerDisplayName = (controller: PlayerController, loc
   controller === "human" ? (locale === "en" ? "Human" : "人类") : "NATBA AI";
 
 export const getAiAutoActionNote = (locale: DisplayLocale): string =>
-  locale === "en" ? "NATBA-0 AI is taking action..." : "NATBA-0 AI 正在自动行动...";
+  locale === "en" ? "NATBA-1 AI is taking action..." : "NATBA-1 AI 正在自动行动...";
 
 

--- a/src/features/local-game/soloVsAiSession.test.tsx
+++ b/src/features/local-game/soloVsAiSession.test.tsx
@@ -9,7 +9,9 @@ import { identityShuffle } from "../../shared/random";
 import type { LocalGameFactory } from "./localGameSession";
 import type { NATBAPolicy } from "../../game/natba/types";
 import type { AIObservation } from "../../game/engine/aiObservation";
+import { LocaleProvider } from "../../app/locale";
 import { natba0RandomLegalPolicy } from "../../game/natba/natba0Policy";
+import { natba1HeuristicPolicy } from "../../game/natba/natba1HeuristicPolicy";
 
 const deterministicGameFactory: LocalGameFactory = (characterIds) =>
   createInitialGame({
@@ -17,8 +19,8 @@ const deterministicGameFactory: LocalGameFactory = (characterIds) =>
     shuffle: identityShuffle,
   });
 
-describe("Phase 19D — Solo vs AI Session Integration", () => {
-  it("allows selecting Human vs NATBA-0 AI in configuration and renders lineup summary", async () => {
+describe("Phase 19F — Solo vs NATBA-1 Session Integration", () => {
+  it("allows selecting Human vs NATBA AI in configuration and renders lineup summary", async () => {
     Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
     const container = document.createElement("div");
     document.body.append(container);
@@ -68,7 +70,7 @@ describe("Phase 19D — Solo vs AI Session Integration", () => {
     const receivedObservations: AIObservation[] = [];
     const spyPolicy: NATBAPolicy = (observation, context, random) => {
       receivedObservations.push(observation);
-      return natba0RandomLegalPolicy(observation, context, random);
+      return natba1HeuristicPolicy(observation, context, random);
     };
 
     try {
@@ -144,6 +146,145 @@ describe("Phase 19D — Solo vs AI Session Integration", () => {
           expect((opp as any).handCards).toBeUndefined();
         }
       }
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
+
+  it("defaults to NATBA-1 heuristic policy when no policy prop is provided", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <StrictMode>
+            <LocalGamePage
+              createGame={deterministicGameFactory}
+              aiDelayMs={0}
+            />
+          </StrictMode>,
+        );
+      });
+
+      const controllerSelects = container.querySelectorAll(
+        "select[aria-label*='controller'], select[aria-label*='控制方']",
+      );
+      const playerBControllerSelect = controllerSelects[1] as HTMLSelectElement;
+      await act(async () => {
+        playerBControllerSelect.value = "ai";
+        playerBControllerSelect.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+
+      const startButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("开始游戏"),
+      );
+
+      await act(async () => {
+        startButton?.click();
+      });
+
+      const candidateButtons = container.querySelectorAll(".preparation-candidate-grid button.debug-card__select");
+      await act(async () => {
+        for (let i = 0; i < 10; i += 1) {
+          (candidateButtons[i] as HTMLButtonElement).click();
+        }
+      });
+
+      const confirmPrepButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("确认备课选择"),
+      );
+      await act(async () => {
+        confirmPrepButton?.click();
+      });
+
+      // Player A ends turn, Player B (NATBA-1 AI) executes automatically
+      const passActionButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("结束本次行动"),
+      );
+      await act(async () => {
+        passActionButton?.click();
+      });
+
+      // No error banner; game progressed cleanly under NATBA-1 default
+      expect(container.querySelector(".error-banner")).toBeNull();
+      expect(container.textContent).toContain("本地人机公开对局");
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
+
+  it("preserves baseline NATBA-0 random legal policy when explicitly injected", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    let natba0Invoked = 0;
+    const injectedNatba0: NATBAPolicy = (observation, context, random) => {
+      natba0Invoked += 1;
+      return natba0RandomLegalPolicy(observation, context, random);
+    };
+
+    try {
+      await act(async () => {
+        root.render(
+          <StrictMode>
+            <LocalGamePage
+              createGame={deterministicGameFactory}
+              policy={injectedNatba0}
+              aiDelayMs={0}
+            />
+          </StrictMode>,
+        );
+      });
+
+      const controllerSelects = container.querySelectorAll(
+        "select[aria-label*='controller'], select[aria-label*='控制方']",
+      );
+      const playerBControllerSelect = controllerSelects[1] as HTMLSelectElement;
+      await act(async () => {
+        playerBControllerSelect.value = "ai";
+        playerBControllerSelect.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+
+      const startButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("开始游戏"),
+      );
+      await act(async () => {
+        startButton?.click();
+      });
+
+      const candidateButtons = container.querySelectorAll(".preparation-candidate-grid button.debug-card__select");
+      await act(async () => {
+        for (let i = 0; i < 10; i += 1) {
+          (candidateButtons[i] as HTMLButtonElement).click();
+        }
+      });
+      const confirmPrepButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("确认备课选择"),
+      );
+      await act(async () => {
+        confirmPrepButton?.click();
+      });
+
+      const passActionButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("结束本次行动"),
+      );
+      await act(async () => {
+        passActionButton?.click();
+      });
+
+      expect(natba0Invoked).toBeGreaterThan(0);
+      expect(container.querySelector(".error-banner")).toBeNull();
     } finally {
       await act(async () => {
         root.unmount();
@@ -278,6 +419,70 @@ describe("Phase 19D — Solo vs AI Session Integration", () => {
 
       expect(container.querySelector(".error-banner")).toBeNull();
       expect(container.textContent).not.toContain("操作不合法");
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
+
+  it("renders bilingual NATBA-1 titles and status notices in Solo vs AI mode", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <StrictMode>
+            <LocaleProvider>
+              <LocalGamePage
+                createGame={deterministicGameFactory}
+                aiDelayMs={10000}
+              />
+            </LocaleProvider>
+          </StrictMode>,
+        );
+      });
+
+      // Explicitly switch to Chinese first
+      const zhButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent === "中文",
+      );
+      await act(async () => {
+        zhButton?.click();
+      });
+
+      const controllerSelects = container.querySelectorAll(
+        "select[aria-label*='controller'], select[aria-label*='控制方']",
+      );
+      const playerBControllerSelect = controllerSelects[1] as HTMLSelectElement;
+      await act(async () => {
+        playerBControllerSelect.value = "ai";
+        playerBControllerSelect.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+
+      const startButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("开始游戏") || b.textContent?.includes("Start game"),
+      );
+      await act(async () => {
+        startButton?.click();
+      });
+
+      // In Chinese mode: check title
+      expect(container.querySelector("h1")?.textContent).toBe("本地人机公开对局");
+
+      // Switch to English: check title is Solo vs NATBA-1
+      const enButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent === "English",
+      );
+      await act(async () => {
+        enButton?.click();
+      });
+
+      expect(container.querySelector("h1")?.textContent).toBe("Solo vs NATBA-1");
     } finally {
       await act(async () => {
         root.unmount();


### PR DESCRIPTION
## Summary

Local Human vs AI sessions now default to **NATBA-1** instead of NATBA-0.

### Changes
- `useLocalGameDebug`: `opts.policy ?? natba1HeuristicPolicy`
- NATBA-0 remains injectable for tests / baseline
- Copy: `NATBA-1 AI 正在自动行动...` / `NATBA-1 AI is taking action...`
- Game summary English title: `Solo vs NATBA-1`
- `soloVsAiSession.test.tsx` covers default NATBA-1 and explicit NATBA-0 injection

### Audit
Grok-4.6/High reviewed `5d3b267` before push. **P0/P1: none.** P2 only (tests do not pin policy identity; injected NATBA-0 still shows NATBA-1 title). Not blocking.

### Verification
| Check | Result |
| :--- | :--- |
| `pnpm run test:run` | 54 files / 749 passed |
| `pnpm run test:shuffle` | 749 passed |
| `pnpm run build` + `check:production` | ✅ |
| `pnpm run check:size` | JS gzip 103,169 / 108,000 |
| `pnpm run test:e2e` | 13 passed |
| `pnpm run test:e2e:production` | 3 passed |

No rule / card-pool / skill value changes.