### PR TITLE
feat: Phase 20B default solo vs AI

### DIFF
--- a/e2e/production/reaction-field.spec.ts
+++ b/e2e/production/reaction-field.spec.ts
@@ -140,7 +140,7 @@ for (const [path, assetPrefix, brandPrefix] of [["/", "/assets/", "/"], ["/playt
       expect(asset.status, relativeAssetPath).toBe(200);
       expect(asset.contentType, relativeAssetPath).toBe(contentType);
     }
-    await expect(page.getByRole("heading", { name: "反应域 · 本地双人角色选择" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "反应域 · 本地人机角色选择" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "新手引导：配置" })).toBeVisible();
     await expect(page.getByText(
       "当前目标：确认本地同屏双人阵容后，再开始本局公开对局。",
@@ -159,6 +159,7 @@ for (const [path, assetPrefix, brandPrefix] of [["/", "/assets/", "/"], ["/playt
     await expect(page.locator(".character-selection-hero__icon")).toBeVisible();
     await expect(page.locator(".character-selection-hero__icon")).toHaveAttribute("alt", "");
     await expect(page.locator(".character-selection-hero__icon")).toHaveAttribute("aria-hidden", "true");
+    await expect(page.getByLabel("对局模式")).toHaveValue("solo_ai");
     await expect(page.getByLabel("player_1 角色")).toHaveValue("laboratory_teacher");
     await expect(page.getByLabel("player_2 角色")).toHaveValue("chemical_factory_ceo");
     await page.getByRole("button", { name: "关于与帮助" }).click();
@@ -175,6 +176,8 @@ for (const [path, assetPrefix, brandPrefix] of [["/", "/assets/", "/"], ["/playt
     await expect(repository).toHaveAttribute("target", "_blank");
     await expect(repository).toHaveAttribute("rel", "noopener noreferrer");
     await page.keyboard.press("Escape");
+    await page.getByLabel("对局模式").selectOption("two_player");
+    await expect(page.getByRole("heading", { name: "反应域 · 本地双人角色选择" })).toBeVisible();
     await page.getByLabel("player_1 角色").selectOption("chemical_factory_ceo");
     await page.getByLabel("player_2 角色").selectOption("acid_king");
     await page.getByRole("button", { name: "开始游戏" }).click();
@@ -240,6 +243,7 @@ test("正式构建在 / 验证 Phase 16 双语游戏日志、反应日志与 DIY
   void networkFailures;
 
   await page.goto("/");
+  await page.getByLabel("对局模式").selectOption("two_player");
   await page.getByLabel("player_1 角色").selectOption("laboratory_teacher");
   await page.getByLabel("player_2 角色").selectOption("laboratory_teacher");
   await page.getByRole("button", { name: "开始游戏" }).click();

--- a/e2e/tests/debug-alpha.spec.ts
+++ b/e2e/tests/debug-alpha.spec.ts
@@ -26,6 +26,7 @@ test.use({ locale: "zh-CN" });
 
 async function startNoTeacherGame(page: Page) {
   await page.goto("/");
+  await page.getByLabel("对局模式").selectOption("two_player");
   await page.getByLabel("player_1 角色").selectOption("chemical_factory_ceo");
   await page.getByLabel("player_2 角色").selectOption("acid_king");
   await page.getByRole("button", { name: "开始游戏" }).click();
@@ -180,7 +181,7 @@ test("Alpha 4 language layer changes only presentation and keeps feedback static
   await page.getByRole("button", { name: "English" }).click();
   await page.reload();
   await expect(page.locator("html")).toHaveAttribute("lang", "zh-CN");
-  await expect(page.getByRole("heading", { name: "反应域 · 本地双人角色选择" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "反应域 · 本地人机角色选择" })).toBeVisible();
 });
 
 test.describe("English browser preference", () => {
@@ -196,7 +197,7 @@ test.describe("English browser preference", () => {
     }))).toEqual({ language: "en-US", languages: ["en-US"] });
     await expect(page.locator("html")).toHaveAttribute("lang", "en");
     await expect(page.getByRole("heading", {
-      name: "REACTION FIELD · Local two-player character selection",
+      name: "REACTION FIELD · Solo vs AI character selection",
     })).toBeVisible();
     await expect(page.getByLabel("player_1 character")).toHaveValue("laboratory_teacher");
   });
@@ -211,7 +212,7 @@ test("Alpha 4 English display covers setup, all public phases, dialogs, and fata
   };
 
   await switchToEnglish("/");
-  await expect(page.getByRole("heading", { name: "REACTION FIELD · Local two-player character selection" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "REACTION FIELD · Solo vs AI character selection" })).toBeVisible();
   await expect(page.getByText(
     "Current goal: Confirm the local shared-screen two-player lineup before starting this public game.",
     { exact: true },
@@ -285,10 +286,13 @@ test("默认配置、正式元数据与 configuring 帮助界面", async ({ page
   await page.goto("/");
 
   await expect(page.getByRole("heading", {
-    name: "反应域 · 本地双人角色选择",
+    name: "反应域 · 本地人机角色选择",
   })).toBeVisible();
+  await expect(page.getByLabel("对局模式")).toHaveValue("solo_ai");
   await expect(page.getByLabel("player_1 角色")).toHaveValue("laboratory_teacher");
   await expect(page.getByLabel("player_2 角色")).toHaveValue("chemical_factory_ceo");
+  await expect(page.getByLabel("player_1 控制方")).toHaveValue("human");
+  await expect(page.getByLabel("player_2 控制方")).toHaveValue("ai");
   await expect(page.getByText("Web Playtest Alpha · v0.16.0-alpha.2 · MVP0-P10", {
     exact: false,
   })).toBeVisible();
@@ -525,6 +529,7 @@ test("默认老师/CEO、双老师备课与无老师 mainAction", async ({ page,
   await page.getByRole("button", { name: "返回角色选择" }).click();
   await expect(page.getByRole("alertdialog")).toBeVisible();
   await page.getByRole("button", { name: "确认返回" }).click();
+  await page.getByLabel("对局模式").selectOption("two_player");
   await page.getByLabel("player_2 角色").selectOption("laboratory_teacher");
   await page.getByRole("button", { name: "开始游戏" }).click();
   await expect(page.getByText("当前选择玩家：玩家 A")).toBeVisible();
@@ -652,7 +657,7 @@ test("fatal 会话只允许全新恢复或返回配置", async ({ page, runtimeE
   await page.goto("/?scenario=fatal");
   await page.getByRole("button", { name: "返回角色选择" }).click();
   await expect(page.getByRole("heading", {
-    name: "反应域 · 本地双人角色选择",
+    name: "反应域 · 本地人机角色选择",
   })).toBeVisible();
 });
 

--- a/src/features/local-game/components/AboutDialog.tsx
+++ b/src/features/local-game/components/AboutDialog.tsx
@@ -57,7 +57,7 @@ export function AboutDialog({ onClose }: AboutDialogProps) {
           <h3>{isEnglish ? "Controls" : "当前能力与基本操作"}</h3>
           <ul>
             {[
-              ["本地公开对局；手牌、牌堆、状态与日志公开。", "Public hands, deck, status, and log."],
+              ["默认人机公开对局，亦支持本地双人；手牌、牌堆、状态与日志公开。", "Default Solo vs AI, with local two-player option; public hands, deck, status, and log."],
               ["按阶段完成备课、主行动、响应、状态处理与角色技能。", "Follow phase panels."],
               ["酸碱中和产生虚拟 H2O；酸与碳酸盐产生虚拟 CO2；两者只记录结果，不创建 CardInstance。", "Virtual H2O/CO2; no CardInstance."],
               ["主动 DIY 每周期一次；角色技能按定义展示。", "DIY once per cycle."],
@@ -72,7 +72,7 @@ export function AboutDialog({ onClose }: AboutDialogProps) {
           <h3>{isEnglish ? "Quick guide" : "首局速查"}</h3>
           <ul>
             {[
-              ["在角色选择页确认阵容；双方手牌公开。", "Confirm lineup; hands are public."],
+              ["在配置页确认阵容与模式；双方手牌公开。", "Confirm lineup and mode; hands are public."],
               ["按当前面板完成各阶段操作或实验反击。", "Follow the active panel."],
               ["响应 DIY 关闭。中和产出虚拟 H2O，酸+碳酸盐产出虚拟 CO2。", "Virtual H2O/CO2 only."],
               ["卡池固定 68 张；真实金属、方程式与反应链延期。", "68-card pool; metals deferred."],

--- a/src/features/local-game/components/CharacterSelectionPanel.tsx
+++ b/src/features/local-game/components/CharacterSelectionPanel.tsx
@@ -61,6 +61,25 @@ export function CharacterSelectionPanel({
     getCharacterDefinition(characterId),
   );
 
+  const isSoloVsAi = session.playerControllers.some((c) => c === "ai");
+  const isTwoPlayer = session.playerControllers[0] === "human" && session.playerControllers[1] === "human";
+  const currentModeValue: "solo_ai" | "two_player" | "custom" =
+    session.playerControllers[0] === "human" && session.playerControllers[1] === "ai"
+      ? "solo_ai"
+      : isTwoPlayer
+        ? "two_player"
+        : "custom";
+
+  const handleModeChange = (mode: "solo_ai" | "two_player") => {
+    if (mode === "solo_ai") {
+      dispatch({ type: "SELECT_PLAYER_CONTROLLER", playerIndex: 0, controller: "human" });
+      dispatch({ type: "SELECT_PLAYER_CONTROLLER", playerIndex: 1, controller: "ai" });
+    } else {
+      dispatch({ type: "SELECT_PLAYER_CONTROLLER", playerIndex: 0, controller: "human" });
+      dispatch({ type: "SELECT_PLAYER_CONTROLLER", playerIndex: 1, controller: "human" });
+    }
+  };
+
   return (
     <main className="local-game-page character-selection-page">
       <section className="debug-section character-selection-hero" aria-labelledby="character-selection-title">
@@ -75,11 +94,17 @@ export function CharacterSelectionPanel({
           />
           <div>
             <p className="debug-kicker">{isEnglish ? "REACTION FIELD · Web Playtest Alpha · MVP0-P10" : "反应域 · Web Playtest Alpha · MVP0-P10"}</p>
-            <h1 id="character-selection-title">{isEnglish ? "REACTION FIELD · Local two-player character selection" : "反应域 · 本地双人角色选择"}</h1>
+            <h1 id="character-selection-title">
+              {isEnglish
+                ? (isSoloVsAi ? "REACTION FIELD · Solo vs AI character selection" : "REACTION FIELD · Local two-player character selection")
+                : (isSoloVsAi ? "反应域 · 本地人机角色选择" : "反应域 · 本地双人角色选择")}
+            </h1>
           </div>
         </div>
         <p className="panel-note">
-          {isEnglish ? "Choose characters and controllers; hands are public." : "选择角色与控制方后开始；双方手牌公开。"}
+          {isEnglish
+            ? (isSoloVsAi ? "Choose characters and mode; hands are public." : "Choose characters and controllers; hands are public.")
+            : (isSoloVsAi ? "选择角色与模式后开始；双方手牌公开。" : "选择角色与控制方后开始；双方手牌公开。")}
         </p>
         <p className="mirror-note">{isEnglish ? "Mirrored characters are allowed." : "试玩版允许镜像角色。"}</p>
       </section>
@@ -87,9 +112,34 @@ export function CharacterSelectionPanel({
       <section className="debug-section character-config" aria-labelledby="lineup-title">
         <div className="panel-heading">
           <div>
-            <p className="debug-kicker">{isEnglish ? "Local shared screen · 2 players · 7 characters" : "本地同屏 · 2 名玩家 · 7 个角色"}</p>
+            <p className="debug-kicker">
+              {isEnglish
+                ? (isSoloVsAi ? "Solo vs AI · 7 characters" : "Local shared screen · 2 players · 7 characters")
+                : (isSoloVsAi ? "本地人机 · 7 个角色" : "本地同屏 · 2 名玩家 · 7 个角色")}
+            </p>
             <h2 id="lineup-title">{isEnglish ? "Current lineup" : "当前阵容"}</h2>
           </div>
+        </div>
+        <div className="game-mode-selection">
+          <label className="field-row game-mode-field">
+            <span>{isEnglish ? "Game mode" : "对局模式"}</span>
+            <select
+              aria-label={isEnglish ? "Game mode" : "对局模式"}
+              onChange={(event) => {
+                const value = event.target.value;
+                if (value === "solo_ai" || value === "two_player") {
+                  handleModeChange(value);
+                }
+              }}
+              value={currentModeValue}
+            >
+              <option value="solo_ai">{isEnglish ? "Solo vs AI (Default)" : "人机对局 (默认)"}</option>
+              <option value="two_player">{isEnglish ? "Local two-player" : "本地双人"}</option>
+              {currentModeValue === "custom" ? (
+                <option value="custom">{isEnglish ? "Custom controllers" : "自定义控制方"}</option>
+              ) : null}
+            </select>
+          </label>
         </div>
         <div className="character-select-grid">
           {([0, 1] as const).map((playerIndex) => (

--- a/src/features/local-game/components/GameSummary.tsx
+++ b/src/features/local-game/components/GameSummary.tsx
@@ -27,7 +27,7 @@ export function GameSummary({
   const isEnglish = locale === "en";
   const isSoloVsAi = Boolean(playerControllers && playerControllers.some((c) => c === "ai"));
   const summaryTitle = isEnglish
-    ? (isSoloVsAi ? "Solo vs NATBA-1" : "Local public two-player game")
+    ? (isSoloVsAi ? "Solo vs AI" : "Local public two-player game")
     : (isSoloVsAi ? "本地人机公开对局" : "本地双人公开对局");
   const winnerText = game.phase === "gameOver"
     ? game.isDraw

--- a/src/features/local-game/local-game.css
+++ b/src/features/local-game/local-game.css
@@ -286,7 +286,8 @@
 }
 
 .character-select-field,
-.character-controller-field {
+.character-controller-field,
+.game-mode-field {
   background: #f7f9fb;
   border: 1px solid #e1e7ec;
   border-radius: 8px;

--- a/src/features/local-game/localGameSession.ts
+++ b/src/features/local-game/localGameSession.ts
@@ -20,7 +20,7 @@ export const defaultCharacterSelection: CharacterSelection = [
 
 export const defaultPlayerControllers: PlayerControllerSelection = [
   "human",
-  "human",
+  "ai",
 ];
 
 export type ConfiguringLocalGameSession = Readonly<{

--- a/src/features/local-game/presentationLocale.ts
+++ b/src/features/local-game/presentationLocale.ts
@@ -274,7 +274,7 @@ export const getPlayerControllerDisplayName = (controller: PlayerController, loc
   controller === "human" ? (locale === "en" ? "Human" : "人类") : "NATBA AI";
 
 export const getAiAutoActionNote = (locale: DisplayLocale): string =>
-  locale === "en" ? "NATBA-1 AI is taking action..." : "NATBA-1 AI 正在自动行动...";
+  locale === "en" ? "NATBA AI is taking action..." : "NATBA AI 正在自动行动...";
 
 const diyBlockerNames: Readonly<Record<string, LocalizedLabel>> = {
   NOT_ACTIVE_PLAYER: ["非当前行动玩家", "Not active player"],

--- a/src/features/local-game/soloVsAiSession.test.tsx
+++ b/src/features/local-game/soloVsAiSession.test.tsx
@@ -20,7 +20,7 @@ const deterministicGameFactory: LocalGameFactory = (characterIds) =>
   });
 
 describe("Phase 19F — Solo vs NATBA-1 Session Integration", () => {
-  it("allows selecting Human vs NATBA AI in configuration and renders lineup summary", async () => {
+  it("defaults to Human vs NATBA AI in configuration, allows switching to local two-player, and renders lineup summary", async () => {
     Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
     const container = document.createElement("div");
     document.body.append(container);
@@ -43,16 +43,34 @@ describe("Phase 19F — Solo vs NATBA-1 Session Integration", () => {
       );
       expect(controllerSelects).toHaveLength(2);
 
+      // Default is Solo vs AI
+      expect(container.textContent).toContain("玩家 A (人类)");
+      expect(container.textContent).toContain("玩家 B (NATBA AI)");
+      expect(container.querySelector("h1")?.textContent).toBe("反应域 · 本地人机角色选择");
+
+      // Switch to local two-player via mode selector
+      const modeSelect = container.querySelector(
+        "select[aria-label*='mode'], select[aria-label*='模式']",
+      ) as HTMLSelectElement;
+      expect(modeSelect).toBeDefined();
+
+      await act(async () => {
+        modeSelect.value = "two_player";
+        modeSelect.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+
       expect(container.textContent).toContain("玩家 A (人类)");
       expect(container.textContent).toContain("玩家 B (人类)");
+      expect(container.querySelector("h1")?.textContent).toBe("反应域 · 本地双人角色选择");
 
-      const playerBControllerSelect = controllerSelects[1] as HTMLSelectElement;
+      // Switch back to Solo vs AI
       await act(async () => {
-        playerBControllerSelect.value = "ai";
-        playerBControllerSelect.dispatchEvent(new Event("change", { bubbles: true }));
+        modeSelect.value = "solo_ai";
+        modeSelect.dispatchEvent(new Event("change", { bubbles: true }));
       });
 
       expect(container.textContent).toContain("玩家 B (NATBA AI)");
+      expect(container.querySelector("h1")?.textContent).toBe("反应域 · 本地人机角色选择");
     } finally {
       await act(async () => {
         root.unmount();
@@ -285,6 +303,8 @@ describe("Phase 19F — Solo vs NATBA-1 Session Integration", () => {
 
       expect(natba0Invoked).toBeGreaterThan(0);
       expect(container.querySelector(".error-banner")).toBeNull();
+      expect(container.querySelector("h1")?.textContent).toBe("本地人机公开对局");
+      expect(container.querySelector("h1")?.textContent).not.toContain("NATBA-1");
     } finally {
       await act(async () => {
         root.unmount();
@@ -474,7 +494,7 @@ describe("Phase 19F — Solo vs NATBA-1 Session Integration", () => {
       // In Chinese mode: check title
       expect(container.querySelector("h1")?.textContent).toBe("本地人机公开对局");
 
-      // Switch to English: check title is Solo vs NATBA-1
+      // Switch to English: check title is Solo vs AI
       const enButton = Array.from(container.querySelectorAll("button")).find(
         (b) => b.textContent === "English",
       );
@@ -482,7 +502,7 @@ describe("Phase 19F — Solo vs NATBA-1 Session Integration", () => {
         enButton?.click();
       });
 
-      expect(container.querySelector("h1")?.textContent).toBe("Solo vs NATBA-1");
+      expect(container.querySelector("h1")?.textContent).toBe("Solo vs AI");
     } finally {
       await act(async () => {
         root.unmount();

--- a/src/game/tests/localGameSession.test.ts
+++ b/src/game/tests/localGameSession.test.ts
@@ -81,29 +81,36 @@ const orderedCharacterLineups = characterDefinitions.flatMap((playerOne) =>
 );
 
 describe("Phase 9 local Debug Alpha configuration", () => {
-  it("starts in configuring mode with the frozen teacher and CEO defaults", () => {
+  it("starts in configuring mode with the frozen teacher and CEO defaults and solo vs AI controllers", () => {
     const state = createConfiguringLocalGameSession();
 
     expect(state).toEqual({
       mode: "configuring",
       characterIds: defaultCharacterSelection,
-      playerControllers: ["human", "human"],
+      playerControllers: ["human", "ai"],
       revision: 0,
       error: null,
     });
     expect("game" in state).toBe(false);
   });
 
-  it("supports selecting player controller for human vs ai configuration", () => {
+  it("supports selecting player controller for human vs human and human vs ai configuration", () => {
     let state: LocalGameSessionState = createConfiguringLocalGameSession();
+    state = localGameSessionReducer(state, {
+      type: "SELECT_PLAYER_CONTROLLER",
+      playerIndex: 1,
+      controller: "human",
+    });
+
+    expect(state.playerControllers).toEqual(["human", "human"]);
+    expect(state.error).toBeNull();
+
     state = localGameSessionReducer(state, {
       type: "SELECT_PLAYER_CONTROLLER",
       playerIndex: 1,
       controller: "ai",
     });
-
     expect(state.playerControllers).toEqual(["human", "ai"]);
-    expect(state.error).toBeNull();
 
     const invalidState = localGameSessionReducer(state, {
       type: "SELECT_PLAYER_CONTROLLER",


### PR DESCRIPTION
## Summary

Default session is Human vs NATBA-1.x. Local two-player is an explicit option.

- `defaultPlayerControllers = ["human", "ai"]`
- Mode switcher on character select
- Titles: Solo vs AI / 本地人机公开对局 — no hardcoded NATBA-1
- Hands remain public (20C)

### Audit
Grok-4.6/High reviewed the working tree. P0/P1 none. P2 guidance still says two-player (deferred to 20F).

### Verification
Vitest 763, E2E 14+4, JS gzip 106734/108000.