### PR TITLE
feat: Phase 20A official play shell

### DIFF
--- a/e2e/playShellLayout.ts
+++ b/e2e/playShellLayout.ts
@@ -1,0 +1,48 @@
+import { expect, type Page } from "@playwright/test";
+
+export type PlayShellLayoutSnapshot = {
+  columnCount: number;
+  columns: string;
+  surfaceVisible: boolean;
+  sidebarVisible: boolean;
+};
+
+export async function readPlayShellLayout(page: Page): Promise<PlayShellLayoutSnapshot> {
+  await page.evaluate(() => window.scrollTo(0, 0));
+  return page.evaluate(() => {
+    const shell = document.querySelector(".play-shell-layout");
+    const surface = document.querySelector(".play-surface");
+    const sidebar = document.querySelector(".play-sidebar");
+    if (!shell || !surface || !sidebar) {
+      throw new Error("Play shell landmarks are missing");
+    }
+
+    const vis = (element: Element) => {
+      const rect = element.getBoundingClientRect();
+      return rect.top < window.innerHeight
+        && rect.bottom > 0
+        && rect.left < window.innerWidth
+        && rect.right > 0;
+    };
+
+    const columns = getComputedStyle(shell).gridTemplateColumns;
+    return {
+      columnCount: columns.trim().split(/\s+/u).filter(Boolean).length,
+      columns,
+      surfaceVisible: vis(surface),
+      sidebarVisible: vis(sidebar),
+    };
+  });
+}
+
+export async function expectPortraitPlayShell(page: Page) {
+  const layout = await readPlayShellLayout(page);
+  expect(layout.columnCount, `portrait columns: ${layout.columns}`).toBe(1);
+}
+
+export async function expectLandscapePlayShell(page: Page) {
+  const layout = await readPlayShellLayout(page);
+  expect(layout.columnCount, `landscape columns: ${layout.columns}`).toBe(2);
+  expect(layout.surfaceVisible, "play-surface must intersect the landscape viewport").toBe(true);
+  expect(layout.sidebarVisible, "play-sidebar must intersect the landscape viewport").toBe(true);
+}

