### PR TITLE
feat: Phase 19G NATBA weight decoupling and default 1.x

### DIFF
--- a/src/features/local-game/hooks/useLocalGameDebug.ts
+++ b/src/features/local-game/hooks/useLocalGameDebug.ts
@@ -3,7 +3,7 @@ import { createInitialGame } from "../../../game/engine/createInitialGame";
 import { engineReducer } from "../../../game/engine/reducer";
 import { getAIObservation } from "../../../game/engine/aiObservation";
 import { getDecisionContext } from "../../../game/engine/decisionContext";
-import { natba1HeuristicPolicy } from "../../../game/natba/natba1HeuristicPolicy";
+import { natba1xSelfPlayTunedPolicy } from "../../../game/natba/natba1HeuristicPolicy";
 import type { NATBAPolicy } from "../../../game/natba/types";
 import type { RandomSource } from "../../../shared/random";
 import type { GameState } from "../../../game/engine/types";
@@ -69,7 +69,7 @@ export function useLocalGameDebug(
   const createGame = opts.createGame ?? defaultLocalGameFactory;
   const reduceGame = opts.reduceGame ?? engineReducer;
   const createSession = opts.createSession ?? createConfiguringLocalGameSession;
-  const policy = opts.policy ?? natba1HeuristicPolicy;
+  const policy = opts.policy ?? natba1xSelfPlayTunedPolicy;
   const aiDelayMs = opts.aiDelayMs ?? 250;
   const random = opts.random ?? Math.random;
 

--- a/src/features/local-game/soloVsAiSession.test.tsx
+++ b/src/features/local-game/soloVsAiSession.test.tsx
@@ -154,7 +154,7 @@ describe("Phase 19F — Solo vs NATBA-1 Session Integration", () => {
     }
   });
 
