### PR TITLE
feat: Phase 18E.1 DIY Selection Context

### DIFF
--- a/e2e/production/reaction-field.spec.ts
+++ b/e2e/production/reaction-field.spec.ts
@@ -281,6 +281,7 @@ test("正式构建在 / 验证 Phase 16 双语游戏日志、反应日志与 DIY
   // 1. Formal DIY Virtual Attack execution
   const diyPanel = page.locator(".diy-panel");
   await expect(diyPanel).toBeVisible();
+  await page.getByRole("button", { name: "进入主动 DIY" }).click();
 
   const virtualAttackRecipes = [
     {

--- a/src/features/local-game/components/DiyPanel.test.tsx
+++ b/src/features/local-game/components/DiyPanel.test.tsx
@@ -93,8 +93,8 @@ beforeEach(() => {
   });
 });
 
-describe("Selection-First DiyPanel Component", () => {
-  it("renders only diy-component cards and excludes ordinary substance cards", async () => {
+describe("Selection-First DiyPanel Component with DIY Selection Context", () => {
+  it("does not allow selecting component cards when not in DIY mode, renders explicit entry button", async () => {
     Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
     const container = document.createElement("div");
     document.body.append(container);
@@ -113,10 +113,27 @@ describe("Selection-First DiyPanel Component", () => {
         );
       });
 
-      const candidateCards = container.querySelectorAll(".candidate-card");
+      // Initially outside DIY selection context: no candidate-card clickable items
+      const candidateCardsBefore = container.querySelectorAll(".candidate-card");
+      expect(candidateCardsBefore.length).toBe(0);
+
+      // Entry button is visible
+      const enterButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("进入主动 DIY"),
+      ) as HTMLButtonElement;
+      expect(enterButton).toBeDefined();
+      expect(enterButton.disabled).toBe(false);
+      expect(container.textContent).toContain("PLAY_DIY_SELECTION · status: NOT_IN_DIY_MODE");
+
+      // Click enter button to enter DIY Selection Context
+      await act(async () => {
+        enterButton.click();
+      });
+
+      const candidateCardsAfter = container.querySelectorAll(".candidate-card");
       // h, cl, c, o1, o2 are diy-components (5 cards), substance_hcl_dilute is not
-      expect(candidateCards.length).toBe(5);
-      const submitButton = container.querySelector('button.primary-button') as HTMLButtonElement;
+      expect(candidateCardsAfter.length).toBe(5);
+      const submitButton = container.querySelector("button.primary-button") as HTMLButtonElement;
       expect(submitButton).not.toBeNull();
       expect(submitButton.disabled).toBe(true);
       expect(container.textContent).toContain("请在下方点选手牌中的组件卡牌组合出牌。");
@@ -126,7 +143,7 @@ describe("Selection-First DiyPanel Component", () => {
     }
   });
 
-  it("handles multi-selection, toggling, and clear selection", async () => {
+  it("handles multi-selection, toggling, clear selection, and cancel DIY", async () => {
     Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
     const container = document.createElement("div");
     document.body.append(container);
@@ -143,6 +160,14 @@ describe("Selection-First DiyPanel Component", () => {
             createElement(DiyPanel, { game, dispatchGameAction: dispatch }),
           ),
         );
+      });
+
+      // Enter DIY mode
+      const enterButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("进入主动 DIY"),
+      ) as HTMLButtonElement;
+      await act(async () => {
+        enterButton.click();
       });
 
       const buttons = Array.from(
@@ -180,6 +205,11 @@ describe("Selection-First DiyPanel Component", () => {
       expect(clButton?.getAttribute("aria-pressed")).toBe("false");
       expect(submitButton.disabled).toBe(true);
 
+      // Select Cl- again
+      await act(async () => {
+        clButton?.click();
+      });
+
       // Clear selection
       const clearButton = Array.from(
         container.querySelectorAll("button"),
@@ -189,14 +219,48 @@ describe("Selection-First DiyPanel Component", () => {
         clearButton?.click();
       });
       expect(hButton?.getAttribute("aria-pressed")).toBe("false");
+      expect(clButton?.getAttribute("aria-pressed")).toBe("false");
       expect(container.textContent).toContain("请在下方点选手牌中的组件卡牌组合出牌。");
+
+      // Select H+ and Cl- again
+      await act(async () => {
+        hButton?.click();
+        clButton?.click();
+      });
+
+      // Cancel DIY -> exits selection context and clears selection
+      const cancelButton = Array.from(
+        container.querySelectorAll("button"),
+      ).find((b) => b.textContent?.includes("取消 DIY"));
+      expect(cancelButton).toBeDefined();
+      await act(async () => {
+        cancelButton?.click();
+      });
+
+      // Returned to idle mode
+      expect(container.querySelectorAll(".candidate-card").length).toBe(0);
+      const reEnterButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("进入主动 DIY"),
+      ) as HTMLButtonElement;
+      expect(reEnterButton).toBeDefined();
+
+      // Re-enter DIY mode: selection is empty
+      await act(async () => {
+        reEnterButton.click();
+      });
+      const newButtons = Array.from(
+        container.querySelectorAll(".candidate-card"),
+      ) as HTMLButtonElement[];
+      for (const btn of newButtons) {
+        expect(btn.getAttribute("aria-pressed")).toBe("false");
+      }
     } finally {
       await act(async () => root.unmount());
       container.remove();
     }
   });
 
-  it("submits PLAY_DIY_SELECTION action without recipeId and clears selection on success", async () => {
+  it("submits PLAY_DIY_SELECTION action without recipeId and exits selection mode on success", async () => {
     Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
     const container = document.createElement("div");
     document.body.append(container);
@@ -216,6 +280,14 @@ describe("Selection-First DiyPanel Component", () => {
             createElement(DiyPanel, { game, dispatchGameAction: dispatch }),
           ),
         );
+      });
+
+      // Enter DIY mode
+      const enterButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("进入主动 DIY"),
+      ) as HTMLButtonElement;
+      await act(async () => {
+        enterButton.click();
       });
 
       const buttons = Array.from(
@@ -246,9 +318,13 @@ describe("Selection-First DiyPanel Component", () => {
       // Verification: recipeId must not be present in formal action
       expect("recipeId" in (actions[0] as unknown as Record<string, unknown>)).toBe(false);
 
-      // Selection state should be reset
-      expect(hButton?.getAttribute("aria-pressed")).toBe("false");
-      expect(clButton?.getAttribute("aria-pressed")).toBe("false");
+      // After submit: should exit DIY mode
+      expect(container.querySelectorAll(".candidate-card").length).toBe(0);
+      expect(
+        Array.from(container.querySelectorAll("button")).some((b) =>
+          b.textContent?.includes("进入主动 DIY"),
+        ),
+      ).toBe(true);
     } finally {
       await act(async () => root.unmount());
       container.remove();
@@ -281,7 +357,7 @@ describe("Selection-First DiyPanel Component", () => {
     const dispatch = vi.fn();
 
     try {
-      // 1. Without FIRE: C + O + O matches CO2 but is blocked with OWN_FIRE_REQUIRED
+      // 1. Without FIRE: enter DIY -> C + O + O matches CO2 but is blocked with OWN_FIRE_REQUIRED
       await act(async () => {
         root.render(
           createElement(
@@ -290,6 +366,13 @@ describe("Selection-First DiyPanel Component", () => {
             createElement(DiyPanel, { game: gameWithoutFire, dispatchGameAction: dispatch }),
           ),
         );
+      });
+
+      const enterButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("进入主动 DIY"),
+      ) as HTMLButtonElement;
+      await act(async () => {
+        enterButton.click();
       });
 
       const buttons = Array.from(
@@ -322,7 +405,24 @@ describe("Selection-First DiyPanel Component", () => {
         );
       });
 
-      // Since cards are already selected, it should immediately be EXECUTABLE upon receiving gameWithFire
+      // Re-enter and select on gameWithFire
+      const enterButtonFire = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("进入主动 DIY"),
+      );
+      if (enterButtonFire) {
+        await act(async () => {
+          enterButtonFire.click();
+        });
+        const buttonsFire = Array.from(
+          container.querySelectorAll(".candidate-card"),
+        ) as HTMLButtonElement[];
+        await act(async () => {
+          buttonsFire.find((b) => b.textContent?.includes("c_card_1"))?.click();
+          buttonsFire.find((b) => b.textContent?.includes("o_card_1"))?.click();
+          buttonsFire.find((b) => b.textContent?.includes("o_card_2"))?.click();
+        });
+      }
+
       expect(container.textContent).toContain("执行效果：移除自身火情状态 (CO2)");
       const submitButtonFire = container.querySelector("button.primary-button") as HTMLButtonElement;
       expect(submitButtonFire.disabled).toBe(false);
@@ -331,7 +431,6 @@ describe("Selection-First DiyPanel Component", () => {
       container.remove();
     }
   });
-
 
   it("disables all controls during AI turn", async () => {
     Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
@@ -356,15 +455,11 @@ describe("Selection-First DiyPanel Component", () => {
         );
       });
 
-      const candidateCards = Array.from(
-        container.querySelectorAll(".candidate-card"),
-      ) as HTMLButtonElement[];
-      for (const btn of candidateCards) {
-        expect(btn.disabled).toBe(true);
-      }
-
-      const submitButton = container.querySelector("button.primary-button") as HTMLButtonElement;
-      expect(submitButton.disabled).toBe(true);
+      const enterButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("进入主动 DIY") || b.textContent?.includes("Enter active DIY"),
+      ) as HTMLButtonElement;
+      expect(enterButton).toBeDefined();
+      expect(enterButton.disabled).toBe(true);
     } finally {
       await act(async () => root.unmount());
       container.remove();
@@ -392,8 +487,7 @@ describe("Selection-First DiyPanel Component", () => {
       });
 
       expect(container.textContent).toContain("主动 DIY");
-      expect(container.textContent).toContain("手牌组件卡");
-      expect(container.textContent).toContain("执行主动 DIY");
+      expect(container.textContent).toContain("进入主动 DIY");
 
       const englishButton = Array.from(
         container.querySelectorAll(".locale-switch__button"),
@@ -405,9 +499,35 @@ describe("Selection-First DiyPanel Component", () => {
       });
 
       expect(container.textContent).toContain("Active DIY");
+      expect(container.textContent).toContain("Enter active DIY");
+
+      const enterButtonEn = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent === "Enter active DIY",
+      ) as HTMLButtonElement;
+      expect(enterButtonEn).toBeDefined();
+
+      await act(async () => {
+        enterButtonEn.click();
+      });
+
       expect(container.textContent).toContain("Hand component cards");
       expect(container.textContent).toContain("Run active DIY");
+      expect(container.textContent).toContain("Cancel DIY");
       expect(container.textContent).toContain("Select component cards from your hand to craft.");
+
+      const chineseButton = Array.from(
+        container.querySelectorAll(".locale-switch__button"),
+      ).find((b) => b.textContent === "中文") as HTMLButtonElement;
+      expect(chineseButton).toBeDefined();
+
+      await act(async () => {
+        chineseButton.click();
+      });
+
+      expect(container.textContent).toContain("手牌组件卡");
+      expect(container.textContent).toContain("执行主动 DIY");
+      expect(container.textContent).toContain("取消 DIY");
+      expect(container.textContent).toContain("请在下方点选手牌中的组件卡牌组合出牌。");
     } finally {
       await act(async () => root.unmount());
       container.remove();

--- a/src/features/local-game/components/DiyPanel.tsx
+++ b/src/features/local-game/components/DiyPanel.tsx
@@ -48,6 +48,7 @@ export function DiyPanel({ game, playerControllers, dispatchGameAction }: DiyPan
     });
   }, [activePlayer, game]);
 
+  const [isSelecting, setIsSelecting] = useState<boolean>(false);
   const [selectedCardIds, setSelectedCardIds] = useState<CardInstanceId[]>([]);
   const [targetPlayerId, setTargetPlayerId] = useState<PlayerId | undefined>();
   const targets = activePlayer ? getOpponentTargets(game, activePlayer.id) : [];
@@ -59,11 +60,16 @@ export function DiyPanel({ game, playerControllers, dispatchGameAction }: DiyPan
       : defaultTargetPlayerId;
 
   useEffect(() => {
+    setIsSelecting(false);
+    setSelectedCardIds([]);
+  }, [activePlayer?.id, game.cycleNumber, game.roundInCycle, game.phase]);
+
+  useEffect(() => {
     setSelectedCardIds((prev) => prev.filter((id) => candidateCardIds.includes(id)));
   }, [candidateCardIds]);
 
   const analysis: DIYSelectionAnalysis | null = useMemo(() => {
-    if (!activePlayer || selectedCardIds.length === 0) {
+    if (!isSelecting || !activePlayer || selectedCardIds.length === 0) {
       return null;
     }
     const initialAnalysis = analyzeDIYSelection(
@@ -84,7 +90,7 @@ export function DiyPanel({ game, playerControllers, dispatchGameAction }: DiyPan
       );
     }
     return initialAnalysis;
-  }, [activePlayer, effectiveTargetPlayerId, game, selectedCardIds]);
+  }, [activePlayer, effectiveTargetPlayerId, game, isSelecting, selectedCardIds]);
 
   if (game.phase !== "mainAction" || !activePlayer) {
     return null;
@@ -202,6 +208,11 @@ export function DiyPanel({ game, playerControllers, dispatchGameAction }: DiyPan
     return null;
   }
 
+  function handleCancelDiy() {
+    setSelectedCardIds([]);
+    setIsSelecting(false);
+  }
+
   function handlePlayDiy() {
     if (!activePlayer || !canSubmit || !analysis || analysis.status !== "EXECUTABLE") {
       return;
@@ -219,6 +230,7 @@ export function DiyPanel({ game, playerControllers, dispatchGameAction }: DiyPan
       targetPlayerId: targetId,
     });
     setSelectedCardIds([]);
+    setIsSelecting(false);
   }
 
   return (
@@ -244,103 +256,128 @@ export function DiyPanel({ game, playerControllers, dispatchGameAction }: DiyPan
       <details className="debug-details">
         <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
         <p>
-          PLAY_DIY_SELECTION · status: {analysis?.status ?? "NO_SELECTION"}
-          {analysis && "recipeId" in analysis ? ` · recipe: ${analysis.recipeId}` : ""}
-          {analysis && "blockerCode" in analysis ? ` · blocker: ${analysis.blockerCode}` : ""}
+          PLAY_DIY_SELECTION · status: {isSelecting ? (analysis?.status ?? "NO_SELECTION") : "NOT_IN_DIY_MODE"}
+          {isSelecting && analysis && "recipeId" in analysis ? ` · recipe: ${analysis.recipeId}` : ""}
+          {isSelecting && analysis && "blockerCode" in analysis ? ` · blocker: ${analysis.blockerCode}` : ""}
         </p>
       </details>
 
-      <div className="diy-candidate-section">
-        <div className="diy-candidate-heading">
-          <span className="diy-candidate-label">
-            {isEnglish ? "Hand component cards" : "手牌组件卡"}
-          </span>
-          {selectedCardIds.length > 0 ? (
-            <button
-              className="secondary-button compact-button"
-              disabled={isAi}
-              onClick={() => setSelectedCardIds([])}
-              type="button"
-            >
-              {isEnglish
-                ? `Clear selection (${selectedCardIds.length})`
-                : `清空选择 (${selectedCardIds.length})`}
-            </button>
-          ) : null}
-        </div>
-
-        {candidateCardIds.length > 0 ? (
-          <div
-            className="candidate-grid"
-            role="group"
-            aria-label={isEnglish ? "DIY component cards" : "DIY 组件卡牌"}
+      {!isSelecting ? (
+        <div className="diy-entry-section">
+          <button
+            className="secondary-button"
+            disabled={isAi}
+            onClick={() => setIsSelecting(true)}
+            type="button"
           >
-            {candidateCardIds.map((cardInstanceId) => {
-              const isSelected = selectedCardIds.includes(cardInstanceId);
-              const def = getCardDefinition(game, cardInstanceId);
-              const cardName = def
-                ? getCardDisplayName(def.id, def.name, locale)
-                : cardInstanceId;
-
-              return (
+            {isEnglish ? "Enter active DIY" : "进入主动 DIY"}
+          </button>
+        </div>
+      ) : (
+        <>
+          <div className="diy-candidate-section">
+            <div className="diy-candidate-heading">
+              <span className="diy-candidate-label">
+                {isEnglish ? "Hand component cards" : "手牌组件卡"}
+              </span>
+              {selectedCardIds.length > 0 ? (
                 <button
-                  aria-pressed={isSelected}
-                  className={`debug-card candidate-card${isSelected ? " is-selected" : ""}`}
+                  className="secondary-button compact-button"
                   disabled={isAi}
-                  key={cardInstanceId}
-                  onClick={() => {
-                    setSelectedCardIds((prev) =>
-                      prev.includes(cardInstanceId)
-                        ? prev.filter((id) => id !== cardInstanceId)
-                        : [...prev, cardInstanceId],
-                    );
-                  }}
+                  onClick={() => setSelectedCardIds([])}
                   type="button"
                 >
-                  <span className="debug-card__name">{cardName}</span>
-                  <span className="debug-card__line">{cardInstanceId}</span>
+                  {isEnglish
+                    ? `Clear selection (${selectedCardIds.length})`
+                    : `清空选择 (${selectedCardIds.length})`}
                 </button>
-              );
-            })}
+              ) : null}
+            </div>
+
+            {candidateCardIds.length > 0 ? (
+              <div
+                className="candidate-grid"
+                role="group"
+                aria-label={isEnglish ? "DIY component cards" : "DIY 组件卡牌"}
+              >
+                {candidateCardIds.map((cardInstanceId) => {
+                  const isSelected = selectedCardIds.includes(cardInstanceId);
+                  const def = getCardDefinition(game, cardInstanceId);
+                  const cardName = def
+                    ? getCardDisplayName(def.id, def.name, locale)
+                    : cardInstanceId;
+
+                  return (
+                    <button
+                      aria-pressed={isSelected}
+                      className={`debug-card candidate-card${isSelected ? " is-selected" : ""}`}
+                      disabled={isAi}
+                      key={cardInstanceId}
+                      onClick={() => {
+                        setSelectedCardIds((prev) =>
+                          prev.includes(cardInstanceId)
+                            ? prev.filter((id) => id !== cardInstanceId)
+                            : [...prev, cardInstanceId],
+                        );
+                      }}
+                      type="button"
+                    >
+                      <span className="debug-card__name">{cardName}</span>
+                      <span className="debug-card__line">{cardInstanceId}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            ) : (
+              <p className="empty-note">
+                {isEnglish ? "No DIY component cards in hand." : "手牌中暂无可用 DIY 组件牌。"}
+              </p>
+            )}
           </div>
-        ) : (
-          <p className="empty-note">
-            {isEnglish ? "No DIY component cards in hand." : "手牌中暂无可用 DIY 组件牌。"}
-          </p>
-        )}
-      </div>
 
-      {isTargetRequired ? (
-        <label className="field-row">
-          <span>{isEnglish ? "DIY target" : "DIY 目标"}</span>
-          <select
-            disabled={isAi}
-            onChange={(e) => setTargetPlayerId(e.target.value as PlayerId)}
-            value={effectiveTargetPlayerId ?? ""}
-          >
-            {targets.map((t) => (
-              <option key={t.id} value={t.id}>
-                {getPlayerDisplayName(t, locale)}
-              </option>
-            ))}
-          </select>
-        </label>
-      ) : isNoTargetRecipe ? (
-        <p className="empty-note">
-          {isEnglish ? "No target required." : "此配方不需要选择目标。"}
-        </p>
-      ) : null}
+          {isTargetRequired ? (
+            <label className="field-row">
+              <span>{isEnglish ? "DIY target" : "DIY 目标"}</span>
+              <select
+                disabled={isAi}
+                onChange={(e) => setTargetPlayerId(e.target.value as PlayerId)}
+                value={effectiveTargetPlayerId ?? ""}
+              >
+                {targets.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {getPlayerDisplayName(t, locale)}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : isNoTargetRecipe ? (
+            <p className="empty-note">
+              {isEnglish ? "No target required." : "此配方不需要选择目标。"}
+            </p>
+          ) : null}
 
-      <div className="diy-preview-section">{renderPreview()}</div>
+          <div className="diy-preview-section">{renderPreview()}</div>
 
-      <button
-        className="primary-button"
-        disabled={!canSubmit}
-        onClick={handlePlayDiy}
-        type="button"
-      >
-        {isEnglish ? "Run active DIY" : "执行主动 DIY"}
-      </button>
+          <div className="diy-action-row">
+            <button
+              className="primary-button"
+              disabled={!canSubmit}
+              onClick={handlePlayDiy}
+              type="button"
+            >
+              {isEnglish ? "Run active DIY" : "执行主动 DIY"}
+            </button>
+            <button
+              className="secondary-button"
+              disabled={isAi}
+              onClick={handleCancelDiy}
+              type="button"
+            >
+              {isEnglish ? "Cancel DIY" : "取消 DIY"}
+            </button>
+          </div>
+        </>
+      )}
     </section>
   );
 }

--- a/src/features/local-game/local-game.css
+++ b/src/features/local-game/local-game.css
@@ -1148,6 +1148,17 @@ select {
   margin: 0;
 }
 
+.diy-entry-section {
+  display: grid;
+  gap: 8px;
+}
+
+.diy-action-row {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .error-banner,
 .quiet-banner {
   border-radius: 6px;


### PR DESCRIPTION
## Summary

Add explicit DIY Selection Context per Freeze §7.1–7.2.

- Idle: only “Enter active DIY”; no candidate cards
- Enter/cancel are UI-local; no GameState side effects
- Cancel clears selection; can re-enter
- Play still dispatches `PLAY_DIY_SELECTION` without `recipeId`

### Audit
Grok-4.6/High reviewed `8c6d8ad`. **P0: none.** Known P1 remains: DIY selection and ordinary ActionPanel selection are not mutually exclusive. Not a §7.1 regression.

### Verification (local)
DiyPanel tests 6/6; implementer also reported test:run / shuffle / e2e / production e2e / size 105301 / 108000.