--- a/e2e/production/reaction-field.spec.ts
+++ b/e2e/production/reaction-field.spec.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { expect, test as base, type Page } from "@playwright/test";
+import { expectLandscapePlayShell, expectPortraitPlayShell } from "../playShellLayout";
 
 function readExpectedBuildCommit(): string {
   const commit = execFileSync("git", ["rev-parse", "--short=12", "HEAD"], {
@@ -424,4 +425,39 @@ test("正式构建在 / 验证 Phase 16 双语游戏日志、反应日志与 DIY
   expect(await logItems.count()).toBe(logCountAfterReaction);
 
   await page.getByRole("button", { name: "中文" }).click();
+});
+
+test("正式对局壳在 390 竖屏单列，横屏 844 与 1024 双栏同屏", async ({
+  page,
+  externalRequests,
+  networkFailures,
+  runtimeErrors,
+}) => {
+  void externalRequests;
+  void runtimeErrors;
+  void networkFailures;
+
+  await page.goto("/");
+  await page.getByLabel("player_1 角色").selectOption("chemical_factory_ceo");
+  await page.getByLabel("player_2 角色").selectOption("acid_king");
+  await page.getByRole("button", { name: "开始游戏" }).click();
+  await expect(page.locator(".play-shell-layout")).toBeVisible();
+  await expect(page.locator(".play-surface")).toBeVisible();
+  await expect(page.locator(".play-sidebar")).toBeVisible();
+
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await expectLandscapePlayShell(page);
+  await expectNoHorizontalOverflow(page);
+
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await expectLandscapePlayShell(page);
+  await expectNoHorizontalOverflow(page);
+
+  await page.setViewportSize({ width: 844, height: 390 });
+  await expectLandscapePlayShell(page);
+  await expectNoHorizontalOverflow(page);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expectPortraitPlayShell(page);
+  await expectNoHorizontalOverflow(page);
 });

--- a/e2e/tests/debug-alpha.spec.ts
+++ b/e2e/tests/debug-alpha.spec.ts
@@ -3,6 +3,7 @@ import {
   test as base,
   type Page,
 } from "@playwright/test";
+import { expectLandscapePlayShell, expectPortraitPlayShell } from "../playShellLayout";
 
 const test = base.extend<{ runtimeErrors: string[] }>({
   runtimeErrors: async ({ page }, use) => {
@@ -828,4 +829,26 @@ test("390×844 覆盖 configuring、playing、reaction、About、fatal 与 gameO
   await expectFactoryCount(page, Number(gameOverFactoryCount));
 
   await openAndCloseAbout(page);
+});
+
+test("390 竖屏单列，横屏 844 与 1024 为 play-shell 双栏同屏", async ({ page, runtimeErrors }) => {
+  void runtimeErrors;
+  await startNoTeacherGame(page);
+  await expect(page.locator(".play-shell-layout")).toBeVisible();
+
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await expectLandscapePlayShell(page);
+  await expectNoHorizontalOverflow(page);
+
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await expectLandscapePlayShell(page);
+  await expectNoHorizontalOverflow(page);
+
+  await page.setViewportSize({ width: 844, height: 390 });
+  await expectLandscapePlayShell(page);
+  await expectNoHorizontalOverflow(page);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expectPortraitPlayShell(page);
+  await expectNoHorizontalOverflow(page);
 });

--- a/src/features/local-game/LocalGamePage.tsx
+++ b/src/features/local-game/LocalGamePage.tsx
@@ -26,6 +26,7 @@ import { PreparationPanel } from "./components/PreparationPanel";
 import { ResponsePanel } from "./components/ResponsePanel";
 import { StatusPanel } from "./components/StatusPanel";
 import { SuccessfulReactionNotice } from "./components/SuccessfulReactionNotice";
+import { TableReferenceBoard } from "./components/TableReferenceBoard";
 import { useLocalGameDebug } from "./hooks/useLocalGameDebug";
 import type {
   LocalGameEngineReducer,
@@ -82,8 +83,8 @@ function PlayingGame({
         onReturnToCharacterSelection={(trigger) => onRequestSessionExit("return", trigger)}
       />
       <SuccessfulReactionNotice game={game} />
-      <div className="debug-layout">
-        <div className="debug-main">
+      <div className="debug-layout play-shell-layout">
+        <div className="debug-main play-surface">
           <div className="players-grid">
             {game.players.map((player, index) => (
               <PlayerPanel
@@ -98,9 +99,10 @@ function PlayingGame({
               />
             ))}
           </div>
+          <TableReferenceBoard game={game} />
           <GameLog game={game} />
         </div>
-        <aside className="debug-sidebar" aria-label={isEnglish ? "Action panels" : "操作面板"}>
+        <aside className="debug-sidebar play-sidebar" aria-label={isEnglish ? "Action panels" : "操作面板"}>
           <NewPlayerGuidance
             collapsed={guidanceCollapsed}
             game={game}

--- a/src/features/local-game/components/CardDebugCard.tsx
+++ b/src/features/local-game/components/CardDebugCard.tsx
@@ -25,7 +25,7 @@ export function CardDebugCard({
 
   if (!definition) {
     return (
-      <article className="debug-card is-missing">
+      <article className="debug-card card-face is-missing">
         <button className="debug-card__select" disabled type="button">
           {getOptionalCardDisplayName(undefined, locale)} {cardInstanceId}
         </button>
@@ -33,22 +33,43 @@ export function CardDebugCard({
     );
   }
 
+  const isIon = definition.type === "ion";
+  const typeBadgeLabel = isIon
+    ? (isEnglish ? "Ion" : "离子")
+    : (isEnglish ? "Substance" : "实体");
+
   return (
     <article
-      className={`debug-card${selected ? " is-selected" : ""}`}
+      className={`debug-card card-face${selected ? " is-selected" : ""}${disabled ? " is-disabled" : ""}`}
     >
+      <div className="card-face__badge-row">
+        <span className={`card-face__type-badge ${isIon ? "is-ion" : "is-substance"}`}>
+          {typeBadgeLabel}
+        </span>
+        {definition.tags.length > 0 ? (
+          <span className="card-face__tag-chip">
+            {definition.tags[0]}
+          </span>
+        ) : null}
+      </div>
       <button
-        className="debug-card__select"
+        className="debug-card__select card-face__button"
         disabled={disabled}
         onClick={() => onSelect?.(cardInstanceId)}
         type="button"
       >
-        <span className="debug-card__name">{getCardDisplayName(definition.id, definition.name, locale)}</span>
-        <span className="debug-card__line">{isEnglish ? "Selectable in this game" : "可在当前对局中选择"}</span>
+        <span className="debug-card__name card-face__name">
+          {getCardDisplayName(definition.id, definition.name, locale)}
+        </span>
+        <span className="debug-card__line card-face__line">
+          {isEnglish ? "Selectable in this game" : "可在当前对局中选择"}
+        </span>
       </button>
       <details className="debug-details debug-card__details">
         <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
-        <span className="debug-card__meta">{cardInstanceId} · {formatList(definition.tags)} · {formatList(definition.allowedTimings)}</span>
+        <span className="debug-card__meta">
+          {cardInstanceId} · {formatList(definition.tags)} · {formatList(definition.allowedTimings)}
+        </span>
       </details>
     </article>
   );

--- a/src/features/local-game/components/GameSummary.tsx
+++ b/src/features/local-game/components/GameSummary.tsx
@@ -38,11 +38,24 @@ export function GameSummary({
     : (isEnglish ? "Not finished" : "未结束");
 
   return (
-    <section className="debug-section debug-summary" aria-labelledby="summary-title">
-      <div>
-        <p className="debug-kicker">{releaseMetadata.displayName}</p>
-        <h1 id="summary-title">{summaryTitle}</h1>
+    <section className="debug-section debug-summary table-summary-bar" aria-labelledby="summary-title">
+      <div className="table-summary-bar__header">
+        <div className="table-summary-bar__titles">
+          <p className="debug-kicker">{releaseMetadata.displayName}</p>
+          <h1 id="summary-title">{summaryTitle}</h1>
+        </div>
+        <div className="table-summary-bar__status-chip">
+          <span className="round-badge">
+            {isEnglish
+              ? `Cycle ${game.cycleNumber} · Round ${game.roundInCycle}`
+              : `第 ${game.cycleNumber} 周期 · 第 ${game.roundInCycle} 轮`}
+          </span>
+          {game.phase === "gameOver" ? (
+            <span className="outcome-badge is-game-over">{winnerText}</span>
+          ) : null}
+        </div>
       </div>
+
       <dl className="summary-grid">
         {([
           [isEnglish ? "Experiment cycle" : "实验周期", game.cycleNumber],
@@ -57,10 +70,12 @@ export function GameSummary({
           <div key={l}><dt>{l}</dt><dd>{v}</dd></div>
         ))}
       </dl>
+
       <details className="debug-details">
         <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
         <p>{game.phase} · {getTotalCardCount(game)} cards · {describeTableReference(game)}</p>
       </details>
+
       <div className="summary-actions">
         {error ? <p className="error-banner">{error}</p> : <p className="quiet-banner">{isEnglish ? "Awaiting action" : "等待操作"}</p>}
         <div className="session-actions">

--- a/src/features/local-game/components/PlayerPanel.tsx
+++ b/src/features/local-game/components/PlayerPanel.tsx
@@ -13,6 +13,7 @@ import {
   getCharacterDisplayName,
   getPlayerControllerDisplayName,
   getPlayerDisplayName,
+  getStatusDisplayName,
 } from "../presentationLocale";
 
 type PlayerPanelProps = {
@@ -43,20 +44,68 @@ export function PlayerPanel({
     ? player.statuses.map((status) => `${status.statusId} (${status.id})`).join(", ")
     : "无";
 
+  const hpPercent = Math.max(0, Math.min(100, (player.hp / player.maxHp) * 100));
+  const hpToneClass = hpPercent <= 25 ? "is-critical" : hpPercent <= 50 ? "is-low" : "is-healthy";
+
   return (
     <section className="debug-section player-panel" aria-labelledby={`${player.id}-title`}>
       <div className="player-panel__header">
-        <div>
+        <div className="player-panel__identity">
           <h2 id={`${player.id}-title`}>{getPlayerDisplayName(player, locale)}</h2>
           <p>
             {getCharacterDisplayName(character.id, locale)}
             {controller ? ` · ${getPlayerControllerDisplayName(controller, locale)}` : ""}
           </p>
         </div>
-        {showActivePlayerIndicator && game.activePlayerId === player.id ? (
-          <span className="active-pill">{isEnglish ? "Active" : "当前行动"}</span>
-        ) : null}
+        <div className="player-panel__badges">
+          {showActivePlayerIndicator && game.activePlayerId === player.id ? (
+            <span className="active-pill">{isEnglish ? "Active" : "当前行动"}</span>
+          ) : null}
+          {player.eliminated ? (
+            <span className="status-pill is-eliminated">{isEnglish ? "Eliminated" : "已淘汰"}</span>
+          ) : null}
+        </div>
       </div>
+
+      <div className="player-hp-meter">
+        <div className="player-hp-header">
+          <span className="player-hp-label">{isEnglish ? "HP Gauge" : "生命值"}</span>
+          <strong className="player-hp-val">{player.hp}/{player.maxHp}</strong>
+        </div>
+        <div
+          aria-valuemax={player.maxHp}
+          aria-valuemin={0}
+          aria-valuenow={player.hp}
+          className="player-hp-track"
+          role="progressbar"
+        >
+          <div
+            className={`player-hp-fill ${hpToneClass}`}
+            style={{ width: `${hpPercent}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="player-status-chips">
+        {player.statuses.length > 0 ? (
+          player.statuses.map((status) => (
+            <span className="status-pill is-active-status" key={status.id}>
+              {getStatusDisplayName(status.statusId, locale)}
+            </span>
+          ))
+        ) : (
+          <span className="status-pill is-normal">{isEnglish ? "Normal" : "状态正常"}</span>
+        )}
+        <span className={player.usedDIYThisCycle ? "warn-pill" : "ok-pill"}>
+          {player.usedDIYThisCycle
+            ? (isEnglish ? "DIY: Used" : "DIY: 已用")
+            : (isEnglish ? "DIY: Unused" : "DIY: 可用")}
+        </span>
+        <span className="hand-count-pill">
+          {isEnglish ? `Hand: ${player.hand.length}` : `手牌: ${player.hand.length} 张`}
+        </span>
+      </div>
+
       <dl className="player-stats">
         {([
           [isEnglish ? "HP" : "生命值", `${player.hp} / ${player.maxHp}`],
@@ -86,7 +135,7 @@ export function PlayerPanel({
           ))}
         </details>
       </div>
-      <div className="hand-grid">
+      <div className="hand-grid" aria-label={isEnglish ? `${getPlayerDisplayName(player, locale)}'s hand` : `${getPlayerDisplayName(player, locale)}的手牌`}>
         {player.hand.map((cardInstanceId) => (
           <CardDebugCard
             cardInstanceId={cardInstanceId}

--- a/src/features/local-game/components/TableReferenceBoard.tsx
+++ b/src/features/local-game/components/TableReferenceBoard.tsx
@@ -1,0 +1,61 @@
+import { useLocale } from "../../../app/locale";
+import type { GameState } from "../../../game/engine/types";
+import { getPlayerDisplayNameById } from "../presentationLocale";
+
+type TableReferenceBoardProps = Readonly<{
+  game: GameState;
+}>;
+
+export function TableReferenceBoard({ game }: TableReferenceBoardProps) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
+  const ref = game.tableReference;
+
+  return (
+    <section
+      aria-label={isEnglish ? "Table reference and benchmarks" : "场面基准与牌堆基准"}
+      className="table-center-board"
+    >
+      <div className="table-center-reference">
+        <div className="table-center-reference__header">
+          <span className="table-center-label">
+            {isEnglish ? "Table Reference" : "场面基准牌"}
+          </span>
+          {ref ? (
+            <span className="table-center-turn">
+              {isEnglish ? `Cycle ${ref.cycle} · Round ${ref.round}` : `周期 ${ref.cycle} · 轮次 ${ref.round}`}
+            </span>
+          ) : null}
+        </div>
+        {ref ? (
+          <div className="table-reference-card">
+            <strong className="table-reference-card__name">{ref.displayName}</strong>
+            <span className="table-reference-card__author">
+              {isEnglish ? "Played by " : "由 "}{getPlayerDisplayNameById(ref.playedBy, locale, game.logPresentationContext)}{isEnglish ? "" : " 打出"}
+            </span>
+          </div>
+        ) : (
+          <div className="table-reference-card is-empty">
+            <span className="table-reference-card__name">
+              {isEnglish ? "No reference card yet" : "暂无场面基准牌"}
+            </span>
+            <span className="table-reference-card__author">
+              {isEnglish ? "Play any eligible card to set the first reference" : "可打出任意符合条件的牌建立首张基准"}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="table-center-piles">
+        <div className="pile-stat-chip">
+          <span className="pile-stat-label">{isEnglish ? "Deck" : "牌堆"}</span>
+          <strong className="pile-stat-count">{game.deck.length}</strong>
+        </div>
+        <div className="pile-stat-chip">
+          <span className="pile-stat-label">{isEnglish ? "Discard" : "弃牌堆"}</span>
+          <strong className="pile-stat-count">{game.discardPile.length}</strong>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/local-game/local-game.css
+++ b/src/features/local-game/local-game.css
@@ -1,7 +1,11 @@
 .local-game-page {
+  box-sizing: border-box;
+  margin: 0 auto;
+  max-width: 1560px;
   min-height: 100vh;
   min-width: 0;
-  padding: 24px;
+  padding: 20px;
+  width: 100%;
 }
 
 .release-bar {
@@ -356,10 +360,10 @@
 .debug-section {
   background: #ffffff;
   border: 1px solid #d7dee4;
-  border-radius: 8px;
-  box-shadow: 0 1px 2px rgb(15 23 42 / 7%);
-  padding: 16px;
+  border-radius: 10px;
+  box-shadow: 0 1px 3px rgb(15 23 42 / 6%);
   min-width: 0;
+  padding: 16px;
 }
 
 .debug-kicker {
@@ -379,7 +383,7 @@
 }
 
 .debug-section h1 {
-  font-size: 1.45rem;
+  font-size: 1.35rem;
 }
 
 .debug-section h2 {
@@ -435,11 +439,53 @@
   max-width: 1480px;
 }
 
+.table-summary-bar__header {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.table-summary-bar__titles {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.table-summary-bar__status-chip {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.round-badge {
+  background: #17384d;
+  border-radius: 6px;
+  color: #ffffff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 4px 8px;
+  white-space: nowrap;
+}
+
+.outcome-badge {
+  background: #fef3c7;
+  border: 1px solid #fcd34d;
+  border-radius: 6px;
+  color: #92400e;
+  font-size: 0.78rem;
+  font-weight: 800;
+  padding: 4px 8px;
+}
+
 .summary-grid,
 .player-stats {
   display: grid;
   gap: 8px;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(115px, 1fr));
   margin: 0;
 }
 
@@ -460,7 +506,7 @@ dt {
 
 dd {
   color: #17212b;
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   font-weight: 700;
   margin: 0;
   overflow-wrap: anywhere;
@@ -498,6 +544,7 @@ dd {
   display: flex;
   gap: 12px;
   justify-content: space-between;
+  min-width: 0;
 }
 
 .session-actions {
@@ -511,21 +558,25 @@ dd {
   align-items: start;
   display: grid;
   gap: 16px;
-  grid-template-columns: minmax(0, 1fr) 380px;
+  grid-template-columns: minmax(0, 1fr) 390px;
   margin: 0 auto;
   max-width: 1480px;
+  min-width: 0;
+  width: 100%;
 }
 
 .debug-main,
 .debug-sidebar {
   display: grid;
   gap: 16px;
+  min-width: 0;
 }
 
 .players-grid {
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
+  min-width: 0;
 }
 
 .player-panel {
@@ -533,10 +584,214 @@ dd {
   gap: 12px;
 }
 
-.player-panel__header p {
+.player-panel__identity h2 {
+  font-size: 1.15rem;
+}
+
+.player-panel__identity p {
   color: #60717f;
   font-size: 0.78rem;
-  margin: 4px 0 0;
+  margin: 3px 0 0;
+}
+
+.player-panel__badges {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.player-hp-meter {
+  background: #f7f9fb;
+  border: 1px solid #e1e7ec;
+  border-radius: 8px;
+  display: grid;
+  gap: 6px;
+  padding: 8px 10px;
+}
+
+.player-hp-header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.player-hp-label {
+  color: #52606d;
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.player-hp-val {
+  color: #17212b;
+  font-size: 0.95rem;
+  font-weight: 800;
+}
+
+.player-hp-track {
+  background: #e2e8f0;
+  border-radius: 999px;
+  height: 8px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.player-hp-fill {
+  border-radius: 999px;
+  height: 100%;
+  transition: width 160ms ease-out;
+}
+
+.player-hp-fill.is-healthy {
+  background: linear-gradient(90deg, #10b981, #059669);
+}
+
+.player-hp-fill.is-low {
+  background: linear-gradient(90deg, #f59e0b, #d97706);
+}
+
+.player-hp-fill.is-critical {
+  background: linear-gradient(90deg, #ef4444, #dc2626);
+}
+
+.player-status-chips {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.status-pill {
+  border-radius: 999px;
+  font-size: 0.73rem;
+  font-weight: 800;
+  padding: 3px 8px;
+}
+
+.status-pill.is-normal {
+  background: #f1f5f9;
+  border: 1px solid #cbd5e1;
+  color: #475569;
+}
+
+.status-pill.is-active-status {
+  background: #fef2f2;
+  border: 1px solid #fca5a5;
+  color: #b91c1c;
+}
+
+.status-pill.is-eliminated {
+  background: #1e293b;
+  color: #ffffff;
+}
+
+.hand-count-pill {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 999px;
+  color: #52606d;
+  font-size: 0.73rem;
+  font-weight: 700;
+  padding: 3px 8px;
+}
+
+.table-center-board {
+  align-items: center;
+  background: #f4f7f9;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  box-shadow: 0 1px 3px rgb(15 23 42 / 5%);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  min-width: 0;
+  padding: 12px 16px;
+}
+
+.table-center-reference {
+  display: grid;
+  flex: 1 1 240px;
+  gap: 6px;
+  min-width: 0;
+}
+
+.table-center-reference__header {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+}
+
+.table-center-label {
+  color: #356554;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.table-center-turn {
+  color: #60717f;
+  font-size: 0.73rem;
+  font-weight: 700;
+}
+
+.table-reference-card {
+  background: #ffffff;
+  border: 1px solid #b8c5ce;
+  border-left: 4px solid #244b64;
+  border-radius: 6px;
+  display: grid;
+  gap: 3px;
+  padding: 8px 12px;
+}
+
+.table-reference-card.is-empty {
+  border-left: 4px dashed #94a3b8;
+}
+
+.table-reference-card__name {
+  color: #17212b;
+  font-size: 0.95rem;
+  font-weight: 800;
+}
+
+.table-reference-card__author {
+  color: #5d6e7a;
+  font-size: 0.74rem;
+  line-height: 1.35;
+}
+
+.table-center-piles {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  gap: 8px;
+}
+
+.pile-stat-chip {
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid #d7dee4;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  min-width: 72px;
+  padding: 6px 10px;
+}
+
+.pile-stat-label {
+  color: #60717f;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.pile-stat-count {
+  color: #17212b;
+  font-size: 1.05rem;
+  font-weight: 800;
 }
 
 .character-readout {
@@ -626,14 +881,15 @@ dd {
 .candidate-grid {
   display: grid;
   gap: 8px;
+  min-width: 0;
 }
 
 .hand-grid {
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(135px, 1fr));
 }
 
 .candidate-grid {
-  grid-template-columns: repeat(auto-fill, minmax(135px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
 }
 
 .action-card-list {
@@ -715,34 +971,81 @@ dd {
 }
 
 .debug-card {
-  background: #fbfcfd;
-  border: 1px solid #ccd6de;
-  border-radius: 8px;
+  background: #ffffff;
+  border: 1.5px solid #cbd5e1;
+  border-radius: 9px;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 5%);
   color: #17212b;
   display: grid;
-  gap: 5px;
-  padding: 10px;
+  gap: 4px;
+  min-width: 0;
+  padding: 8px 10px;
   text-align: left;
+  transition: border-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
   width: 100%;
 }
 
 .debug-card:has(.debug-card__select:not(:disabled):hover) {
-  border-color: #38766b;
+  border-color: #244b64;
+  box-shadow: 0 4px 10px rgb(0 0 0 / 10%);
+  transform: translateY(-2px);
 }
 
-.debug-card:has(.debug-card__select:disabled) {
-  opacity: 0.7;
+.debug-card:has(.debug-card__select:disabled),
+.debug-card.is-disabled {
+  opacity: 0.65;
 }
 
 .debug-card.is-selected {
-  background: #eaf5f1;
-  border-color: #2d6b5f;
-  box-shadow: inset 0 0 0 1px #2d6b5f;
+  background: #f0fdf4;
+  border-color: #059669;
+  box-shadow: 0 0 0 2px #059669, 0 4px 12px rgb(5 150 105 / 15%);
+}
+
+.card-face__badge-row {
+  align-items: center;
+  display: flex;
+  gap: 4px;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.card-face__type-badge {
+  border-radius: 4px;
+  font-size: 0.68rem;
+  font-weight: 800;
+  padding: 1px 5px;
+}
+
+.card-face__type-badge.is-ion {
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  color: #1d4ed8;
+}
+
+.card-face__type-badge.is-substance {
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  color: #15803d;
+}
+
+.card-face__tag-chip {
+  background: #f1f5f9;
+  border-radius: 3px;
+  color: #64748b;
+  font-size: 0.65rem;
+  font-weight: 600;
+  overflow: hidden;
+  padding: 1px 4px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .debug-card__name {
-  font-size: 0.98rem;
+  color: #0f172a;
+  font-size: 0.95rem;
   font-weight: 800;
+  line-height: 1.25;
 }
 
 .debug-card__select {
@@ -752,8 +1055,9 @@ dd {
   color: #17212b;
   cursor: pointer;
   display: grid;
-  gap: 5px;
-  min-height: 58px;
+  gap: 4px;
+  min-height: 52px;
+  min-width: 0;
   padding: 0;
   text-align: left;
   width: 100%;
@@ -1195,8 +1499,8 @@ select {
   color: #263642;
   font-size: 0.85rem;
   line-height: 1.45;
-  padding: 8px;
   overflow-wrap: anywhere;
+  padding: 8px;
 }
 
 .game-log__entry-id {
@@ -1269,7 +1573,7 @@ select {
   }
 
   .local-game-page {
-    padding: 12px;
+    padding: 10px;
   }
 
   .players-grid {
@@ -1298,6 +1602,20 @@ select {
   .new-player-guidance__show {
     justify-self: stretch;
     width: 100%;
+  }
+
+  .table-center-board {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .table-center-piles {
+    justify-content: stretch;
+    width: 100%;
+  }
+
+  .pile-stat-chip {
+    flex: 1 1 0;
   }
 
   .summary-actions,

--- a/src/features/local-game/local-game.css
+++ b/src/features/local-game/local-game.css
@@ -565,6 +565,15 @@ dd {
   width: 100%;
 }
 
+.debug-layout.play-shell-layout {
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 390px);
+}
+
+.play-surface,
+.play-sidebar {
+  min-width: 0;
+}
+
 .debug-main,
 .debug-sidebar {
   display: grid;
@@ -1576,6 +1585,14 @@ select {
     padding: 10px;
   }
 
+  .debug-layout.play-shell-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .debug-layout.play-shell-layout > .play-sidebar {
+    grid-row: 1;
+  }
+
   .players-grid {
     grid-template-columns: 1fr;
   }
@@ -1661,5 +1678,37 @@ select {
   .failure-diagnostics,
   .fatal-actions {
     grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (orientation: landscape) and (min-width: 761px) {
+  .debug-layout.play-shell-layout {
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 390px);
+  }
+
+  .debug-layout.play-shell-layout > .play-sidebar {
+    grid-row: auto;
+  }
+}
+
+@media (orientation: landscape) and (max-height: 500px) {
+  .local-game-page {
+    padding: 8px 12px;
+  }
+
+  .table-summary-bar {
+    gap: 8px;
+    margin-bottom: 8px;
+    padding: 10px 12px;
+  }
+
+  .table-summary-bar .summary-grid,
+  .table-summary-bar .debug-details,
+  .table-summary-bar .quiet-banner {
+    display: none;
+  }
+
+  .debug-section.debug-summary h1 {
+    font-size: 1.05rem;
   }
 }


### PR DESCRIPTION
## Summary

Official play-table shell per Freeze §5: player zones, HP, statuses, table reference, card faces, portrait column + landscape dual column.

Hands remain public. No engine / NATBA / private-view changes.

### Layout
- 390×844: single column, no overflow
- 844×390 and 1024×768: dual column via `.play-shell-layout` (not the old 1100px `.debug-layout`)
- Debug `<details>` stay closed by default

### Verification
| Check | Result |
| :--- | :--- |
| `test:run` / `test:shuffle` | 763 passed |
| `test:e2e` | 14 passed |
| `test:e2e:production` | 4 passed |
| `check:size` | JS 106,335 / 108,000 |