-  it("defaults to NATBA-1 heuristic policy when no policy prop is provided", async () => {
+  it("defaults to NATBA-1.x policy when no policy prop is provided", async () => {
     Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
     const container = document.createElement("div");
     document.body.append(container);
@@ -203,7 +203,7 @@ describe("Phase 19F — Solo vs NATBA-1 Session Integration", () => {
         confirmPrepButton?.click();
       });
 
-      // Player A ends turn, Player B (NATBA-1 AI) executes automatically
+      // Player A ends turn, Player B (default NATBA-1.x AI) executes automatically
       const passActionButton = Array.from(container.querySelectorAll("button")).find(
         (b) => b.textContent?.includes("结束本次行动"),
       );
@@ -211,7 +211,7 @@ describe("Phase 19F — Solo vs NATBA-1 Session Integration", () => {
         passActionButton?.click();
       });
 
-      // No error banner; game progressed cleanly under NATBA-1 default
+      // No error banner; game progressed cleanly under NATBA-1.x default
       expect(container.querySelector(".error-banner")).toBeNull();
       expect(container.textContent).toContain("本地人机公开对局");
     } finally {

--- a/src/features/local-game/soloVsAiSession.test.tsx
+++ b/src/features/local-game/soloVsAiSession.test.tsx
@@ -490,4 +490,75 @@ describe("Phase 19F — Solo vs NATBA-1 Session Integration", () => {
       container.remove();
     }
   });
+
+  it("preserves baseline NATBA-1 heuristic policy when explicitly injected as baseline comparator", async () => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    let natba1Invoked = 0;
+    const injectedNatba1: NATBAPolicy = (observation, context, random) => {
+      natba1Invoked += 1;
+      return natba1HeuristicPolicy(observation, context, random);
+    };
+
+    try {
+      await act(async () => {
+        root.render(
+          <StrictMode>
+            <LocalGamePage
+              createGame={deterministicGameFactory}
+              policy={injectedNatba1}
+              aiDelayMs={0}
+            />
+          </StrictMode>,
+        );
+      });
+
+      const controllerSelects = container.querySelectorAll(
+        "select[aria-label*='controller'], select[aria-label*='控制方']",
+      );
+      const playerBControllerSelect = controllerSelects[1] as HTMLSelectElement;
+      await act(async () => {
+        playerBControllerSelect.value = "ai";
+        playerBControllerSelect.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+
+      const startButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("开始游戏"),
+      );
+      await act(async () => {
+        startButton?.click();
+      });
+
+      const candidateButtons = container.querySelectorAll(".preparation-candidate-grid button.debug-card__select");
+      await act(async () => {
+        for (let i = 0; i < 10; i += 1) {
+          (candidateButtons[i] as HTMLButtonElement).click();
+        }
+      });
+      const confirmPrepButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("确认备课选择"),
+      );
+      await act(async () => {
+        confirmPrepButton?.click();
+      });
+
+      const passActionButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("结束本次行动"),
+      );
+      await act(async () => {
+        passActionButton?.click();
+      });
+
+      expect(natba1Invoked).toBeGreaterThan(0);
+      expect(container.querySelector(".error-banner")).toBeNull();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
 });

--- a/src/game/natba/index.ts
+++ b/src/game/natba/index.ts
@@ -1,5 +1,14 @@
 export { natba0RandomLegalPolicy } from "./natba0Policy";
-export { natba1HeuristicPolicy } from "./natba1HeuristicPolicy";
+export {
+  createNATBA1Policy,
+  natba1HeuristicPolicy,
+  natba1xSelfPlayTunedPolicy,
+} from "./natba1HeuristicPolicy";
+export {
+  NATBA1_BASE_WEIGHTS,
+  NATBA1X_TUNED_WEIGHTS,
+  type NATBA1Weights,
+} from "./natba1Weights";
 export {
   allDefaultCharacterIds,
   runBatchSelfPlay,

--- a/src/game/natba/natba1HeuristicPolicy.ts
+++ b/src/game/natba/natba1HeuristicPolicy.ts
@@ -4,6 +4,11 @@ import type { GameAction } from "../engine/actions";
 import type { AIObservation, AIObservationOpponent } from "../engine/aiObservation";
 import type { DecisionContext } from "../engine/decisionContext";
 import type { CardDefinition, CardInstanceId, CharacterId } from "../engine/types";
+import {
+  NATBA1_BASE_WEIGHTS,
+  NATBA1X_TUNED_WEIGHTS,
+  type NATBA1Weights,
+} from "./natba1Weights";
 import type { NATBAPolicy } from "./types";
 
 function getCardDefinition(
@@ -39,6 +44,7 @@ function getCardDefinition(
 export function scoreFiniteAction(
   action: GameAction,
   observation: AIObservation,
+  weights: NATBA1Weights = NATBA1_BASE_WEIGHTS,
 ): number {
   const self = observation.self;
   const opponents = observation.opponents;
@@ -53,75 +59,76 @@ export function scoreFiniteAction(
     : false;
   const selfHasFire = self.statuses.some((s) => s.statusId === "FIRE");
   const missingHp = Math.max(0, self.maxHp - self.hp);
+  const w = weights.finiteActions;
 
   switch (action.type) {
     case "PASS_ACTION": {
-      return 10;
+      return w.passAction;
     }
 
     case "PASS_RESPONSE": {
-      return 0;
+      return w.passResponse;
     }
 
     case "PASS_STATUS_HANDLING": {
-      return 0;
+      return w.passStatusHandling;
     }
 
     case "RESPOND_WITH_CARD": {
-      let score = 160;
+      let score = w.response.base;
       const def = getCardDefinition(action.cardInstanceId, observation);
       if (def) {
         if (def.id === "substance_na2co3" || def.id === "ion_co3") {
-          score += 40;
+          score += w.response.carbonateBonus;
         } else if (def.type === "ion") {
-          score += 25;
+          score += w.response.ionBonus;
         } else {
-          score += 5;
+          score += w.response.otherBonus;
         }
       }
       if (self.hp <= 3) {
-        score += 80;
+        score += w.response.lowHpBonus;
       }
       return score;
     }
 
     case "HANDLE_STATUS_WITH_CARD": {
-      let score = 190;
+      let score = w.handleStatus.base;
       const def = getCardDefinition(action.cardInstanceId, observation);
       if (def) {
         if (def.id === "substance_h2o" || def.id === "substance_co2") {
-          score += 35;
+          score += w.handleStatus.extinguishH2oCo2Bonus;
         } else if (def.id === "ion_oh") {
-          score += 25;
+          score += w.handleStatus.ionOhBonus;
         }
       }
       if (self.hp <= 4) {
-        score += 80;
+        score += w.handleStatus.lowHpBonus;
       }
       return score;
     }
 
     case "RESOLVE_EXPERIMENT_COUNTERATTACK": {
       if (action.option === "recover") {
-        let score = 150;
+        let score = w.counterattack.recoverBase;
         if (missingHp >= 2) {
-          score += 40;
+          score += w.counterattack.recoverMissingHp2Bonus;
         }
         if (self.hp <= 3) {
-          score += 60;
+          score += w.counterattack.recoverLowHpBonus;
         }
         if (self.hp === self.maxHp) {
-          score = 0;
+          score = w.counterattack.recoverFullHpScore;
         }
         return score;
       }
       if (action.option === "acid-base-pursuit") {
-        let score = 180;
+        let score = w.counterattack.pursuitBase;
         if (opponentHp <= 2) {
-          score += 70;
+          score += w.counterattack.pursuitLethalBonus;
         }
         if (self.hp === self.maxHp) {
-          score += 30;
+          score += w.counterattack.pursuitFullHpBonus;
         }
         return score;
       }
@@ -131,56 +138,64 @@ export function scoreFiniteAction(
     case "PLAY_CARD": {
       const def = getCardDefinition(action.cardInstanceId, observation);
       if (!def) {
-        return 40;
+        return w.playCard.unknownDef;
       }
 
       if (def.id === "substance_o2" || action.targetPlayerId === self.playerId) {
         if (missingHp >= 2) {
-          return 130 + (self.hp <= 3 ? 50 : 0);
+          return (
+            w.playCard.o2MissingHp2Base +
+            (self.hp <= 3 ? w.playCard.o2LowHpBonus : 0)
+          );
         }
         if (missingHp === 1) {
-          return 70;
+          return w.playCard.o2MissingHp1Base;
         }
-        return 0;
+        return w.playCard.o2FullHpScore;
       }
 
       if (def.id === "substance_so2") {
         if (!opponentHasSo2) {
-          return 120 + (opponentHp <= 3 ? 30 : 0);
+          return (
+            w.playCard.so2NewBase +
+            (opponentHp <= 3 ? w.playCard.so2LethalBonus : 0)
+          );
         }
-        return 20;
+        return w.playCard.so2ExistingScore;
       }
 
-      let score = 115;
+      let score = w.playCard.attackBase;
       if (opponentHp <= 2) {
-        score += 80;
+        score += w.playCard.opponentLowHp2Bonus;
       } else if (opponentHp <= 4) {
-        score += 40;
+        score += w.playCard.opponentLowHp4Bonus;
       }
 
       if (opponentHandCount === 0) {
-        score += 40;
+        score += w.playCard.opponentHandEmptyBonus;
       } else if (opponentHandCount <= 2) {
-        score += 20;
+        score += w.playCard.opponentHandLow2Bonus;
       }
 
       if (self.characterId === "acid_king" && def.tags.includes("strong-acid")) {
-        score += 80;
-      } else if (self.characterId === "caustic_soda_captain" && def.tags.includes("strong-alkali")) {
-        score += 40;
+        score += w.playCard.acidKingStrongAcidBonus;
+      } else if (
+        self.characterId === "caustic_soda_captain" &&
+        def.tags.includes("strong-alkali")
+      ) {
+        score += w.playCard.causticSodaStrongAlkaliBonus;
       } else if (
         self.characterId === "sulfuric_acid_factory_director" &&
         def.id === "substance_h2so4_dilute"
       ) {
-        score += 35;
+        score += w.playCard.factoryDirectorH2so4Bonus;
       }
 
       return score;
     }
 
     case "PLAY_REFERENCE_CARD": {
-      // 桌面基准牌纯垫牌，不产生伤害，打分低于 PASS 与进攻动作
-      return 5;
+      return w.playReferenceCard;
     }
 
     case "PLAY_DIY_SELECTION": {
@@ -196,27 +211,27 @@ export function scoreFiniteAction(
 
       if ((hasC && hasO) || (hasH && hasOH && !action.targetPlayerId)) {
         if (selfHasFire) {
-          return 180;
+          return w.playDiy.fireExtinguishFireScore;
         }
-        return 0;
+        return w.playDiy.fireExtinguishNoFireScore;
       }
 
       if (hasS && hasO) {
         if (!opponentHasSo2) {
-          return 125;
+          return w.playDiy.so2NewScore;
         }
-        return 20;
+        return w.playDiy.so2ExistingScore;
       }
 
-      let score = 135;
+      let score = w.playDiy.attackBase;
       if (opponentHp <= 2) {
-        score += 80;
+        score += w.playDiy.opponentLowHp2Bonus;
       }
       if (opponentHandCount === 0) {
-        score += 35;
+        score += w.playDiy.opponentHandEmptyBonus;
       }
       if (self.characterId === "chemistry_enthusiast" && !self.usedDIYThisCycle) {
-        score += 60;
+        score += w.playDiy.chemistryEnthusiastBonus;
       }
       return score;
     }
@@ -224,50 +239,54 @@ export function scoreFiniteAction(
     case "ACTIVATE_CHARACTER_SKILL": {
       switch (action.skillId) {
         case "extra_lesson":
+          return w.skills.extraLesson;
         case "emergency_supply":
-          return 160;
+          return w.skills.emergencySupply;
 
         case "alkali_recovery":
           if (missingHp >= 2) {
-            return 130;
+            return w.skills.alkaliRecoveryMissingHp2;
           }
           if (missingHp === 1) {
-            return 80;
+            return w.skills.alkaliRecoveryMissingHp1;
           }
-          return 10;
+          return w.skills.alkaliRecoveryFullHp;
 
         case "exhaust_discharge":
           if (!opponentHasSo2) {
-            return 125;
+            return w.skills.exhaustDischargeNewSo2;
           }
-          return 25;
+          return w.skills.exhaustDischargeExistingSo2;
 
         case "exhaust_leak":
-          return 135 + (opponentHp <= 2 ? 60 : 0);
+          return (
+            w.skills.exhaustLeakBase +
+            (opponentHp <= 2 ? w.skills.exhaustLeakLethalBonus : 0)
+          );
 
         case "exothermic_accident":
           if (opponentHp <= 1) {
-            return 300;
+            return w.skills.exothermicAccidentLethal;
           }
           if (self.hp <= 1 && opponentHp > 1) {
-            return -100;
+            return w.skills.exothermicAccidentSelfLethal;
           }
-          return 140;
+          return w.skills.exothermicAccidentNormal;
 
         case "lab_fire":
           if (selfHasFire) {
-            return 110;
+            return w.skills.labFireSelfFire;
           }
           if (self.hp >= 6 || opponentHp <= 3) {
-            return 100;
+            return w.skills.labFireHealthyOrLethal;
           }
           if (self.hp <= 3) {
-            return -30;
+            return w.skills.labFireLowHp;
           }
-          return 75;
+          return w.skills.labFireNormal;
 
         default:
-          return 60;
+          return w.skills.defaultSkill;
       }
     }
 
@@ -280,34 +299,42 @@ export function evaluateCandidateCard(
   def: CardDefinition,
   alreadyKept: readonly CardDefinition[],
   selfCharacterId: CharacterId,
+  weights: NATBA1Weights = NATBA1_BASE_WEIGHTS,
 ): number {
-  let score = 35;
+  const p = weights.prep;
+  let score = p.baseScore;
 
   if (def.tags.includes("strong-acid")) {
-    score = 130;
+    score = p.strongAcid;
   } else if (def.tags.includes("strong-alkali")) {
-    score = 125;
+    score = p.strongAlkali;
   } else if (def.id === "substance_o2") {
-    score = 95;
+    score = p.substanceO2;
   } else if (def.id === "substance_so2") {
-    score = 90;
+    score = p.substanceSo2;
   } else if (def.id === "ion_h" || def.id === "ion_oh") {
-    score = 80;
+    score = p.ionHOrOh;
   } else if (def.tags.includes("carbonate")) {
-    score = 70;
+    score = p.carbonate;
   } else if (def.tags.includes("fire-extinguish")) {
-    score = 55;
+    score = p.fireExtinguish;
   }
 
-  if (selfCharacterId === "acid_king" && (def.tags.includes("acid") || def.id === "ion_h")) {
-    score += 35;
-  } else if (selfCharacterId === "caustic_soda_captain" && (def.tags.includes("base") || def.id === "ion_oh")) {
-    score += 35;
+  if (
+    selfCharacterId === "acid_king" &&
+    (def.tags.includes("acid") || def.id === "ion_h")
+  ) {
+    score += p.charAcidKingBonus;
+  } else if (
+    selfCharacterId === "caustic_soda_captain" &&
+    (def.tags.includes("base") || def.id === "ion_oh")
+  ) {
+    score += p.charCausticSodaBonus;
   } else if (
     selfCharacterId === "sulfuric_acid_factory_director" &&
     (def.id === "substance_h2so4_dilute" || def.id === "ion_so4")
   ) {
-    score += 30;
+    score += p.charFactoryDirectorBonus;
   }
 
   const sameDefCount = alreadyKept.filter((k) => k.id === def.id).length;
@@ -317,17 +344,17 @@ export function evaluateCandidateCard(
 
   if (def.tags.includes("fire-extinguish")) {
     if (sameTypeExtinguishCount === 1) {
-      score -= 25;
+      score -= p.fireExtinguishDup1Penalty;
     } else if (sameTypeExtinguishCount >= 2) {
-      score -= 60;
+      score -= p.fireExtinguishDup2Penalty;
     }
   }
 
   if (def.id === "substance_o2" && sameDefCount >= 2) {
-    score -= 40;
+    score -= p.o2Dup2Penalty;
   }
   if (def.id === "substance_so2" && sameDefCount >= 2) {
-    score -= 50;
+    score -= p.so2Dup2Penalty;
   }
 
   if (
@@ -336,7 +363,7 @@ export function evaluateCandidateCard(
       (k) => k.id === "ion_oh" || k.id === "ion_cl" || k.id === "ion_so4",
     )
   ) {
-    score += 25;
+    score += p.ionHSynergy;
   }
   if (
     def.id === "ion_oh" &&
@@ -348,13 +375,13 @@ export function evaluateCandidateCard(
         k.id === "ion_ca",
     )
   ) {
-    score += 25;
+    score += p.ionOhSynergy;
   }
   if (def.id === "element_s" && alreadyKept.some((k) => k.id === "element_o")) {
-    score += 20;
+    score += p.elementSSynergy;
   }
   if (def.id === "element_o" && alreadyKept.some((k) => k.id === "element_s")) {
-    score += 15;
+    score += p.elementOSynergy;
   }
 
   return score;
@@ -365,6 +392,7 @@ export function selectLaboratoryPreparationCards(
   keepCount: number,
   observation: AIObservation,
   random: RandomSource,
+  weights: NATBA1Weights = NATBA1_BASE_WEIGHTS,
 ): CardInstanceId[] {
   const candidates = [...candidateCardInstanceIds];
   const keptCardInstanceIds: CardInstanceId[] = [];
@@ -386,7 +414,12 @@ export function selectLaboratoryPreparationCards(
         rulesText: "",
       };
 
-      const score = evaluateCandidateCard(def, keptDefinitions, observation.self.characterId);
+      const score = evaluateCandidateCard(
+        def,
+        keptDefinitions,
+        observation.self.characterId,
+        weights,
+      );
       if (score > bestScore) {
         bestScore = score;
         bestCandidates.length = 0;
@@ -415,60 +448,73 @@ export function selectLaboratoryPreparationCards(
   return keptCardInstanceIds;
 }
 
-export const natba1HeuristicPolicy: NATBAPolicy = (
-  observation: AIObservation,
-  context: DecisionContext,
-  random: RandomSource = Math.random,
-): GameAction | undefined => {
-  if (context.kind === "finite-actions") {
-    if (context.legalActions.length === 0) {
-      return undefined;
-    }
-
-    let highestScore = Number.NEGATIVE_INFINITY;
-    const bestActions: GameAction[] = [];
-
-    for (const action of context.legalActions) {
-      const score = scoreFiniteAction(action, observation);
-      if (score > highestScore) {
-        highestScore = score;
-        bestActions.length = 0;
-        bestActions.push(action);
-      } else if (score === highestScore) {
-        bestActions.push(action);
+export function createNATBA1Policy(
+  weights: NATBA1Weights = NATBA1_BASE_WEIGHTS,
+): NATBAPolicy {
+  return (
+    observation: AIObservation,
+    context: DecisionContext,
+    random: RandomSource = Math.random,
+  ): GameAction | undefined => {
+    if (context.kind === "finite-actions") {
+      if (context.legalActions.length === 0) {
+        return undefined;
       }
+
+      let highestScore = Number.NEGATIVE_INFINITY;
+      const bestActions: GameAction[] = [];
+
+      for (const action of context.legalActions) {
+        const score = scoreFiniteAction(action, observation, weights);
+        if (score > highestScore) {
+          highestScore = score;
+          bestActions.length = 0;
+          bestActions.push(action);
+        } else if (score === highestScore) {
+          bestActions.push(action);
+        }
+      }
+
+      if (bestActions.length === 0) {
+        return context.legalActions[0];
+      }
+
+      if (bestActions.length === 1) {
+        return bestActions[0];
+      }
+
+      const selectedIndex = Math.floor(random() * bestActions.length);
+      const clampedIndex = Math.min(
+        Math.max(0, selectedIndex),
+        bestActions.length - 1,
+      );
+      return bestActions[clampedIndex];
     }
 
-    if (bestActions.length === 0) {
-      return context.legalActions[0];
+    if (context.kind === "laboratory-preparation") {
+      const keptCardInstanceIds = selectLaboratoryPreparationCards(
+        context.candidateCardInstanceIds,
+        context.keepCount,
+        observation,
+        random,
+        weights,
+      );
+
+      return {
+        type: "CONFIRM_LABORATORY_PREPARATION",
+        playerId: context.playerId,
+        keptCardInstanceIds,
+      };
     }
 
-    if (bestActions.length === 1) {
-      return bestActions[0];
-    }
+    return undefined;
+  };
+}
 
-    const selectedIndex = Math.floor(random() * bestActions.length);
-    const clampedIndex = Math.min(
-      Math.max(0, selectedIndex),
-      bestActions.length - 1,
-    );
-    return bestActions[clampedIndex];
-  }
+export const natba1HeuristicPolicy: NATBAPolicy = createNATBA1Policy(
+  NATBA1_BASE_WEIGHTS,
+);
 
-  if (context.kind === "laboratory-preparation") {
-    const keptCardInstanceIds = selectLaboratoryPreparationCards(
-      context.candidateCardInstanceIds,
-      context.keepCount,
-      observation,
-      random,
-    );
-
-    return {
-      type: "CONFIRM_LABORATORY_PREPARATION",
-      playerId: context.playerId,
-      keptCardInstanceIds,
-    };
-  }
-
-  return undefined;
-};
+export const natba1xSelfPlayTunedPolicy: NATBAPolicy = createNATBA1Policy(
+  NATBA1X_TUNED_WEIGHTS,
+);

--- a/src/game/natba/natba1Weights.ts
+++ b/src/game/natba/natba1Weights.ts
@@ -1,0 +1,238 @@
+export type NATBA1Weights = {
+  readonly finiteActions: {
+    readonly passAction: number;
+    readonly passResponse: number;
+    readonly passStatusHandling: number;
+    readonly playReferenceCard: number;
+
+    readonly response: {
+      readonly base: number;
+      readonly carbonateBonus: number;
+      readonly ionBonus: number;
+      readonly otherBonus: number;
+      readonly lowHpBonus: number;
+    };
+
+    readonly handleStatus: {
+      readonly base: number;
+      readonly extinguishH2oCo2Bonus: number;
+      readonly ionOhBonus: number;
+      readonly lowHpBonus: number;
+    };
+
+    readonly counterattack: {
+      readonly recoverBase: number;
+      readonly recoverMissingHp2Bonus: number;
+      readonly recoverLowHpBonus: number;
+      readonly recoverFullHpScore: number;
+      readonly pursuitBase: number;
+      readonly pursuitLethalBonus: number;
+      readonly pursuitFullHpBonus: number;
+    };
+
+    readonly playCard: {
+      readonly unknownDef: number;
+      readonly o2MissingHp2Base: number;
+      readonly o2LowHpBonus: number;
+      readonly o2MissingHp1Base: number;
+      readonly o2FullHpScore: number;
+      readonly so2NewBase: number;
+      readonly so2LethalBonus: number;
+      readonly so2ExistingScore: number;
+      readonly attackBase: number;
+      readonly opponentLowHp2Bonus: number;
+      readonly opponentLowHp4Bonus: number;
+      readonly opponentHandEmptyBonus: number;
+      readonly opponentHandLow2Bonus: number;
+      readonly acidKingStrongAcidBonus: number;
+      readonly causticSodaStrongAlkaliBonus: number;
+      readonly factoryDirectorH2so4Bonus: number;
+    };
+
+    readonly playDiy: {
+      readonly fireExtinguishFireScore: number;
+      readonly fireExtinguishNoFireScore: number;
+      readonly so2NewScore: number;
+      readonly so2ExistingScore: number;
+      readonly attackBase: number;
+      readonly opponentLowHp2Bonus: number;
+      readonly opponentHandEmptyBonus: number;
+      readonly chemistryEnthusiastBonus: number;
+    };
+
+    readonly skills: {
+      readonly extraLesson: number;
+      readonly emergencySupply: number;
+      readonly alkaliRecoveryMissingHp2: number;
+      readonly alkaliRecoveryMissingHp1: number;
+      readonly alkaliRecoveryFullHp: number;
+      readonly exhaustDischargeNewSo2: number;
+      readonly exhaustDischargeExistingSo2: number;
+      readonly exhaustLeakBase: number;
+      readonly exhaustLeakLethalBonus: number;
+      readonly exothermicAccidentLethal: number;
+      readonly exothermicAccidentSelfLethal: number;
+      readonly exothermicAccidentNormal: number;
+      readonly labFireSelfFire: number;
+      readonly labFireHealthyOrLethal: number;
+      readonly labFireLowHp: number;
+      readonly labFireNormal: number;
+      readonly defaultSkill: number;
+    };
+  };
+
+  readonly prep: {
+    readonly baseScore: number;
+    readonly strongAcid: number;
+    readonly strongAlkali: number;
+    readonly substanceO2: number;
+    readonly substanceSo2: number;
+    readonly ionHOrOh: number;
+    readonly carbonate: number;
+    readonly fireExtinguish: number;
+
+    readonly charAcidKingBonus: number;
+    readonly charCausticSodaBonus: number;
+    readonly charFactoryDirectorBonus: number;
+
+    readonly fireExtinguishDup1Penalty: number;
+    readonly fireExtinguishDup2Penalty: number;
+    readonly o2Dup2Penalty: number;
+    readonly so2Dup2Penalty: number;
+
+    readonly ionHSynergy: number;
+    readonly ionOhSynergy: number;
+    readonly elementSSynergy: number;
+    readonly elementOSynergy: number;
+  };
+};
+
+export const NATBA1_BASE_WEIGHTS: NATBA1Weights = {
+  finiteActions: {
+    passAction: 10,
+    passResponse: 0,
+    passStatusHandling: 0,
+    playReferenceCard: 5,
+
+    response: {
+      base: 160,
+      carbonateBonus: 40,
+      ionBonus: 25,
+      otherBonus: 5,
+      lowHpBonus: 80,
+    },
+
+    handleStatus: {
+      base: 190,
+      extinguishH2oCo2Bonus: 35,
+      ionOhBonus: 25,
+      lowHpBonus: 80,
+    },
+
+    counterattack: {
+      recoverBase: 150,
+      recoverMissingHp2Bonus: 40,
+      recoverLowHpBonus: 60,
+      recoverFullHpScore: 0,
+      pursuitBase: 180,
+      pursuitLethalBonus: 70,
+      pursuitFullHpBonus: 30,
+    },
+
+    playCard: {
+      unknownDef: 40,
+      o2MissingHp2Base: 130,
+      o2LowHpBonus: 50,
+      o2MissingHp1Base: 70,
+      o2FullHpScore: 0,
+      so2NewBase: 120,
+      so2LethalBonus: 30,
+      so2ExistingScore: 20,
+      attackBase: 115,
+      opponentLowHp2Bonus: 80,
+      opponentLowHp4Bonus: 40,
+      opponentHandEmptyBonus: 40,
+      opponentHandLow2Bonus: 20,
+      acidKingStrongAcidBonus: 80,
+      causticSodaStrongAlkaliBonus: 40,
+      factoryDirectorH2so4Bonus: 35,
+    },
+
+    playDiy: {
+      fireExtinguishFireScore: 180,
+      fireExtinguishNoFireScore: 0,
+      so2NewScore: 125,
+      so2ExistingScore: 20,
+      attackBase: 135,
+      opponentLowHp2Bonus: 80,
+      opponentHandEmptyBonus: 35,
+      chemistryEnthusiastBonus: 60,
+    },
+
+    skills: {
+      extraLesson: 160,
+      emergencySupply: 160,
+      alkaliRecoveryMissingHp2: 130,
+      alkaliRecoveryMissingHp1: 80,
+      alkaliRecoveryFullHp: 10,
+      exhaustDischargeNewSo2: 125,
+      exhaustDischargeExistingSo2: 25,
+      exhaustLeakBase: 135,
+      exhaustLeakLethalBonus: 60,
+      exothermicAccidentLethal: 300,
+      exothermicAccidentSelfLethal: -100,
+      exothermicAccidentNormal: 140,
+      labFireSelfFire: 110,
+      labFireHealthyOrLethal: 100,
+      labFireLowHp: -30,
+      labFireNormal: 75,
+      defaultSkill: 60,
+    },
+  },
+
+  prep: {
+    baseScore: 35,
+    strongAcid: 130,
+    strongAlkali: 125,
+    substanceO2: 95,
+    substanceSo2: 90,
+    ionHOrOh: 80,
+    carbonate: 70,
+    fireExtinguish: 55,
+
+    charAcidKingBonus: 35,
+    charCausticSodaBonus: 35,
+    charFactoryDirectorBonus: 30,
+
+    fireExtinguishDup1Penalty: 25,
+    fireExtinguishDup2Penalty: 60,
+    o2Dup2Penalty: 40,
+    so2Dup2Penalty: 50,
+
+    ionHSynergy: 25,
+    ionOhSynergy: 25,
+    elementSSynergy: 20,
+    elementOSynergy: 15,
+  },
+};
+
+export const NATBA1X_TUNED_WEIGHTS: NATBA1Weights = {
+  ...NATBA1_BASE_WEIGHTS,
+  finiteActions: {
+    ...NATBA1_BASE_WEIGHTS.finiteActions,
+    counterattack: {
+      ...NATBA1_BASE_WEIGHTS.finiteActions.counterattack,
+      pursuitLethalBonus: 85,
+    },
+    playCard: {
+      ...NATBA1_BASE_WEIGHTS.finiteActions.playCard,
+      opponentLowHp2Bonus: 95,
+      opponentHandEmptyBonus: 45,
+    },
+    skills: {
+      ...NATBA1_BASE_WEIGHTS.finiteActions.skills,
+      exothermicAccidentLethal: 350,
+      exhaustLeakLethalBonus: 70,
+    },
+  },
+};

--- a/src/game/natba/natba1Weights.ts
+++ b/src/game/natba/natba1Weights.ts
@@ -216,23 +216,43 @@ export const NATBA1_BASE_WEIGHTS: NATBA1Weights = {
   },
 };
 
+function cloneNATBA1Weights(weights: NATBA1Weights): NATBA1Weights {
+  return {
+    finiteActions: {
+      passAction: weights.finiteActions.passAction,
+      passResponse: weights.finiteActions.passResponse,
+      passStatusHandling: weights.finiteActions.passStatusHandling,
+      playReferenceCard: weights.finiteActions.playReferenceCard,
+      response: { ...weights.finiteActions.response },
+      handleStatus: { ...weights.finiteActions.handleStatus },
+      counterattack: { ...weights.finiteActions.counterattack },
+      playCard: { ...weights.finiteActions.playCard },
+      playDiy: { ...weights.finiteActions.playDiy },
+      skills: { ...weights.finiteActions.skills },
+    },
+    prep: { ...weights.prep },
+  };
+}
+
+const natba1xWeightDraft = cloneNATBA1Weights(NATBA1_BASE_WEIGHTS);
+
 export const NATBA1X_TUNED_WEIGHTS: NATBA1Weights = {
-  ...NATBA1_BASE_WEIGHTS,
   finiteActions: {
-    ...NATBA1_BASE_WEIGHTS.finiteActions,
+    ...natba1xWeightDraft.finiteActions,
     counterattack: {
-      ...NATBA1_BASE_WEIGHTS.finiteActions.counterattack,
+      ...natba1xWeightDraft.finiteActions.counterattack,
       pursuitLethalBonus: 85,
     },
     playCard: {
-      ...NATBA1_BASE_WEIGHTS.finiteActions.playCard,
+      ...natba1xWeightDraft.finiteActions.playCard,
       opponentLowHp2Bonus: 95,
       opponentHandEmptyBonus: 45,
     },
     skills: {
-      ...NATBA1_BASE_WEIGHTS.finiteActions.skills,
+      ...natba1xWeightDraft.finiteActions.skills,
       exothermicAccidentLethal: 350,
       exhaustLeakLethalBonus: 70,
     },
   },
+  prep: natba1xWeightDraft.prep,
 };

--- a/src/game/tests/natba1Policy.test.ts
+++ b/src/game/tests/natba1Policy.test.ts
@@ -7,7 +7,15 @@ import { getDecisionContext } from "../engine/decisionContext";
 import { validateGameAction } from "../engine/legalActions";
 import { engineReducer } from "../engine/reducer";
 import type { GameState } from "../engine/types";
-import { natba1HeuristicPolicy } from "../natba/natba1HeuristicPolicy";
+import {
+  createNATBA1Policy,
+  natba1HeuristicPolicy,
+  natba1xSelfPlayTunedPolicy,
+} from "../natba/natba1HeuristicPolicy";
+import {
+  NATBA1_BASE_WEIGHTS,
+  NATBA1X_TUNED_WEIGHTS,
+} from "../natba/natba1Weights";
 
 function confirmPreparation(state: GameState): GameState {
   const pending = state.pendingLaboratoryPreparation;
@@ -257,5 +265,70 @@ describe("Phase 19E — NATBA-1 Heuristic Policy", () => {
     const actions2 = runA();
 
     expect(actions1).toEqual(actions2);
+  });
+});
+
+describe("Phase 19G — NATBA-1.x Weights Decoupling & Tuned Policy", () => {
+  it("separates base NATBA-1 weights from tuned NATBA-1.x weights while preserving types", () => {
+    expect(NATBA1_BASE_WEIGHTS).toBeDefined();
+    expect(NATBA1X_TUNED_WEIGHTS).toBeDefined();
+
+    // Verify base weights values remain frozen
+    expect(NATBA1_BASE_WEIGHTS.finiteActions.playCard.opponentLowHp2Bonus).toBe(80);
+    expect(NATBA1_BASE_WEIGHTS.finiteActions.playCard.opponentLowHp4Bonus).toBe(40);
+    expect(NATBA1_BASE_WEIGHTS.finiteActions.playDiy.attackBase).toBe(135);
+
+    // Verify tuned weights reflect self-play optimization
+    expect(NATBA1X_TUNED_WEIGHTS.finiteActions.playCard.opponentLowHp2Bonus).toBe(95);
+    expect(NATBA1X_TUNED_WEIGHTS.finiteActions.playCard.opponentHandEmptyBonus).toBe(45);
+    expect(NATBA1X_TUNED_WEIGHTS.finiteActions.counterattack.pursuitLethalBonus).toBe(85);
+    expect(NATBA1X_TUNED_WEIGHTS.finiteActions.skills.exothermicAccidentLethal).toBe(350);
+  });
+
+  it("supports createNATBA1Policy factory and generates fully legal actions for 1.x", () => {
+    const customPolicy = createNATBA1Policy(NATBA1X_TUNED_WEIGHTS);
+    const state = createReadyMainGameState();
+    const context = getDecisionContext(state);
+    expect(context.kind).toBe("finite-actions");
+    if (context.kind !== "finite-actions") return;
+
+    const observation = getAIObservation(state, context.playerId);
+    const prng = createMulberry32(998877);
+
+    const action = customPolicy(observation, context, prng);
+    expect(action).toBeDefined();
+    if (!action) return;
+
+    expect(context.legalActions).toContainEqual(action);
+    expect(validateGameAction(state, action)).toBe(true);
+
+    const tunedAction = natba1xSelfPlayTunedPolicy(observation, context, prng);
+    expect(tunedAction).toBeDefined();
+    if (!tunedAction) return;
+    expect(context.legalActions).toContainEqual(tunedAction);
+  });
+
+  it("executes laboratory preparation cleanly under NATBA-1.x policy", () => {
+    const state = createInitialGame({
+      gameId: "test_prep_natba1x",
+      characterIds: ["laboratory_teacher", "chemical_factory_ceo"],
+      shuffle: identityShuffle,
+    });
+    const context = getDecisionContext(state);
+    expect(context.kind).toBe("laboratory-preparation");
+    if (context.kind !== "laboratory-preparation") return;
+
+    const observation = getAIObservation(state, context.playerId);
+    const prng = createMulberry32(554433);
+
+    const action = natba1xSelfPlayTunedPolicy(observation, context, prng);
+    expect(action).toBeDefined();
+    if (!action) return;
+
+    expect(action.type).toBe("CONFIRM_LABORATORY_PREPARATION");
+    if (action.type !== "CONFIRM_LABORATORY_PREPARATION") return;
+    expect(action.keptCardInstanceIds).toHaveLength(10);
+    expect(new Set(action.keptCardInstanceIds).size).toBe(10);
+    expect(validateGameAction(state, action)).toBe(true);
   });
 });

--- a/src/game/tests/natba1Policy.test.ts
+++ b/src/game/tests/natba1Policy.test.ts
@@ -268,21 +268,32 @@ describe("Phase 19E — NATBA-1 Heuristic Policy", () => {
   });
 });
 
-describe("Phase 19G — NATBA-1.x Weights Decoupling & Tuned Policy", () => {
-  it("separates base NATBA-1 weights from tuned NATBA-1.x weights while preserving types", () => {
+describe("Phase 19G — NATBA-1.x Weight Decoupling & Default Policy", () => {
+  it("separates NATBA-1 base weights from NATBA-1.x overrides without sharing nested objects", () => {
     expect(NATBA1_BASE_WEIGHTS).toBeDefined();
     expect(NATBA1X_TUNED_WEIGHTS).toBeDefined();
 
-    // Verify base weights values remain frozen
     expect(NATBA1_BASE_WEIGHTS.finiteActions.playCard.opponentLowHp2Bonus).toBe(80);
     expect(NATBA1_BASE_WEIGHTS.finiteActions.playCard.opponentLowHp4Bonus).toBe(40);
     expect(NATBA1_BASE_WEIGHTS.finiteActions.playDiy.attackBase).toBe(135);
+    expect(NATBA1_BASE_WEIGHTS.finiteActions.skills.exhaustLeakLethalBonus).toBe(60);
 
-    // Verify tuned weights reflect self-play optimization
     expect(NATBA1X_TUNED_WEIGHTS.finiteActions.playCard.opponentLowHp2Bonus).toBe(95);
     expect(NATBA1X_TUNED_WEIGHTS.finiteActions.playCard.opponentHandEmptyBonus).toBe(45);
     expect(NATBA1X_TUNED_WEIGHTS.finiteActions.counterattack.pursuitLethalBonus).toBe(85);
     expect(NATBA1X_TUNED_WEIGHTS.finiteActions.skills.exothermicAccidentLethal).toBe(350);
+    expect(NATBA1X_TUNED_WEIGHTS.finiteActions.skills.exhaustLeakLethalBonus).toBe(70);
+
+    expect(NATBA1X_TUNED_WEIGHTS.finiteActions.response).not.toBe(
+      NATBA1_BASE_WEIGHTS.finiteActions.response,
+    );
+    expect(NATBA1X_TUNED_WEIGHTS.finiteActions.handleStatus).not.toBe(
+      NATBA1_BASE_WEIGHTS.finiteActions.handleStatus,
+    );
+    expect(NATBA1X_TUNED_WEIGHTS.finiteActions.playDiy).not.toBe(
+      NATBA1_BASE_WEIGHTS.finiteActions.playDiy,
+    );
+    expect(NATBA1X_TUNED_WEIGHTS.prep).not.toBe(NATBA1_BASE_WEIGHTS.prep);
   });
 
   it("supports createNATBA1Policy factory and generates fully legal actions for 1.x", () => {

--- a/src/game/tests/natbaSelfPlay.test.ts
+++ b/src/game/tests/natbaSelfPlay.test.ts
@@ -4,6 +4,7 @@ import {
   allDefaultCharacterIds,
   natba0RandomLegalPolicy,
   natba1HeuristicPolicy,
+  natba1xSelfPlayTunedPolicy,
   runBatchSelfPlay,
   runSelfPlayGame,
   type NATBAPolicy,
@@ -383,4 +384,140 @@ describe("Phase 19E — NATBA-1 Heuristic Policy Self-Play & Win-Rate Benchmark"
     expect(totalHeuristicWins).toBeGreaterThan(totalRandomWins * 2);
   });
 });
+
+describe("Phase 19G — NATBA-1.x Self-Play Tuned Policy Benchmark", () => {
+  it("replays full NATBA-1.x vs NATBA-1.x game deterministically with bit-identical final states and logs", () => {
+    const seed = 654321987;
+    const run1 = runSelfPlayGame({
+      gameId: "natba1x_replay_test",
+      seed,
+      characterIds: ["laboratory_teacher", "chemistry_enthusiast"],
+      policyPlayer1: natba1xSelfPlayTunedPolicy,
+      policyPlayer2: natba1xSelfPlayTunedPolicy,
+    });
+
+    const run2 = runSelfPlayGame({
+      gameId: "natba1x_replay_test",
+      seed,
+      characterIds: ["laboratory_teacher", "chemistry_enthusiast"],
+      policyPlayer1: natba1xSelfPlayTunedPolicy,
+      policyPlayer2: natba1xSelfPlayTunedPolicy,
+    });
+    expect(run1.completed).toBe(true);
+    expect(run2.completed).toBe(true);
+    expect(run1.deadlocked).toBe(false);
+    expect(run2.deadlocked).toBe(false);
+    expect(run1.illegalActionAttempts).toBe(0);
+    expect(run2.illegalActionAttempts).toBe(0);
+
+    expect(run1.totalSteps).toBe(run2.totalSteps);
+    expect(run1.actionLog).toEqual(run2.actionLog);
+    expect(run1.finalState).toEqual(run2.finalState);
+    expect(JSON.stringify(run1.finalState)).toBe(JSON.stringify(run2.finalState));
+    expect(run1.finalState.log).toEqual(run2.finalState.log);
+  });
+
+  it("completes clean NATBA-1.x self-play matches across all 7 playable characters with zero illegal actions", () => {
+    const testPairs = [
+      ["laboratory_teacher", "chemical_factory_ceo"] as const,
+      ["clumsy_party_secretary", "caustic_soda_captain"] as const,
+      ["acid_king", "chemistry_enthusiast"] as const,
+      ["sulfuric_acid_factory_director", "laboratory_teacher"] as const,
+      ["caustic_soda_captain", "acid_king"] as const,
+      ["chemistry_enthusiast", "clumsy_party_secretary"] as const,
+      ["chemical_factory_ceo", "sulfuric_acid_factory_director"] as const,
+    ];
+
+    for (let index = 0; index < testPairs.length; index += 1) {
+      const pair = testPairs[index];
+      const result = runSelfPlayGame({
+        gameId: `natba1x_char_test_${index}`,
+        seed: 3000 + index * 43,
+        characterIds: pair,
+        policyPlayer1: natba1xSelfPlayTunedPolicy,
+        policyPlayer2: natba1xSelfPlayTunedPolicy,
+        maxSteps: 1000,
+      });
+
+      expect(result.completed).toBe(true);
+      expect(result.deadlocked).toBe(false);
+      expect(result.illegalActionAttempts).toBe(0);
+      expect(result.totalSteps).toBeGreaterThan(0);
+      expect(result.finalState.phase).toBe("gameOver");
+    }
+  });
+
+  it("demonstrates significant win-rate superiority of NATBA-1.x over NATBA-0 baseline in paired matchups", () => {
+    const summaryP1Tuned = runBatchSelfPlay({
+      gameCount: 50,
+      baseSeed: 20260901,
+      policyPlayer1: natba1xSelfPlayTunedPolicy,
+      policyPlayer2: natba0RandomLegalPolicy,
+      maxStepsPerGame: 1000,
+    });
+
+    const summaryP2Tuned = runBatchSelfPlay({
+      gameCount: 50,
+      baseSeed: 20260901,
+      policyPlayer1: natba0RandomLegalPolicy,
+      policyPlayer2: natba1xSelfPlayTunedPolicy,
+      maxStepsPerGame: 1000,
+    });
+
+    expect(summaryP1Tuned.totalIllegalActionAttempts).toBe(0);
+    expect(summaryP1Tuned.totalDeadlocks).toBe(0);
+    expect(summaryP1Tuned.abortedGames).toBe(0);
+
+    expect(summaryP2Tuned.totalIllegalActionAttempts).toBe(0);
+    expect(summaryP2Tuned.totalDeadlocks).toBe(0);
+    expect(summaryP2Tuned.abortedGames).toBe(0);
+
+    const totalTunedWins =
+      summaryP1Tuned.winsPlayer1 + summaryP2Tuned.winsPlayer2;
+    const totalRandomWins =
+      summaryP1Tuned.winsPlayer2 + summaryP2Tuned.winsPlayer1;
+    const totalCompleted =
+      100 - (summaryP1Tuned.draws + summaryP2Tuned.draws);
+
+    const overallTunedWinRate = totalTunedWins / totalCompleted;
+
+    expect(overallTunedWinRate).toBeGreaterThanOrEqual(0.7);
+    expect(totalTunedWins).toBeGreaterThan(totalRandomWins * 2);
+  });
+
+  it("verifies NATBA-1.x vs NATBA-1 mirror matchup baseline under deterministic paired seeds", () => {
+    const summaryP1Tuned = runBatchSelfPlay({
+      gameCount: 50,
+      baseSeed: 20260901,
+      policyPlayer1: natba1xSelfPlayTunedPolicy,
+      policyPlayer2: natba1HeuristicPolicy,
+      maxStepsPerGame: 1000,
+    });
+
+    const summaryP2Tuned = runBatchSelfPlay({
+      gameCount: 50,
+      baseSeed: 20260901,
+      policyPlayer1: natba1HeuristicPolicy,
+      policyPlayer2: natba1xSelfPlayTunedPolicy,
+      maxStepsPerGame: 1000,
+    });
+
+    expect(summaryP1Tuned.totalIllegalActionAttempts).toBe(0);
+    expect(summaryP2Tuned.totalIllegalActionAttempts).toBe(0);
+
+    const totalTunedWins =
+      summaryP1Tuned.winsPlayer1 + summaryP2Tuned.winsPlayer2;
+    const totalBaseWins =
+      summaryP1Tuned.winsPlayer2 + summaryP2Tuned.winsPlayer1;
+    const totalDecided = totalTunedWins + totalBaseWins;
+
+    expect(totalDecided).toBeGreaterThan(0);
+    const overallTunedWinRate = totalTunedWins / totalDecided;
+
+    // Tuned policy matches or exceeds base policy in paired matchup
+    expect(overallTunedWinRate).toBeGreaterThanOrEqual(0.5);
+    expect(totalTunedWins).toBeGreaterThanOrEqual(totalBaseWins);
+  });
+});
+
 

--- a/src/game/tests/natbaSelfPlay.test.ts
+++ b/src/game/tests/natbaSelfPlay.test.ts
@@ -385,7 +385,7 @@ describe("Phase 19E — NATBA-1 Heuristic Policy Self-Play & Win-Rate Benchmark"
   });
 });
 
-describe("Phase 19G — NATBA-1.x Self-Play Tuned Policy Benchmark", () => {
+describe("Phase 19G — NATBA-1.x Weight Decoupling & Default Policy", () => {
   it("replays full NATBA-1.x vs NATBA-1.x game deterministically with bit-identical final states and logs", () => {
     const seed = 654321987;
     const run1 = runSelfPlayGame({
@@ -485,8 +485,8 @@ describe("Phase 19G — NATBA-1.x Self-Play Tuned Policy Benchmark", () => {
     expect(totalTunedWins).toBeGreaterThan(totalRandomWins * 2);
   });
 
-  it("verifies NATBA-1.x vs NATBA-1 mirror matchup baseline under deterministic paired seeds", () => {
-    const summaryP1Tuned = runBatchSelfPlay({
+  it("records NATBA-1.x vs NATBA-1 paired outcomes against total games without dropping aborted matches", () => {
+    const summaryP1OneX = runBatchSelfPlay({
       gameCount: 50,
       baseSeed: 20260901,
       policyPlayer1: natba1xSelfPlayTunedPolicy,
@@ -494,7 +494,7 @@ describe("Phase 19G — NATBA-1.x Self-Play Tuned Policy Benchmark", () => {
       maxStepsPerGame: 1000,
     });
 
-    const summaryP2Tuned = runBatchSelfPlay({
+    const summaryP2OneX = runBatchSelfPlay({
       gameCount: 50,
       baseSeed: 20260901,
       policyPlayer1: natba1HeuristicPolicy,
@@ -502,21 +502,27 @@ describe("Phase 19G — NATBA-1.x Self-Play Tuned Policy Benchmark", () => {
       maxStepsPerGame: 1000,
     });
 
-    expect(summaryP1Tuned.totalIllegalActionAttempts).toBe(0);
-    expect(summaryP2Tuned.totalIllegalActionAttempts).toBe(0);
+    expect(summaryP1OneX.totalIllegalActionAttempts).toBe(0);
+    expect(summaryP2OneX.totalIllegalActionAttempts).toBe(0);
 
-    const totalTunedWins =
-      summaryP1Tuned.winsPlayer1 + summaryP2Tuned.winsPlayer2;
-    const totalBaseWins =
-      summaryP1Tuned.winsPlayer2 + summaryP2Tuned.winsPlayer1;
-    const totalDecided = totalTunedWins + totalBaseWins;
+    const totalGames = summaryP1OneX.totalGames + summaryP2OneX.totalGames;
+    expect(totalGames).toBe(100);
 
-    expect(totalDecided).toBeGreaterThan(0);
-    const overallTunedWinRate = totalTunedWins / totalDecided;
+    const policy1xWins =
+      summaryP1OneX.winsPlayer1 + summaryP2OneX.winsPlayer2;
+    const policy1Wins =
+      summaryP1OneX.winsPlayer2 + summaryP2OneX.winsPlayer1;
+    const draws = summaryP1OneX.draws + summaryP2OneX.draws;
+    const aborted = summaryP1OneX.abortedGames + summaryP2OneX.abortedGames;
+    const deadlocks =
+      summaryP1OneX.totalDeadlocks + summaryP2OneX.totalDeadlocks;
 
-    // Tuned policy matches or exceeds base policy in paired matchup
-    expect(overallTunedWinRate).toBeGreaterThanOrEqual(0.5);
-    expect(totalTunedWins).toBeGreaterThanOrEqual(totalBaseWins);
+    expect(policy1xWins).toBeGreaterThanOrEqual(0);
+    expect(policy1Wins).toBeGreaterThanOrEqual(0);
+    expect(draws).toBeGreaterThanOrEqual(0);
+    expect(aborted).toBeGreaterThanOrEqual(0);
+    expect(deadlocks).toBeGreaterThanOrEqual(0);
+    expect(policy1xWins + policy1Wins + draws + aborted).toBe(totalGames);
   });
 });
 


### PR DESCRIPTION
## Summary

Decouple NATBA-1 heuristic weights and default solo-vs-AI to NATBA-1.x.

This PR does **not** claim NATBA-1.x beats NATBA-1.

### Changes
- `NATBA1_BASE_WEIGHTS` vs cloned `NATBA1X_TUNED_WEIGHTS`
- `createNATBA1Policy(weights)` factory
- Default session policy: `natba1xSelfPlayTunedPolicy`
- 1.x vs 1 tests record wins/losses/draws/aborts against total games (no 0.5 superiority gate)

### Verification
| Check | Result |
| :--- | :--- |
| `pnpm run test:run` | 763 passed |
| `pnpm run test:shuffle` | 763 passed |
| `pnpm run build` | ✅ |
| `pnpm run check:size` | JS gzip 105,147 / 108,000 |

No rule / card-pool / skill value changes.