### PR TITLE
feat: Phase 18E Selection-First DIY UI

### DIFF
--- a/e2e/production/reaction-field.spec.ts
+++ b/e2e/production/reaction-field.spec.ts
@@ -285,6 +285,7 @@ test("正式构建在 / 验证 Phase 16 双语游戏日志、反应日志与 DIY
   const virtualAttackRecipes = [
     {
       id: "diy_hcl_from_h_cl",
+      components: ["H+", "Cl-"],
       recipeZh: "H+ + Cl- -> 稀 HCl",
       recipeEn: "H+ + Cl- -> dilute HCl",
       productZh: "稀 HCl",
@@ -295,6 +296,7 @@ test("正式构建在 / 验证 Phase 16 双语游戏日志、反应日志与 DIY
     },
     {
       id: "diy_naoh_from_na_oh",
+      components: ["Na+", "OH-"],
       recipeZh: "Na+ + OH- -> 稀 NaOH",
       recipeEn: "Na+ + OH- -> dilute NaOH",
       productZh: "稀 NaOH",
@@ -305,6 +307,7 @@ test("正式构建在 / 验证 Phase 16 双语游戏日志、反应日志与 DIY
     },
     {
       id: "diy_koh_from_k_oh",
+      components: ["K+", "OH-"],
       recipeZh: "K+ + OH- -> 稀 KOH",
       recipeEn: "K+ + OH- -> dilute KOH",
       productZh: "稀 KOH",
@@ -315,6 +318,7 @@ test("正式构建在 / 验证 Phase 16 双语游戏日志、反应日志与 DIY
     },
     {
       id: "diy_h2so4_from_2h_so4",
+      components: ["H+", "H+", "SO4^2-"],
       recipeZh: "2H+ + SO4^2- -> 稀 H2SO4",
       recipeEn: "2H+ + SO4^2- -> dilute H2SO4",
       productZh: "稀 H2SO4",
@@ -325,6 +329,7 @@ test("正式构建在 / 验证 Phase 16 双语游戏日志、反应日志与 DIY
     },
     {
       id: "diy_limewater_from_ca_2oh",
+      components: ["Ca2+", "OH-", "OH-"],
       recipeZh: "Ca2+ + 2OH- -> 石灰水 Ca(OH)2",
       recipeEn: "Ca2+ + 2OH- -> limewater Ca(OH)2",
       productZh: "石灰水 Ca(OH)2",
@@ -336,29 +341,43 @@ test("正式构建在 / 验证 Phase 16 双语游戏日志、反应日志与 DIY
   ];
 
   let selectedRecipeInfo = virtualAttackRecipes[0];
-  const recipeSelect = diyPanel.locator("select").first();
-  const componentSelects = diyPanel.locator(".component-slots select");
+  const candidateButtons = diyPanel.locator(".candidate-card");
+  const candidateCount = await candidateButtons.count();
+  const availableCandidates: { element: ReturnType<typeof candidateButtons.nth>; name: string }[] = [];
+
+  for (let i = 0; i < candidateCount; i += 1) {
+    const card = candidateButtons.nth(i);
+    const name = (await card.locator(".debug-card__name").textContent()) ?? "";
+    availableCandidates.push({ element: card, name: name.trim() });
+  }
 
   for (const recipeInfo of virtualAttackRecipes) {
-    await recipeSelect.selectOption(recipeInfo.id);
-    const slotCount = await componentSelects.count();
-    let allAvailable = true;
-    for (let i = 0; i < slotCount; i += 1) {
-      const optCount = await componentSelects.nth(i).locator("option").count();
-      if (optCount <= 1) {
-        allAvailable = false;
+    const matchedButtons: (typeof availableCandidates)[0]["element"][] = [];
+    const usedIndices = new Set<number>();
+
+    let allFound = true;
+    for (const comp of recipeInfo.components) {
+      const foundIdx = availableCandidates.findIndex(
+        (c, idx) => !usedIndices.has(idx) && (c.name === comp || c.name.startsWith(comp)),
+      );
+      if (foundIdx === -1) {
+        allFound = false;
         break;
       }
+      usedIndices.add(foundIdx);
+      matchedButtons.push(availableCandidates[foundIdx].element);
     }
-    if (allAvailable) {
+
+    if (allFound) {
       selectedRecipeInfo = recipeInfo;
-      for (let i = 0; i < slotCount; i += 1) {
-        await componentSelects.nth(i).selectOption({ index: 1 });
+      for (const btn of matchedButtons) {
+        await btn.click();
       }
       break;
     }
   }
 
+  await expect(page.getByRole("button", { name: "执行主动 DIY" })).toBeEnabled();
   await page.getByRole("button", { name: "执行主动 DIY" }).click();
 
   const logItems = gameLog.locator("ol li");

--- a/src/features/local-game/components/DiyPanel.test.tsx
+++ b/src/features/local-game/components/DiyPanel.test.tsx
@@ -1,0 +1,416 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider, LocaleSwitch } from "../../../app/locale";
+import type { GameAction } from "../../../game/engine/actions";
+import { createInitialGame } from "../../../game/engine/createInitialGame";
+import type { CardInstance, GameState } from "../../../game/engine/types";
+import { identityShuffle } from "../../../shared/random";
+import { DiyPanel } from "./DiyPanel";
+
+function createTestGame(): GameState {
+  const base = createInitialGame({
+    characterIds: ["chemical_factory_ceo", "acid_king"],
+    shuffle: identityShuffle,
+  });
+
+  const cardInstances: Record<string, CardInstance> = {
+    ...base.cardInstances,
+    c_card_1: {
+      id: "c_card_1",
+      definitionId: "element_c",
+      ownerId: "player_1",
+      zone: { type: "hand", playerId: "player_1" },
+    },
+    o_card_1: {
+      id: "o_card_1",
+      definitionId: "element_o",
+      ownerId: "player_1",
+      zone: { type: "hand", playerId: "player_1" },
+    },
+    o_card_2: {
+      id: "o_card_2",
+      definitionId: "element_o",
+      ownerId: "player_1",
+      zone: { type: "hand", playerId: "player_1" },
+    },
+    h_card_1: {
+      id: "h_card_1",
+      definitionId: "ion_h",
+      ownerId: "player_1",
+      zone: { type: "hand", playerId: "player_1" },
+    },
+    cl_card_1: {
+      id: "cl_card_1",
+      definitionId: "ion_cl",
+      ownerId: "player_1",
+      zone: { type: "hand", playerId: "player_1" },
+    },
+    substance_card_1: {
+      id: "substance_card_1",
+      definitionId: "substance_hcl_dilute",
+      ownerId: "player_1",
+      zone: { type: "hand", playerId: "player_1" },
+    },
+  };
+
+  const players = base.players.map((p) => {
+    if (p.id === "player_1") {
+      return {
+        ...p,
+        hand: [
+          "h_card_1",
+          "cl_card_1",
+          "c_card_1",
+          "o_card_1",
+          "o_card_2",
+          "substance_card_1",
+        ],
+      };
+    }
+    return p;
+  });
+
+  return {
+    ...base,
+    cardInstances,
+    players,
+    phase: "mainAction",
+    activePlayerId: "player_1",
+  };
+}
+
+beforeEach(() => {
+  Object.defineProperty(globalThis.navigator, "language", {
+    configurable: true,
+    value: "zh-CN",
+  });
+  Object.defineProperty(globalThis.navigator, "languages", {
+    configurable: true,
+    value: ["zh-CN"],
+  });
+});
+
+describe("Selection-First DiyPanel Component", () => {
+  it("renders only diy-component cards and excludes ordinary substance cards", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const game = createTestGame();
+    const dispatch = vi.fn();
+
+    try {
+      await act(async () => {
+        root.render(
+          createElement(
+            LocaleProvider,
+            null,
+            createElement(DiyPanel, { game, dispatchGameAction: dispatch }),
+          ),
+        );
+      });
+
+      const candidateCards = container.querySelectorAll(".candidate-card");
+      // h, cl, c, o1, o2 are diy-components (5 cards), substance_hcl_dilute is not
+      expect(candidateCards.length).toBe(5);
+      const submitButton = container.querySelector('button.primary-button') as HTMLButtonElement;
+      expect(submitButton).not.toBeNull();
+      expect(submitButton.disabled).toBe(true);
+      expect(container.textContent).toContain("请在下方点选手牌中的组件卡牌组合出牌。");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  it("handles multi-selection, toggling, and clear selection", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const game = createTestGame();
+    const dispatch = vi.fn();
+
+    try {
+      await act(async () => {
+        root.render(
+          createElement(
+            LocaleProvider,
+            null,
+            createElement(DiyPanel, { game, dispatchGameAction: dispatch }),
+          ),
+        );
+      });
+
+      const buttons = Array.from(
+        container.querySelectorAll(".candidate-card"),
+      ) as HTMLButtonElement[];
+      const hButton = buttons.find((b) => b.textContent?.includes("h_card_1"));
+      const clButton = buttons.find((b) => b.textContent?.includes("cl_card_1"));
+      expect(hButton).toBeDefined();
+      expect(clButton).toBeDefined();
+
+      // Click H+
+      await act(async () => {
+        hButton?.click();
+      });
+      expect(hButton?.getAttribute("aria-pressed")).toBe("true");
+      expect(hButton?.classList.contains("is-selected")).toBe(true);
+      expect(container.textContent).toContain("当前所选组合暂无可执行 DIY 配方。");
+
+      // Click Cl- -> matches dilute HCl
+      await act(async () => {
+        clButton?.click();
+      });
+      expect(clButton?.getAttribute("aria-pressed")).toBe("true");
+      expect(container.textContent).toContain("匹配配方：");
+      expect(container.textContent).toContain("生成虚拟产品 稀 HCl");
+      expect(container.textContent).toContain("对 玩家 B 造成 1 点酸性伤害（等待响应）");
+
+      const submitButton = container.querySelector("button.primary-button") as HTMLButtonElement;
+      expect(submitButton.disabled).toBe(false);
+
+      // Unselect Cl-
+      await act(async () => {
+        clButton?.click();
+      });
+      expect(clButton?.getAttribute("aria-pressed")).toBe("false");
+      expect(submitButton.disabled).toBe(true);
+
+      // Clear selection
+      const clearButton = Array.from(
+        container.querySelectorAll("button"),
+      ).find((b) => b.textContent?.includes("清空选择"));
+      expect(clearButton).toBeDefined();
+      await act(async () => {
+        clearButton?.click();
+      });
+      expect(hButton?.getAttribute("aria-pressed")).toBe("false");
+      expect(container.textContent).toContain("请在下方点选手牌中的组件卡牌组合出牌。");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  it("submits PLAY_DIY_SELECTION action without recipeId and clears selection on success", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const game = createTestGame();
+    const actions: GameAction[] = [];
+    const dispatch = vi.fn((action: GameAction) => {
+      actions.push(action);
+    });
+
+    try {
+      await act(async () => {
+        root.render(
+          createElement(
+            LocaleProvider,
+            null,
+            createElement(DiyPanel, { game, dispatchGameAction: dispatch }),
+          ),
+        );
+      });
+
+      const buttons = Array.from(
+        container.querySelectorAll(".candidate-card"),
+      ) as HTMLButtonElement[];
+      const hButton = buttons.find((b) => b.textContent?.includes("h_card_1"));
+      const clButton = buttons.find((b) => b.textContent?.includes("cl_card_1"));
+
+      await act(async () => {
+        hButton?.click();
+        clButton?.click();
+      });
+
+      const submitButton = container.querySelector("button.primary-button") as HTMLButtonElement;
+      expect(submitButton.disabled).toBe(false);
+
+      await act(async () => {
+        submitButton.click();
+      });
+
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(actions[0]).toEqual({
+        type: "PLAY_DIY_SELECTION",
+        playerId: "player_1",
+        componentCardInstanceIds: ["h_card_1", "cl_card_1"],
+        targetPlayerId: "player_2",
+      });
+      // Verification: recipeId must not be present in formal action
+      expect("recipeId" in (actions[0] as unknown as Record<string, unknown>)).toBe(false);
+
+      // Selection state should be reset
+      expect(hButton?.getAttribute("aria-pressed")).toBe("false");
+      expect(clButton?.getAttribute("aria-pressed")).toBe("false");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  it("handles Fire extinction recipes correctly: blocked when no fire, executable when player has fire", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const gameWithoutFire = createTestGame();
+    const gameWithFire: GameState = {
+      ...gameWithoutFire,
+      players: gameWithoutFire.players.map((p) =>
+        p.id === "player_1"
+          ? {
+              ...p,
+              statuses: [
+                {
+                  id: "fire_1",
+                  statusId: "FIRE" as const,
+                  createdAt: 1,
+                },
+              ],
+            }
+          : p,
+      ),
+    };
+    const dispatch = vi.fn();
+
+    try {
+      // 1. Without FIRE: C + O + O matches CO2 but is blocked with OWN_FIRE_REQUIRED
+      await act(async () => {
+        root.render(
+          createElement(
+            LocaleProvider,
+            null,
+            createElement(DiyPanel, { game: gameWithoutFire, dispatchGameAction: dispatch }),
+          ),
+        );
+      });
+
+      const buttons = Array.from(
+        container.querySelectorAll(".candidate-card"),
+      ) as HTMLButtonElement[];
+      const cButton = buttons.find((b) => b.textContent?.includes("c_card_1"));
+      const o1Button = buttons.find((b) => b.textContent?.includes("o_card_1"));
+      const o2Button = buttons.find((b) => b.textContent?.includes("o_card_2"));
+
+      await act(async () => {
+        cButton?.click();
+        o1Button?.click();
+        o2Button?.click();
+      });
+
+      expect(container.textContent).toContain("匹配配方：");
+      expect(container.textContent).toContain("需自身处于火情状态方可灭火");
+      expect(container.textContent).toContain("此配方不需要选择目标。");
+      const submitButton = container.querySelector("button.primary-button") as HTMLButtonElement;
+      expect(submitButton.disabled).toBe(true);
+
+      // 2. With FIRE: C + O + O is EXECUTABLE
+      await act(async () => {
+        root.render(
+          createElement(
+            LocaleProvider,
+            null,
+            createElement(DiyPanel, { game: gameWithFire, dispatchGameAction: dispatch }),
+          ),
+        );
+      });
+
+      // Since cards are already selected, it should immediately be EXECUTABLE upon receiving gameWithFire
+      expect(container.textContent).toContain("执行效果：移除自身火情状态 (CO2)");
+      const submitButtonFire = container.querySelector("button.primary-button") as HTMLButtonElement;
+      expect(submitButtonFire.disabled).toBe(false);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+
+  it("disables all controls during AI turn", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const game = createTestGame();
+    const dispatch = vi.fn();
+
+    try {
+      await act(async () => {
+        root.render(
+          createElement(
+            LocaleProvider,
+            null,
+            createElement(DiyPanel, {
+              game,
+              playerControllers: ["ai", "human"],
+              dispatchGameAction: dispatch,
+            }),
+          ),
+        );
+      });
+
+      const candidateCards = Array.from(
+        container.querySelectorAll(".candidate-card"),
+      ) as HTMLButtonElement[];
+      for (const btn of candidateCards) {
+        expect(btn.disabled).toBe(true);
+      }
+
+      const submitButton = container.querySelector("button.primary-button") as HTMLButtonElement;
+      expect(submitButton.disabled).toBe(true);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+
+  it("supports dynamic in-place bilingual switching", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const game = createTestGame();
+    const dispatch = vi.fn();
+
+    try {
+      await act(async () => {
+        root.render(
+          createElement(
+            LocaleProvider,
+            null,
+            createElement(LocaleSwitch),
+            createElement(DiyPanel, { game, dispatchGameAction: dispatch }),
+          ),
+        );
+      });
+
+      expect(container.textContent).toContain("主动 DIY");
+      expect(container.textContent).toContain("手牌组件卡");
+      expect(container.textContent).toContain("执行主动 DIY");
+
+      const englishButton = Array.from(
+        container.querySelectorAll(".locale-switch__button"),
+      ).find((b) => b.textContent === "English") as HTMLButtonElement;
+      expect(englishButton).toBeDefined();
+
+      await act(async () => {
+        englishButton.click();
+      });
+
+      expect(container.textContent).toContain("Active DIY");
+      expect(container.textContent).toContain("Hand component cards");
+      expect(container.textContent).toContain("Run active DIY");
+      expect(container.textContent).toContain("Select component cards from your hand to craft.");
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  });
+});

--- a/src/features/local-game/components/DiyPanel.tsx
+++ b/src/features/local-game/components/DiyPanel.tsx
@@ -1,22 +1,26 @@
 import { useEffect, useMemo, useState } from "react";
 import { useLocale } from "../../../app/locale";
 import type { GameAction } from "../../../game/engine/actions";
-import type { CardInstanceId, GameState, PlayerId } from "../../../game/engine/types";
+import { analyzeDIYSelection } from "../../../game/engine/diy";
+import type {
+  CardInstanceId,
+  DIYSelectionAnalysis,
+  GameState,
+  PlayerId,
+} from "../../../game/engine/types";
 import type { PlayerControllerSelection } from "../localGameSession";
 import {
-  cardDefinitionById,
   getActivePlayer,
-  getAvailableComponentCards,
   getCardDefinition,
   getOpponentTargets,
-  getPlayableDiyRecipes,
-  getRecipeById,
-  getRequiredComponentSlots,
+  getPlayer,
 } from "../localGameView";
 import {
   getCardDisplayName,
+  getDamageKindDisplayName,
+  getDiyBlockerDisplayName,
   getDiyRecipeDisplayName,
-  getOptionalCardDisplayName,
+  getDiyVirtualProductDisplayName,
   getPlayerDisplayName,
 } from "../presentationLocale";
 
@@ -35,91 +39,284 @@ export function DiyPanel({ game, playerControllers, dispatchGameAction }: DiyPan
       playerControllers &&
       playerControllers[activePlayer.id === "player_1" ? 0 : 1] === "ai",
   );
-  const recipes = getPlayableDiyRecipes();
-  const [recipeId, setRecipeId] = useState(recipes[0]?.id);
-  const recipe = getRecipeById(recipeId);
-  const slots = useMemo(() => (recipe ? getRequiredComponentSlots(recipe) : []), [recipe]);
-  const [componentIds, setComponentIds] = useState<Record<string, CardInstanceId>>({});
+
+  const candidateCardIds = useMemo(() => {
+    if (!activePlayer) return [];
+    return activePlayer.hand.filter((cardId) => {
+      const def = getCardDefinition(game, cardId);
+      return def?.allowedTimings.includes("diy-component");
+    });
+  }, [activePlayer, game]);
+
+  const [selectedCardIds, setSelectedCardIds] = useState<CardInstanceId[]>([]);
   const [targetPlayerId, setTargetPlayerId] = useState<PlayerId | undefined>();
   const targets = activePlayer ? getOpponentTargets(game, activePlayer.id) : [];
   const defaultTargetPlayerId = targets[0]?.id;
 
-  useEffect(() => {
-    setComponentIds({});
-    setTargetPlayerId(recipe?.requiresTarget ? defaultTargetPlayerId : undefined);
-  }, [defaultTargetPlayerId, recipe?.id, recipe?.requiresTarget]);
+  const effectiveTargetPlayerId =
+    targetPlayerId && targets.some((t) => t.id === targetPlayerId)
+      ? targetPlayerId
+      : defaultTargetPlayerId;
 
-  if (game.phase !== "mainAction" || !activePlayer || !recipe) {
+  useEffect(() => {
+    setSelectedCardIds((prev) => prev.filter((id) => candidateCardIds.includes(id)));
+  }, [candidateCardIds]);
+
+  const analysis: DIYSelectionAnalysis | null = useMemo(() => {
+    if (!activePlayer || selectedCardIds.length === 0) {
+      return null;
+    }
+    const initialAnalysis = analyzeDIYSelection(
+      game,
+      activePlayer.id,
+      selectedCardIds,
+      undefined,
+    );
+    if (
+      initialAnalysis.status === "MATCHED_NOT_EXECUTABLE" &&
+      initialAnalysis.blockerCode === "TARGET_PLAYER_REQUIRED"
+    ) {
+      return analyzeDIYSelection(
+        game,
+        activePlayer.id,
+        selectedCardIds,
+        effectiveTargetPlayerId,
+      );
+    }
+    return initialAnalysis;
+  }, [activePlayer, effectiveTargetPlayerId, game, selectedCardIds]);
+
+  if (game.phase !== "mainAction" || !activePlayer) {
     return null;
   }
 
-  const selectedComponentIds = slots
-    .map((slot) => componentIds[slot.slotId])
-    .filter((cardInstanceId): cardInstanceId is CardInstanceId => Boolean(cardInstanceId));
-  const allComponentsSelected = selectedComponentIds.length === slots.length;
-  const canSubmit =
-    !isAi &&
-    allComponentsSelected &&
-    !activePlayer.usedDIYThisCycle &&
-    (!recipe.requiresTarget || Boolean(targetPlayerId));
+  const canSubmit = !isAi && analysis?.status === "EXECUTABLE";
+
+  const isTargetRequired = Boolean(
+    analysis &&
+      ((analysis.status === "EXECUTABLE" &&
+        (analysis.outcome.kind === "VIRTUAL_ATTACK" ||
+          analysis.outcome.kind === "SO2_APPLY_LEAK")) ||
+        (analysis.status === "MATCHED_NOT_EXECUTABLE" &&
+          (analysis.blockerCode === "TARGET_PLAYER_REQUIRED" ||
+            analysis.blockerCode === "TARGET_PLAYER_INVALID"))),
+  );
+
+  const isNoTargetRecipe = Boolean(
+    analysis &&
+      ((analysis.status === "EXECUTABLE" &&
+        (analysis.outcome.kind === "CO2_REMOVE_OWN_FIRE" ||
+          analysis.outcome.kind === "H2O_REMOVE_OWN_FIRE")) ||
+        (analysis.status === "MATCHED_NOT_EXECUTABLE" &&
+          (analysis.blockerCode === "OWN_FIRE_REQUIRED" ||
+            analysis.blockerCode === "UNEXPECTED_TARGET"))),
+  );
+
+  function renderPreview() {
+    if (selectedCardIds.length === 0) {
+      return (
+        <p className="empty-note">
+          {isEnglish
+            ? "Select component cards from your hand to craft."
+            : "请在下方点选手牌中的组件卡牌组合出牌。"}
+        </p>
+      );
+    }
+
+    if (!analysis) {
+      return null;
+    }
+
+    if (analysis.status === "INVALID_SELECTION") {
+      return (
+        <p className="error-banner">
+          {isEnglish
+            ? "Selection contains invalid card instances."
+            : "所选卡牌包含无效实例。"}
+        </p>
+      );
+    }
+
+    if (analysis.status === "NO_RECIPE_MATCH") {
+      return (
+        <p className="panel-note">
+          {isEnglish
+            ? "No matching DIY recipe for current selection."
+            : "当前所选组合暂无可执行 DIY 配方。"}
+        </p>
+      );
+    }
+
+    if (analysis.status === "MATCHED_NOT_EXECUTABLE") {
+      const recipeName = getDiyRecipeDisplayName(analysis.recipeId, analysis.recipeId, locale);
+      const blockerMessage = getDiyBlockerDisplayName(analysis.blockerCode, locale);
+      return (
+        <div className="diy-preview-card is-blocked">
+          <p className="diy-preview-title">
+            {isEnglish ? "Matched recipe: " : "匹配配方："}
+            <strong>{recipeName}</strong>
+          </p>
+          <p className="diy-blocker-message">{blockerMessage}</p>
+        </div>
+      );
+    }
+
+    if (analysis.status === "EXECUTABLE") {
+      const outcome = analysis.outcome;
+      let outcomeText = "";
+      if (outcome.kind === "CO2_REMOVE_OWN_FIRE") {
+        outcomeText = isEnglish
+          ? "Effect: Remove own Fire status (CO2)"
+          : "执行效果：移除自身火情状态 (CO2)";
+      } else if (outcome.kind === "H2O_REMOVE_OWN_FIRE") {
+        outcomeText = isEnglish
+          ? "Effect: Remove own Fire status (H2O)"
+          : "执行效果：移除自身火情状态 (H2O)";
+      } else if (outcome.kind === "SO2_APPLY_LEAK") {
+        const target = getPlayer(game, outcome.targetPlayerId);
+        const targetName = getPlayerDisplayName(target, locale);
+        outcomeText = isEnglish
+          ? `Effect: Apply SO2 leak to ${targetName}`
+          : `执行效果：对 ${targetName} 施加 SO2 泄漏状态`;
+      } else if (outcome.kind === "VIRTUAL_ATTACK") {
+        const target = getPlayer(game, outcome.targetPlayerId);
+        const targetName = getPlayerDisplayName(target, locale);
+        const kindName = getDamageKindDisplayName(outcome.damageKind, locale);
+        const prodName = getDiyVirtualProductDisplayName(analysis.recipeId, locale);
+        outcomeText = isEnglish
+          ? `Effect: Virtual product ${prodName}, deal ${outcome.damageAmount} ${kindName} damage to ${targetName} (awaiting response)`
+          : `执行效果：生成虚拟产品 ${prodName}，对 ${targetName} 造成 ${outcome.damageAmount} 点${kindName}伤害（等待响应）`;
+      }
+
+      return (
+        <div className="diy-preview-card is-executable">
+          <p className="diy-preview-title">
+            {isEnglish ? "Matched recipe: " : "匹配配方："}
+            <strong>{getDiyRecipeDisplayName(analysis.recipeId, analysis.recipeId, locale)}</strong>
+          </p>
+          <p className="diy-outcome-message">{outcomeText}</p>
+        </div>
+      );
+    }
+
+    return null;
+  }
+
+  function handlePlayDiy() {
+    if (!activePlayer || !canSubmit || !analysis || analysis.status !== "EXECUTABLE") {
+      return;
+    }
+
+    const targetId =
+      analysis.outcome.kind === "VIRTUAL_ATTACK" || analysis.outcome.kind === "SO2_APPLY_LEAK"
+        ? analysis.outcome.targetPlayerId
+        : undefined;
+
+    dispatchGameAction({
+      type: "PLAY_DIY_SELECTION",
+      playerId: activePlayer.id,
+      componentCardInstanceIds: selectedCardIds,
+      targetPlayerId: targetId,
+    });
+    setSelectedCardIds([]);
+  }
 
   return (
     <section className="debug-section diy-panel" aria-labelledby="diy-title">
       <div className="panel-heading">
         <div>
-          <p className="debug-kicker">{isEnglish ? "Choose a recipe and run it" : "选择配方和组件后执行"}</p>
+          <p className="debug-kicker">
+            {isEnglish ? "Select component cards to craft" : "点选手牌组件组合出牌"}
+          </p>
           <h2 id="diy-title">{isEnglish ? "Active DIY" : "主动 DIY"}</h2>
         </div>
         <span className={activePlayer.usedDIYThisCycle ? "warn-pill" : "ok-pill"}>
-          {activePlayer.usedDIYThisCycle ? (isEnglish ? "Used this cycle" : "本周期已用") : (isEnglish ? "Available this cycle" : "本周期可用")}
+          {activePlayer.usedDIYThisCycle
+            ? isEnglish
+              ? "Used this cycle"
+              : "本周期已用"
+            : isEnglish
+              ? "Available this cycle"
+              : "本周期可用"}
         </span>
       </div>
-      <details className="debug-details"><summary>{isEnglish ? "Debug details" : "调试详情"}</summary><p>START_ACTIVE_DIY</p></details>
-      <label className="field-row">
-        <span>{isEnglish ? "Recipe" : "配方"}</span>
-        <select value={recipe.id} onChange={(event) => setRecipeId(event.target.value)}>
-          {recipes.map((candidate) => (
-            <option key={candidate.id} value={candidate.id}>
-              {getDiyRecipeDisplayName(candidate.id, candidate.name, locale)}
-            </option>
-          ))}
-        </select>
-      </label>
-      <div className="component-slots">
-        {slots.map((slot) => {
-          const options = getAvailableComponentCards(
-            game,
-            activePlayer,
-            slot.definitionId,
-            selectedComponentIds.filter((id) => id !== componentIds[slot.slotId]),
-          );
-          const def = cardDefinitionById.get(slot.definitionId);
-          const name = def ? getCardDisplayName(def.id, def.name, locale) : slot.definitionId;
 
-          return (
-            <label className="field-row" key={slot.slotId}>
-              <span>{name}</span>
-              <select
-                onChange={(e) => setComponentIds((c) => ({ ...c, [slot.slotId]: e.target.value }))}
-                value={componentIds[slot.slotId] ?? ""}
-              >
-                <option value="">{isEnglish ? "Select " : "选择 "}{name}</option>
-                {options.map((id) => (
-                  <option key={id} value={id}>
-                    {getOptionalCardDisplayName(getCardDefinition(game, id), locale)}
-                  </option>
-                ))}
-              </select>
-            </label>
-          );
-        })}
+      <details className="debug-details">
+        <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
+        <p>
+          PLAY_DIY_SELECTION · status: {analysis?.status ?? "NO_SELECTION"}
+          {analysis && "recipeId" in analysis ? ` · recipe: ${analysis.recipeId}` : ""}
+          {analysis && "blockerCode" in analysis ? ` · blocker: ${analysis.blockerCode}` : ""}
+        </p>
+      </details>
+
+      <div className="diy-candidate-section">
+        <div className="diy-candidate-heading">
+          <span className="diy-candidate-label">
+            {isEnglish ? "Hand component cards" : "手牌组件卡"}
+          </span>
+          {selectedCardIds.length > 0 ? (
+            <button
+              className="secondary-button compact-button"
+              disabled={isAi}
+              onClick={() => setSelectedCardIds([])}
+              type="button"
+            >
+              {isEnglish
+                ? `Clear selection (${selectedCardIds.length})`
+                : `清空选择 (${selectedCardIds.length})`}
+            </button>
+          ) : null}
+        </div>
+
+        {candidateCardIds.length > 0 ? (
+          <div
+            className="candidate-grid"
+            role="group"
+            aria-label={isEnglish ? "DIY component cards" : "DIY 组件卡牌"}
+          >
+            {candidateCardIds.map((cardInstanceId) => {
+              const isSelected = selectedCardIds.includes(cardInstanceId);
+              const def = getCardDefinition(game, cardInstanceId);
+              const cardName = def
+                ? getCardDisplayName(def.id, def.name, locale)
+                : cardInstanceId;
+
+              return (
+                <button
+                  aria-pressed={isSelected}
+                  className={`debug-card candidate-card${isSelected ? " is-selected" : ""}`}
+                  disabled={isAi}
+                  key={cardInstanceId}
+                  onClick={() => {
+                    setSelectedCardIds((prev) =>
+                      prev.includes(cardInstanceId)
+                        ? prev.filter((id) => id !== cardInstanceId)
+                        : [...prev, cardInstanceId],
+                    );
+                  }}
+                  type="button"
+                >
+                  <span className="debug-card__name">{cardName}</span>
+                  <span className="debug-card__line">{cardInstanceId}</span>
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="empty-note">
+            {isEnglish ? "No DIY component cards in hand." : "手牌中暂无可用 DIY 组件牌。"}
+          </p>
+        )}
       </div>
-      {recipe.requiresTarget ? (
+
+      {isTargetRequired ? (
         <label className="field-row">
           <span>{isEnglish ? "DIY target" : "DIY 目标"}</span>
           <select
-            onChange={(e) => setTargetPlayerId(e.target.value)}
-            value={targetPlayerId ?? ""}
+            disabled={isAi}
+            onChange={(e) => setTargetPlayerId(e.target.value as PlayerId)}
+            value={effectiveTargetPlayerId ?? ""}
           >
             {targets.map((t) => (
               <option key={t.id} value={t.id}>
@@ -128,25 +325,18 @@ export function DiyPanel({ game, playerControllers, dispatchGameAction }: DiyPan
             ))}
           </select>
         </label>
-      ) : (
-        <p className="empty-note">{isEnglish ? "No target required." : "此配方不需要选择目标。"}</p>
-      )}
-      <details className="debug-details">
-        <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
-        <p>targetPlayerId: {recipe.requiresTarget ? targetPlayerId ?? "none" : "n/a"}</p>
-      </details>
+      ) : isNoTargetRecipe ? (
+        <p className="empty-note">
+          {isEnglish ? "No target required." : "此配方不需要选择目标。"}
+        </p>
+      ) : null}
+
+      <div className="diy-preview-section">{renderPreview()}</div>
+
       <button
         className="primary-button"
         disabled={!canSubmit}
-        onClick={() =>
-          dispatchGameAction({
-            type: "START_ACTIVE_DIY",
-            playerId: activePlayer.id,
-            recipeId: recipe.id,
-            componentCardInstanceIds: selectedComponentIds,
-            targetPlayerId: recipe.requiresTarget ? targetPlayerId : undefined,
-          })
-        }
+        onClick={handlePlayDiy}
         type="button"
       >
         {isEnglish ? "Run active DIY" : "执行主动 DIY"}
@@ -154,3 +344,4 @@ export function DiyPanel({ game, playerControllers, dispatchGameAction }: DiyPan
     </section>
   );
 }
+

--- a/src/features/local-game/local-game.css
+++ b/src/features/local-game/local-game.css
@@ -1080,6 +1080,74 @@ select {
   gap: 8px;
 }
 
+.diy-candidate-section {
+  display: grid;
+  gap: 8px;
+}
+
+.diy-candidate-heading {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.diy-candidate-label {
+  color: #334250;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.compact-button {
+  font-size: 0.76rem;
+  min-height: 28px;
+  padding: 4px 8px;
+}
+
+.candidate-card {
+  cursor: pointer;
+}
+
+.diy-preview-section {
+  min-width: 0;
+}
+
+.diy-preview-card {
+  border-radius: 6px;
+  display: grid;
+  gap: 4px;
+  padding: 8px 10px;
+}
+
+.diy-preview-card.is-executable {
+  background: #eef7f2;
+  border: 1px solid #c8e3d5;
+}
+
+.diy-preview-card.is-blocked {
+  background: #fff8eb;
+  border: 1px solid #fed7aa;
+}
+
+.diy-preview-title {
+  color: #334250;
+  font-size: 0.82rem;
+  margin: 0;
+}
+
+.diy-blocker-message {
+  color: #9a3412;
+  font-size: 0.84rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.diy-outcome-message {
+  color: #166534;
+  font-size: 0.84rem;
+  font-weight: 700;
+  margin: 0;
+}
+
 .error-banner,
 .quiet-banner {
   border-radius: 6px;

--- a/src/features/local-game/presentationLocale.ts
+++ b/src/features/local-game/presentationLocale.ts
@@ -276,4 +276,17 @@ export const getPlayerControllerDisplayName = (controller: PlayerController, loc
 export const getAiAutoActionNote = (locale: DisplayLocale): string =>
   locale === "en" ? "NATBA-1 AI is taking action..." : "NATBA-1 AI 正在自动行动...";
 
+const diyBlockerNames: Readonly<Record<string, LocalizedLabel>> = {
+  NOT_ACTIVE_PLAYER: ["非当前行动玩家", "Not active player"],
+  INVALID_PHASE: ["当前阶段不可使用主动 DIY", "Active DIY is not allowed in current phase"],
+  DIY_ALREADY_USED_THIS_CYCLE: ["本周期已使用过主动 DIY", "Active DIY already used this cycle"],
+  OWN_FIRE_REQUIRED: ["需自身处于火情状态方可灭火", "Requires active Fire status on self"],
+  TARGET_PLAYER_REQUIRED: ["请选择目标对手", "Please select a target opponent"],
+  TARGET_PLAYER_INVALID: ["所选目标对手无效", "Invalid target opponent selected"],
+  UNEXPECTED_TARGET: ["此配方不需要选择目标", "No target required for this recipe"],
+};
+
+export const getDiyBlockerDisplayName = (blockerCode: string, locale: DisplayLocale): string =>
+  lookup(diyBlockerNames, blockerCode, locale);
+
 


### PR DESCRIPTION
## Summary

Migrate local DIY UI from recipe-first (`START_ACTIVE_DIY`) to selection-first (`PLAY_DIY_SELECTION`).

### Changes
- Hand-component multi-select / deselect / clear (UI-local only)
- Preview via authoritative `analyzeDIYSelection` only
- Submit `PLAY_DIY_SELECTION` without `recipeId`
- Bilingual blocker / outcome copy
- AI turns remain fully disabled

### Audit
Grok-4.6/High reviewed `bc76408` before push. **P0/P1: none.** P2 only (narrower UI tests, leftover unused recipe helpers/CSS).

### Verification
| Check | Result |
| :--- | :--- |
| `pnpm run test:run` | 55 files / 755 passed |
| `pnpm run test:shuffle` | 755 passed |
| `pnpm run test:e2e` | 13 passed |
| `pnpm run test:e2e:production` | 3 passed |
| `pnpm run check:size` | JS gzip 104,072 / 108,000 |

No rule / card-pool / skill value changes.