### PR TITLE
feat: Phase 20C solo private human play view

### DIFF
--- a/e2e/production/reaction-field.spec.ts
+++ b/e2e/production/reaction-field.spec.ts
@@ -431,6 +431,43 @@ test("正式构建在 / 验证 Phase 16 双语游戏日志、反应日志与 DIY
   await page.getByRole("button", { name: "中文" }).click();
 });
 
+test("正式构建人机只显示对手牌背与张数，双人仍公开手牌", async ({
+  page,
+  externalRequests,
+  networkFailures,
+  runtimeErrors,
+}) => {
+  void externalRequests;
+  void runtimeErrors;
+  void networkFailures;
+
+  await page.goto("/");
+  await expect(page.getByText("选择角色与模式后开始；只显示自己的手牌，对手为牌背。")).toBeVisible();
+  await page.getByRole("button", { name: "开始游戏" }).click();
+  await expect(page.getByRole("heading", { name: "本地人机对局" })).toBeVisible();
+  await expect(page.getByText("己方手牌；对手背面")).toBeVisible();
+
+  const opponent = page.locator('[aria-labelledby="player_2-title"]');
+  const opponentCountText = await opponent.locator(".hand-count-pill").textContent();
+  const opponentCount = Number(opponentCountText?.match(/(\d+)/)?.[1]);
+  expect(opponentCount).toBe(14);
+  await expect(opponent.locator(".card-back")).toHaveCount(opponentCount);
+  await expect(opponent.locator(".card-face")).toHaveCount(0);
+  await expect(opponent.locator(".debug-card__select")).toHaveCount(0);
+
+  await page.getByRole("button", { name: "返回角色选择" }).click();
+  await page.getByRole("button", { name: "确认返回" }).click();
+  await page.getByLabel("对局模式").selectOption("two_player");
+  await page.getByLabel("player_1 角色").selectOption("chemical_factory_ceo");
+  await page.getByLabel("player_2 角色").selectOption("acid_king");
+  await page.getByRole("button", { name: "开始游戏" }).click();
+  await expect(page.getByRole("heading", { name: "本地双人公开对局" })).toBeVisible();
+  const twoPlayerOpponent = page.locator('[aria-labelledby="player_2-title"]');
+  await expect(twoPlayerOpponent.locator(".card-face")).toHaveCount(10);
+  await expect(twoPlayerOpponent.locator(".card-back")).toHaveCount(0);
+  await expect(twoPlayerOpponent.locator(".debug-card__select")).toHaveCount(10);
+});
+
 test("正式对局壳在 390 竖屏单列，横屏 844 与 1024 双栏同屏", async ({
   page,
   externalRequests,

--- a/e2e/tests/debug-alpha.spec.ts
+++ b/e2e/tests/debug-alpha.spec.ts
@@ -310,6 +310,35 @@ test("默认配置、正式元数据与 configuring 帮助界面", async ({ page
   await expect(aboutTrigger).toBeFocused();
 });
 
+test("人机私密视角只显示对手牌背与张数，双人仍公开手牌", async ({ page, runtimeErrors }) => {
+  void runtimeErrors;
+  await page.goto("/");
+  await expect(page.getByText("选择角色与模式后开始；只显示自己的手牌，对手为牌背。")).toBeVisible();
+  await page.getByRole("button", { name: "开始游戏" }).click();
+  await expect(page.getByRole("heading", { name: "本地人机对局" })).toBeVisible();
+  await expect(page.getByText("己方手牌；对手背面")).toBeVisible();
+
+  const opponent = page.locator('[aria-labelledby="player_2-title"]');
+  const opponentCountText = await opponent.locator(".hand-count-pill").textContent();
+  const opponentCount = Number(opponentCountText?.match(/(\d+)/)?.[1]);
+  expect(opponentCount).toBe(14);
+  await expect(opponent.locator(".card-back")).toHaveCount(opponentCount);
+  await expect(opponent.locator(".card-face")).toHaveCount(0);
+  await expect(opponent.locator(".debug-card__select")).toHaveCount(0);
+  await expect(opponent.getByText("牌背").first()).toBeVisible();
+
+  const own = page.locator('[aria-labelledby="player_1-title"]');
+  await expect(own.locator(".card-face")).toHaveCount(20);
+  await expect(own.locator(".card-back")).toHaveCount(0);
+
+  await startNoTeacherGame(page);
+  await expect(page.getByRole("heading", { name: "本地双人公开对局" })).toBeVisible();
+  const twoPlayerOpponent = page.locator('[aria-labelledby="player_2-title"]');
+  await expect(twoPlayerOpponent.locator(".card-face")).toHaveCount(10);
+  await expect(twoPlayerOpponent.locator(".card-back")).toHaveCount(0);
+  await expect(twoPlayerOpponent.locator(".debug-card__select")).toHaveCount(10);
+});
+
 test("新手引导覆盖真实流程和 fixture 窗口，并保持可键盘恢复", async ({ page, runtimeErrors }) => {
   void runtimeErrors;
   await page.goto("/");

--- a/scripts/check-size.mjs
+++ b/scripts/check-size.mjs
@@ -4,7 +4,8 @@ import { gzipSync } from "node:zlib";
 import { fileURLToPath } from "node:url";
 
 const limits = Object.freeze({
-  javascriptGzip: 108000,
+  // Phase 20C Human Play View + opponent card-back UI; Freeze §8 authorizes this raise.
+  javascriptGzip: 120000,
   cssGzip: 10 * 1024,
   total: 500 * 1024,
 });

--- a/src/features/local-game/LocalGamePage.tsx
+++ b/src/features/local-game/LocalGamePage.tsx
@@ -35,6 +35,10 @@ import type {
   LocalGameSessionInitializer,
   PlayingLocalGameSession,
 } from "./localGameSession";
+import {
+  getOfficialHumanViewerPlayerId,
+  getOfficialPlayState,
+} from "./officialPlayView";
 import { requiresSessionExitConfirmation } from "./sessionConfirmation";
 
 type PlayingGameProps = Readonly<{
@@ -62,6 +66,8 @@ function PlayingGame({
   const { game, error, playerControllers } = session;
   const { locale } = useLocale();
   const isEnglish = locale === "en";
+  const playGame = getOfficialPlayState(game, playerControllers);
+  const viewerPlayerId = getOfficialHumanViewerPlayerId(playerControllers);
   const [selectedCardId, setSelectedCardId] = useState<CardInstanceId | undefined>();
 
   useEffect(() => {
@@ -77,79 +83,80 @@ function PlayingGame({
     <main className="local-game-page">
       <GameSummary
         error={error ?? undefined}
-        game={game}
+        game={playGame}
         playerControllers={playerControllers}
         onRestart={(trigger) => onRequestSessionExit("restart", trigger)}
         onReturnToCharacterSelection={(trigger) => onRequestSessionExit("return", trigger)}
       />
-      <SuccessfulReactionNotice game={game} />
+      <SuccessfulReactionNotice game={playGame} />
       <div className="debug-layout play-shell-layout">
         <div className="debug-main play-surface">
           <div className="players-grid">
-            {game.players.map((player, index) => (
+            {playGame.players.map((player, index) => (
               <PlayerPanel
                 controller={playerControllers[index as 0 | 1]}
-                game={game}
-                handSelectionDisabled={game.phase !== "mainAction"}
+                game={playGame}
+                handReveal={viewerPlayerId !== undefined && player.id !== viewerPlayerId ? "backs" : "contents"}
+                handSelectionDisabled={playGame.phase !== "mainAction"}
                 key={player.id}
                 onSelectCard={setSelectedCardId}
                 player={player}
                 selectedCardId={selectedCardId}
-                showActivePlayerIndicator={game.phase !== "preparationSelection"}
+                showActivePlayerIndicator={playGame.phase !== "preparationSelection"}
               />
             ))}
           </div>
-          <TableReferenceBoard game={game} />
-          <GameLog game={game} />
+          <TableReferenceBoard game={playGame} />
+          <GameLog game={playGame} />
         </div>
         <aside className="debug-sidebar play-sidebar" aria-label={isEnglish ? "Action panels" : "操作面板"}>
           <NewPlayerGuidance
             collapsed={guidanceCollapsed}
-            game={game}
+            game={playGame}
             mode="playing"
             onCollapsedChange={onGuidanceCollapsedChange}
             onVisibleChange={onGuidanceVisibleChange}
             visible={guidanceVisible}
           />
-          {game.phase === "preparationSelection" ? (
+          {playGame.phase === "preparationSelection" ? (
             <PreparationPanel
               dispatchGameAction={dispatchGameAction}
-              game={game}
+              game={playGame}
               playerControllers={playerControllers}
             />
-          ) : game.phase === "experimentCounterattackWindow" ? (
+          ) : playGame.phase === "experimentCounterattackWindow" ? (
             <ExperimentCounterattackPanel
               dispatchGameAction={dispatchGameAction}
-              game={game}
+              game={playGame}
               playerControllers={playerControllers}
             />
           ) : (
             <>
               <ActionPanel
                 dispatchGameAction={dispatchGameAction}
-                game={game}
+                game={playGame}
                 onSelectCard={setSelectedCardId}
                 playerControllers={playerControllers}
                 selectedCardId={selectedCardId}
               />
               <DiyPanel
                 dispatchGameAction={dispatchGameAction}
-                game={game}
+                game={playGame}
                 playerControllers={playerControllers}
               />
               <ResponsePanel
                 dispatchGameAction={dispatchGameAction}
-                game={game}
+                game={playGame}
                 playerControllers={playerControllers}
               />
               <StatusPanel
                 dispatchGameAction={dispatchGameAction}
-                game={game}
+                game={playGame}
                 playerControllers={playerControllers}
               />
             </>
           )}
-          {game.phase === "gameOver" ? (
+          {playGame.phase === "gameOver" ? (
             <section className="debug-section">
               <h2>{isEnglish ? "Game over" : "对局结束"}</h2>
               <p className="panel-note">

--- a/src/features/local-game/components/AboutDialog.tsx
+++ b/src/features/local-game/components/AboutDialog.tsx
@@ -57,7 +57,7 @@ export function AboutDialog({ onClose }: AboutDialogProps) {
           <h3>{isEnglish ? "Controls" : "当前能力与基本操作"}</h3>
           <ul>
             {[
-              ["默认人机公开对局，亦支持本地双人；手牌、牌堆、状态与日志公开。", "Default Solo vs AI, with local two-player option; public hands, deck, status, and log."],
+              ["默认人机私密视角，亦支持本地双人公开手牌；正式日志可展示已发生事件。", "Default Solo vs AI uses a private hand view; local two-player still shows public hands. The official log may show events that already happened."],
               ["按阶段完成备课、主行动、响应、状态处理与角色技能。", "Follow phase panels."],
               ["酸碱中和产生虚拟 H2O；酸与碳酸盐产生虚拟 CO2；两者只记录结果，不创建 CardInstance。", "Virtual H2O/CO2; no CardInstance."],
               ["主动 DIY 每周期一次；角色技能按定义展示。", "DIY once per cycle."],
@@ -72,7 +72,7 @@ export function AboutDialog({ onClose }: AboutDialogProps) {
           <h3>{isEnglish ? "Quick guide" : "首局速查"}</h3>
           <ul>
             {[
-              ["在配置页确认阵容与模式；双方手牌公开。", "Confirm lineup and mode; hands are public."],
+              ["在配置页确认阵容与模式；人机只看自己的手牌，双人仍公开。", "Confirm lineup and mode; Solo vs AI hides the opponent hand, two-player stays public."],
               ["按当前面板完成各阶段操作或实验反击。", "Follow the active panel."],
               ["响应 DIY 关闭。中和产出虚拟 H2O，酸+碳酸盐产出虚拟 CO2。", "Virtual H2O/CO2 only."],
               ["卡池固定 68 张；真实金属、方程式与反应链延期。", "68-card pool; metals deferred."],

--- a/src/features/local-game/components/ActionPanel.tsx
+++ b/src/features/local-game/components/ActionPanel.tsx
@@ -251,7 +251,9 @@ export function ActionPanel({
       />
       <p className="empty-note">{isEnglish ? "Play updates table reference." : "普通出牌只更新场面基准。"}</p>
       <div className="action-card-list">
-        {activePlayer.hand.map((cardInstanceId) => {
+        {isAi ? (
+          <p className="empty-note">{getAiAutoActionNote(locale)}</p>
+        ) : activePlayer.hand.filter((cardInstanceId) => getCardDefinition(game, cardInstanceId)).map((cardInstanceId) => {
           const definition = getCardDefinition(game, cardInstanceId);
           const canAssociate = canPlayAgainstCurrentTableReference(
             game,

--- a/src/features/local-game/components/CardDebugCard.tsx
+++ b/src/features/local-game/components/CardDebugCard.tsx
@@ -2,7 +2,7 @@ import type { CardInstanceId } from "../../../game/engine/types";
 import { useLocale } from "../../../app/locale";
 import { formatList, getCardDefinition } from "../localGameView";
 import type { GameState } from "../../../game/engine/types";
-import { getCardDisplayName, getOptionalCardDisplayName } from "../presentationLocale";
+import { getCardDisplayName } from "../presentationLocale";
 
 type CardDebugCardProps = {
   cardInstanceId: CardInstanceId;
@@ -25,10 +25,8 @@ export function CardDebugCard({
 
   if (!definition) {
     return (
-      <article className="debug-card card-face is-missing">
-        <button className="debug-card__select" disabled type="button">
-          {getOptionalCardDisplayName(undefined, locale)} {cardInstanceId}
-        </button>
+      <article className="debug-card card-back is-missing">
+        <span className="card-back__caption">{isEnglish ? "Face down" : "牌背"}</span>
       </article>
     );
   }

--- a/src/features/local-game/components/CharacterSelectionPanel.tsx
+++ b/src/features/local-game/components/CharacterSelectionPanel.tsx
@@ -103,8 +103,12 @@ export function CharacterSelectionPanel({
         </div>
         <p className="panel-note">
           {isEnglish
-            ? (isSoloVsAi ? "Choose characters and mode; hands are public." : "Choose characters and controllers; hands are public.")
-            : (isSoloVsAi ? "选择角色与模式后开始；双方手牌公开。" : "选择角色与控制方后开始；双方手牌公开。")}
+            ? (isSoloVsAi
+              ? "Choose characters and mode; you see only your own hand, and the opponent hand is face down."
+              : "Choose characters and controllers; hands are public.")
+            : (isSoloVsAi
+              ? "选择角色与模式后开始；只显示自己的手牌，对手为牌背。"
+              : "选择角色与控制方后开始；双方手牌公开。")}
         </p>
         <p className="mirror-note">{isEnglish ? "Mirrored characters are allowed." : "试玩版允许镜像角色。"}</p>
       </section>

--- a/src/features/local-game/components/DiyPanel.tsx
+++ b/src/features/local-game/components/DiyPanel.tsx
@@ -41,12 +41,12 @@ export function DiyPanel({ game, playerControllers, dispatchGameAction }: DiyPan
   );
 
   const candidateCardIds = useMemo(() => {
-    if (!activePlayer) return [];
+    if (!activePlayer || isAi) return [];
     return activePlayer.hand.filter((cardId) => {
       const def = getCardDefinition(game, cardId);
       return def?.allowedTimings.includes("diy-component");
     });
-  }, [activePlayer, game]);
+  }, [activePlayer, game, isAi]);
 
   const [isSelecting, setIsSelecting] = useState<boolean>(false);
   const [selectedCardIds, setSelectedCardIds] = useState<CardInstanceId[]>([]);

--- a/src/features/local-game/components/ExperimentCounterattackPanel.tsx
+++ b/src/features/local-game/components/ExperimentCounterattackPanel.tsx
@@ -41,8 +41,8 @@ export function ExperimentCounterattackPanel({
     return null;
   }
 
-  const pursuitCards = getExperimentCounterattackPursuitCards(game, responder);
-  const metalCards = getExperimentCounterattackMetalCards(game, responder);
+  const pursuitCards = isAi ? [] : getExperimentCounterattackPursuitCards(game, responder);
+  const metalCards = isAi ? [] : getExperimentCounterattackMetalCards(game, responder);
   const canRecover = pending.legalOptions.includes("recover");
   const used = Boolean(
     responder.characterUsage.perCycle.chemistry_enthusiast_counterattack,

--- a/src/features/local-game/components/GameLog.tsx
+++ b/src/features/local-game/components/GameLog.tsx
@@ -16,11 +16,12 @@ export function GameLog({ game }: GameLogProps) {
     <section className="debug-section game-log" aria-labelledby="game-log-title">
       <h2 id="game-log-title">{isEnglish ? "Full game log" : "完整游戏日志"}</h2>
       <ol>
-        {game.log.map((entry) => {
+        {game.log.map((entry, index) => {
           const reaction = getPublicReactionLogView(game, entry, locale, context);
+          const isLatest = index === game.log.length - 1;
 
           return (
-            <li key={entry.id}>
+            <li className={isLatest ? "is-latest" : undefined} key={entry.id}>
               <div className="game-log__message">
                 {renderGameLogEntry(entry, locale, context)}
                 <details className="debug-details game-log__details">

--- a/src/features/local-game/components/GameSummary.tsx
+++ b/src/features/local-game/components/GameSummary.tsx
@@ -28,7 +28,13 @@ export function GameSummary({
   const isSoloVsAi = Boolean(playerControllers && playerControllers.some((c) => c === "ai"));
   const summaryTitle = isEnglish
     ? (isSoloVsAi ? "Solo vs AI" : "Local public two-player game")
-    : (isSoloVsAi ? "本地人机公开对局" : "本地双人公开对局");
+    : (isSoloVsAi ? "本地人机对局" : "本地双人公开对局");
+  const visibilityLabel = isEnglish
+    ? (isSoloVsAi ? "Private view" : "Public game")
+    : (isSoloVsAi ? "私密视角" : "公开对局");
+  const visibilityValue = isEnglish
+    ? (isSoloVsAi ? "Own hand; opponent backs" : "Public hands")
+    : (isSoloVsAi ? "己方手牌；对手背面" : "手牌可见");
   const winnerText = game.phase === "gameOver"
     ? game.isDraw
       ? (isEnglish ? "Draw" : "平局")
@@ -64,7 +70,7 @@ export function GameSummary({
           [isEnglish ? "Active player" : "当前行动玩家", getPlayerDisplayName(game.players.find((p) => p.id === game.activePlayerId), locale)],
           [isEnglish ? "Deck" : "牌堆", game.deck.length],
           [isEnglish ? "Discard pile" : "弃牌堆", game.discardPile.length],
-          [isEnglish ? "Public game" : "公开对局", isEnglish ? "Public hands" : "手牌可见"],
+          [visibilityLabel, visibilityValue],
           [isEnglish ? "Outcome" : "胜负", winnerText],
         ] as const).map(([l, v]) => (
           <div key={l}><dt>{l}</dt><dd>{v}</dd></div>

--- a/src/features/local-game/components/PlayerPanel.tsx
+++ b/src/features/local-game/components/PlayerPanel.tsx
@@ -22,6 +22,7 @@ type PlayerPanelProps = {
   controller?: PlayerController;
   selectedCardId?: CardInstanceId;
   onSelectCard: (cardInstanceId: CardInstanceId) => void;
+  handReveal?: "contents" | "backs";
   handSelectionDisabled?: boolean;
   showActivePlayerIndicator?: boolean;
 };
@@ -32,6 +33,7 @@ export function PlayerPanel({
   controller,
   selectedCardId,
   onSelectCard,
+  handReveal = "contents",
   handSelectionDisabled = false,
   showActivePlayerIndicator = true,
 }: PlayerPanelProps) {
@@ -136,16 +138,31 @@ export function PlayerPanel({
         </details>
       </div>
       <div className="hand-grid" aria-label={isEnglish ? `${getPlayerDisplayName(player, locale)}'s hand` : `${getPlayerDisplayName(player, locale)}的手牌`}>
-        {player.hand.map((cardInstanceId) => (
-          <CardDebugCard
-            cardInstanceId={cardInstanceId}
-            disabled={effectiveHandDisabled}
-            game={game}
-            key={cardInstanceId}
-            onSelect={effectiveHandDisabled ? undefined : onSelectCard}
-            selected={!effectiveHandDisabled && selectedCardId === cardInstanceId}
-          />
-        ))}
+        {handReveal === "backs"
+          ? player.hand.map((_, index) => (
+              <article
+                aria-label={
+                  isEnglish
+                    ? `Face-down card ${index + 1} of ${player.hand.length}`
+                    : `牌背 ${index + 1}/${player.hand.length}`
+                }
+                className="debug-card card-back"
+                key={`${player.id}-back-${index}`}
+              >
+                <span aria-hidden="true" className="card-back__mark">RF</span>
+                <span className="card-back__caption">{isEnglish ? "Face down" : "牌背"}</span>
+              </article>
+            ))
+          : player.hand.map((cardInstanceId) => (
+              <CardDebugCard
+                cardInstanceId={cardInstanceId}
+                disabled={effectiveHandDisabled}
+                game={game}
+                key={cardInstanceId}
+                onSelect={effectiveHandDisabled ? undefined : onSelectCard}
+                selected={!effectiveHandDisabled && selectedCardId === cardInstanceId}
+              />
+            ))}
       </div>
     </section>
   );

--- a/src/features/local-game/components/PreparationPanel.tsx
+++ b/src/features/local-game/components/PreparationPanel.tsx
@@ -56,13 +56,15 @@ export function PreparationPanel({ game, playerControllers, dispatchGameAction }
       </p>
       <details className="debug-details"><summary>{isEnglish ? "Debug details" : "调试详情"}</summary><p>LABORATORY_PREPARATION</p></details>
       <div className="preparation-candidate-grid">
-        {validCandidateIds.map((cardInstanceId) => (
+        {isAi ? (
+          <p className="empty-note">{getAiAutoActionNote(locale)}</p>
+        ) : validCandidateIds.map((cardInstanceId) => (
           <CardDebugCard
             cardInstanceId={cardInstanceId}
-            disabled={isAi}
+            disabled={false}
             game={game}
             key={cardInstanceId}
-            onSelect={isAi ? undefined : toggleCard}
+            onSelect={toggleCard}
             selected={validSelectedIds.includes(cardInstanceId)}
           />
         ))}

--- a/src/features/local-game/components/PublicPlayedCard.tsx
+++ b/src/features/local-game/components/PublicPlayedCard.tsx
@@ -1,0 +1,34 @@
+import { cardDefinitionsById } from "../../../game/data/cardDefinitions";
+import { useLocale } from "../../../app/locale";
+import { getCardDisplayName, getCardTypeDisplayName } from "../presentationLocale";
+
+type PublicPlayedCardProps = Readonly<{
+  definitionId: string;
+}>;
+
+export function PublicPlayedCard({ definitionId }: PublicPlayedCardProps) {
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
+  const definition = cardDefinitionsById.get(definitionId);
+  const name = definition
+    ? getCardDisplayName(definition.id, definition.name, locale)
+    : definitionId;
+  const typeLabel = definition
+    ? getCardTypeDisplayName(definition.type, locale)
+    : (isEnglish ? "Card" : "卡牌");
+  const isIon = definition?.type === "ion";
+
+  return (
+    <article
+      aria-label={`${name} · ${typeLabel}`}
+      className={`debug-card card-face is-public-play${isIon ? " is-ion" : ""}`}
+    >
+      <div className="card-face__badge-row">
+        <span className={`card-face__type-badge ${isIon ? "is-ion" : "is-substance"}`}>
+          {typeLabel}
+        </span>
+      </div>
+      <strong className="debug-card__name card-face__name">{name}</strong>
+    </article>
+  );
+}

--- a/src/features/local-game/components/ResponsePanel.tsx
+++ b/src/features/local-game/components/ResponsePanel.tsx
@@ -8,6 +8,8 @@ import {
   getResponseCards,
 } from "../localGameView";
 import { CardDebugCard } from "./CardDebugCard";
+import { getOfficialHumanViewerPlayerId } from "../officialPlayView";
+import { describeIncomingResponseAnnouncement } from "../publicRecentAction";
 import { getAiAutoActionNote, getPlayerDisplayName } from "../presentationLocale";
 
 type ResponsePanelProps = {
@@ -27,6 +29,11 @@ export function ResponsePanel({ game, playerControllers, dispatchGameAction }: R
       playerControllers[responder.id === "player_1" ? 0 : 1] === "ai",
   );
   const responseCards = !isAi && responder ? getResponseCards(game, responder) : [];
+  const incomingPlay = describeIncomingResponseAnnouncement(
+    game,
+    locale,
+    playerControllers ? getOfficialHumanViewerPlayerId(playerControllers) : undefined,
+  );
 
   if (game.phase !== "responseWindow" || !pendingResponse || !responder) {
     return null;
@@ -48,6 +55,7 @@ export function ResponsePanel({ game, playerControllers, dispatchGameAction }: R
           {isEnglish ? "Pass response" : "放弃响应"}
         </button>
       </div>
+      {incomingPlay ? <p className="panel-note response-incoming-play">{incomingPlay}</p> : null}
       <p className="panel-note">
         {isEnglish ? `${getPlayerDisplayName(responder, locale)} may respond.` : `轮到 ${responder.name} 决定是否响应当前效果。`}
         {isAi ? ` · ${getAiAutoActionNote(locale)}` : ""}

--- a/src/features/local-game/components/ResponsePanel.tsx
+++ b/src/features/local-game/components/ResponsePanel.tsx
@@ -26,7 +26,7 @@ export function ResponsePanel({ game, playerControllers, dispatchGameAction }: R
       playerControllers &&
       playerControllers[responder.id === "player_1" ? 0 : 1] === "ai",
   );
-  const responseCards = responder ? getResponseCards(game, responder) : [];
+  const responseCards = !isAi && responder ? getResponseCards(game, responder) : [];
 
   if (game.phase !== "responseWindow" || !pendingResponse || !responder) {
     return null;

--- a/src/features/local-game/components/StatusPanel.tsx
+++ b/src/features/local-game/components/StatusPanel.tsx
@@ -27,7 +27,7 @@ export function StatusPanel({ game, playerControllers, dispatchGameAction }: Sta
       playerControllers[player.id === "player_1" ? 0 : 1] === "ai",
   );
   const status = getPlayerStatusById(player, pendingStatusHandling?.statusInstanceId);
-  const handlingCards = player ? getStatusHandlingCards(game, player, status) : [];
+  const handlingCards = !isAi && player ? getStatusHandlingCards(game, player, status) : [];
 
   if (game.phase !== "statusWindow" || !pendingStatusHandling || !player || !status) {
     return null;

--- a/src/features/local-game/components/TableReferenceBoard.tsx
+++ b/src/features/local-game/components/TableReferenceBoard.tsx
@@ -1,15 +1,39 @@
+import { cardDefinitionsById } from "../../../game/data/cardDefinitions";
 import { useLocale } from "../../../app/locale";
 import type { GameState } from "../../../game/engine/types";
-import { getPlayerDisplayNameById } from "../presentationLocale";
+import {
+  formatPublicRecentAction,
+  getPublicRecentAction,
+} from "../publicRecentAction";
+import {
+  getCardDisplayName,
+  getCardTypeDisplayName,
+  getPlayerDisplayNameById,
+} from "../presentationLocale";
+import { PublicPlayedCard } from "./PublicPlayedCard";
 
 type TableReferenceBoardProps = Readonly<{
   game: GameState;
 }>;
 
+const recentKindLabels = {
+  "card-play": ["打出", "Played"],
+  response: ["响应", "Responded with"],
+  "status-handling": ["处理状态", "Handled status with"],
+  diy: ["主动 DIY", "Active DIY"],
+} as const;
+
 export function TableReferenceBoard({ game }: TableReferenceBoardProps) {
   const { locale } = useLocale();
   const isEnglish = locale === "en";
   const ref = game.tableReference;
+  const refDefinition = ref ? cardDefinitionsById.get(ref.definitionId) : undefined;
+  const refName = ref
+    ? getCardDisplayName(ref.definitionId, ref.displayName, locale)
+    : undefined;
+  const refType = refDefinition ? getCardTypeDisplayName(refDefinition.type, locale) : undefined;
+  const recent = getPublicRecentAction(game);
+  const recentView = recent ? formatPublicRecentAction(recent, locale) : undefined;
 
   return (
     <section
@@ -27,9 +51,14 @@ export function TableReferenceBoard({ game }: TableReferenceBoardProps) {
             </span>
           ) : null}
         </div>
-        {ref ? (
+        {ref && refName ? (
           <div className="table-reference-card">
-            <strong className="table-reference-card__name">{ref.displayName}</strong>
+            {refType ? (
+              <span className={`card-face__type-badge ${refDefinition?.type === "ion" ? "is-ion" : "is-substance"}`}>
+                {refType}
+              </span>
+            ) : null}
+            <strong className="table-reference-card__name">{refName}</strong>
             <span className="table-reference-card__author">
               {isEnglish ? "Played by " : "由 "}{getPlayerDisplayNameById(ref.playedBy, locale, game.logPresentationContext)}{isEnglish ? "" : " 打出"}
             </span>
@@ -45,6 +74,32 @@ export function TableReferenceBoard({ game }: TableReferenceBoardProps) {
           </div>
         )}
       </div>
+
+      {recentView ? (
+        <div
+          aria-label={isEnglish ? "Most recent public play" : "最近公开行动"}
+          className="recent-public-action"
+        >
+          <div className="table-center-reference__header">
+            <span className="table-center-label">
+              {isEnglish ? "Latest play" : "最近行动"}
+            </span>
+            <span className="table-center-turn">
+              {getPlayerDisplayNameById(recentView.actorId, locale, game.logPresentationContext)}
+              {" · "}
+              {recentKindLabels[recentView.kind][isEnglish ? 1 : 0]}
+            </span>
+          </div>
+          {recent?.definitionId ? (
+            <PublicPlayedCard definitionId={recent.definitionId} />
+          ) : (
+            <div className="table-reference-card">
+              <span className="card-face__type-badge is-substance">{recentView.typeLabel}</span>
+              <strong className="table-reference-card__name">{recentView.name}</strong>
+            </div>
+          )}
+        </div>
+      ) : null}
 
       <div className="table-center-piles">
         <div className="pile-stat-chip">

--- a/src/features/local-game/local-game.css
+++ b/src/features/local-game/local-game.css
@@ -774,6 +774,31 @@ dd {
   line-height: 1.35;
 }
 
+.recent-public-action {
+  display: grid;
+  flex: 1 1 200px;
+  gap: 6px;
+  min-width: 0;
+}
+
+.recent-public-action .card-face {
+  min-height: 0;
+  padding: 8px 10px;
+}
+
+.recent-public-action .card-face__name {
+  font-size: 0.95rem;
+}
+
+.response-incoming-play {
+  background: #eef6fb;
+  border: 1px solid #b7c9d6;
+  border-radius: 6px;
+  color: #17324a;
+  font-weight: 700;
+  padding: 8px 10px;
+}
+
 .table-center-piles {
   align-items: center;
   display: flex;
@@ -1540,6 +1565,13 @@ select {
   line-height: 1.45;
   overflow-wrap: anywhere;
   padding: 8px;
+}
+
+.game-log li.is-latest {
+  background: #eef6fb;
+  border-color: #244b64;
+  box-shadow: 0 0 0 1px #244b64 inset;
+  font-weight: 700;
 }
 
 .game-log__entry-id {

--- a/src/features/local-game/local-game.css
+++ b/src/features/local-game/local-game.css
@@ -1012,6 +1012,35 @@ dd {
   box-shadow: 0 0 0 2px #059669, 0 4px 12px rgb(5 150 105 / 15%);
 }
 
+.card-back {
+  align-items: center;
+  background:
+    repeating-linear-gradient(
+      135deg,
+      #1f3b4d 0 8px,
+      #163040 8px 16px
+    );
+  border-color: #0f2740;
+  color: #e8eef2;
+  justify-items: center;
+  min-height: 88px;
+  place-content: center;
+  text-align: center;
+}
+
+.card-back__mark {
+  font-size: 0.85rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  opacity: 0.85;
+}
+
+.card-back__caption {
+  color: #d5e2ea;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
 .card-face__badge-row {
   align-items: center;
   display: flex;

--- a/src/features/local-game/officialPlayView.ts
+++ b/src/features/local-game/officialPlayView.ts
@@ -1,0 +1,30 @@
+import { projectHumanPlayState } from "../../game/engine/humanPlayView";
+import type { GameState, PlayerId } from "../../game/engine/types";
+import type { VisibilityMode } from "../../game/engine/visibility";
+import type { PlayerControllerSelection } from "./localGameSession";
+
+export function getOfficialHumanViewerPlayerId(
+  controllers: PlayerControllerSelection,
+): PlayerId | undefined {
+  const humanIndexes = controllers.flatMap((controller, index) =>
+    controller === "human" ? [index] : [],
+  );
+  if (humanIndexes.length !== 1) {
+    return undefined;
+  }
+  return `player_${humanIndexes[0] + 1}`;
+}
+
+export function getOfficialVisibilityMode(
+  controllers: PlayerControllerSelection,
+): VisibilityMode {
+  return getOfficialHumanViewerPlayerId(controllers) ? "human-play" : "public-debug";
+}
+
+export function getOfficialPlayState(
+  game: GameState,
+  controllers: PlayerControllerSelection,
+): GameState {
+  const viewerId = getOfficialHumanViewerPlayerId(controllers);
+  return viewerId ? projectHumanPlayState(game, viewerId) : game;
+}

--- a/src/features/local-game/presentationLocale.ts
+++ b/src/features/local-game/presentationLocale.ts
@@ -1,4 +1,5 @@
 import type {
+  CardType,
   CharacterId,
   CharacterSkillImplementationStatus,
   CharacterSkillType,
@@ -113,6 +114,13 @@ const damageKindNames: Record<string, LocalizedLabel> = {
   base: ["碱性", "alkaline"],
 };
 
+const cardTypeNames: Record<CardType, LocalizedLabel> = {
+  element: ["元素", "Element"],
+  ion: ["离子", "Ion"],
+  substance: ["实体", "Substance"],
+  event: ["事件", "Event"],
+};
+
 const reactionNames: Record<string, LocalizedLabel> = {
   acid_base_neutralization: ["酸碱中和", "Acid-base neutralization"],
   acid_carbonate_co2: ["酸与碳酸盐", "Acid and carbonate"],
@@ -183,6 +191,8 @@ export const getStatusDisplayName = (statusId: string, locale: DisplayLocale): s
 export const getStrictStatusDisplayName = (statusId: string, locale: DisplayLocale): string => lookup(statusNames, statusId, locale, "statusId");
 export const getReactionDisplayName = (reactionId: string, locale: DisplayLocale): string => lookup(reactionNames, reactionId, locale);
 export const getStrictReactionDisplayName = (reactionId: string, locale: DisplayLocale): string => lookup(reactionNames, reactionId, locale, "reactionId");
+export const getCardTypeDisplayName = (type: CardType, locale: DisplayLocale): string =>
+  cardTypeNames[type][locale === "en" ? 1 : 0];
 export const getDamageKindDisplayName = (damageKind: string, locale: DisplayLocale): string => lookup(damageKindNames, damageKind, locale);
 export const getStrictDamageKindDisplayName = (damageKind: string, locale: DisplayLocale): string => lookup(damageKindNames, damageKind, locale, "damageKind");
 export const getSkillTypeDisplayName = (type: CharacterSkillType, locale: DisplayLocale): string => skillTypeNames[type][locale === "en" ? 1 : 0];

--- a/src/features/local-game/publicRecentAction.test.tsx
+++ b/src/features/local-game/publicRecentAction.test.tsx
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import { identityShuffle } from "../../shared/random";
+import { createInitialGame } from "../../game/engine/createInitialGame";
+import { engineReducer } from "../../game/engine/reducer";
+import type { CardInstanceId, GameState, PlayerId } from "../../game/engine/types";
+import {
+  describeIncomingResponseAnnouncement,
+  getPublicRecentAction,
+} from "./publicRecentAction";
+
+function putCardInHand(
+  state: GameState,
+  playerId: PlayerId,
+  cardInstanceId: CardInstanceId,
+): GameState {
+  const card = state.cardInstances[cardInstanceId];
+  if (!card) {
+    throw new Error(`Missing card ${cardInstanceId}`);
+  }
+  return {
+    ...state,
+    players: state.players.map((player) => ({
+      ...player,
+      hand: player.id === playerId
+        ? [...player.hand.filter((id) => id !== cardInstanceId), cardInstanceId]
+        : player.hand.filter((id) => id !== cardInstanceId),
+    })),
+    deck: state.deck.filter((id) => id !== cardInstanceId),
+    discardPile: state.discardPile.filter((id) => id !== cardInstanceId),
+    cardInstances: {
+      ...state.cardInstances,
+      [cardInstanceId]: {
+        ...card,
+        ownerId: playerId,
+        zone: { type: "hand", playerId },
+      },
+    },
+  };
+}
+
+function createReadyState(): GameState {
+  return createInitialGame({
+    characterIds: ["chemical_factory_ceo", "acid_king"],
+    shuffle: identityShuffle,
+  });
+}
+
+describe("public recent action readout", () => {
+  it("reads PLAY_CARD attacks from the pending response source", () => {
+    let state = createReadyState();
+    state = putCardInHand(state, "player_2", "substance_caoh2_limewater_01");
+    state = engineReducer(state, { type: "PASS_ACTION", playerId: "player_1" }, identityShuffle);
+    state = engineReducer(
+      state,
+      {
+        type: "PLAY_CARD",
+        playerId: "player_2",
+        cardInstanceId: "substance_caoh2_limewater_01",
+        targetPlayerId: "player_1",
+      },
+      identityShuffle,
+    );
+
+    const recent = getPublicRecentAction(state);
+    expect(recent).toEqual({
+      actorId: "player_2",
+      kind: "card-play",
+      definitionId: "substance_caoh2_limewater",
+    });
+    expect(describeIncomingResponseAnnouncement(state, "zh-CN")).toBe(
+      "对方打出 石灰水 Ca(OH)2（实体）",
+    );
+    expect(describeIncomingResponseAnnouncement(state, "en")).toBe(
+      "Opponent played Limewater Ca(OH)2 (Substance)",
+    );
+  });
+
+  it("reads reference plays from the latest log event", () => {
+    let state = createReadyState();
+    state = putCardInHand(state, "player_1", "ion_ca_01");
+    state = engineReducer(
+      state,
+      {
+        type: "PLAY_REFERENCE_CARD",
+        playerId: "player_1",
+        cardInstanceId: "ion_ca_01",
+      },
+      identityShuffle,
+    );
+
+    expect(getPublicRecentAction(state)).toEqual({
+      actorId: "player_1",
+      kind: "card-play",
+      definitionId: "ion_ca",
+    });
+  });
+
+  it("reads a successful response card from the reaction log", () => {
+    let state = createReadyState();
+    state = putCardInHand(state, "player_1", "substance_hcl_dilute_01");
+    state = putCardInHand(state, "player_2", "substance_naoh_dilute_01");
+    state = engineReducer(
+      state,
+      {
+        type: "PLAY_CARD",
+        playerId: "player_1",
+        cardInstanceId: "substance_hcl_dilute_01",
+        targetPlayerId: "player_2",
+      },
+      identityShuffle,
+    );
+    state = engineReducer(
+      state,
+      {
+        type: "RESPOND_WITH_CARD",
+        playerId: "player_2",
+        cardInstanceId: "substance_naoh_dilute_01",
+      },
+      identityShuffle,
+    );
+
+    expect(getPublicRecentAction(state)).toEqual({
+      actorId: "player_2",
+      kind: "response",
+      definitionId: "substance_naoh_dilute",
+    });
+  });
+
+  it("reads fire status handling and DIY results from the log", () => {
+    let fireState = createReadyState();
+    fireState = putCardInHand(fireState, "player_2", "substance_h2o_01");
+    fireState = {
+      ...fireState,
+      activePlayerId: "player_2",
+      phase: "statusWindow",
+      players: fireState.players.map((player) =>
+        player.id === "player_2"
+          ? {
+              ...player,
+              statuses: [
+                {
+                  id: "status_test_FIRE_1",
+                  statusId: "FIRE",
+                  sourcePlayerId: "player_1",
+                  createdAt: 1,
+                },
+              ],
+            }
+          : player,
+      ),
+      pendingStatusHandling: {
+        playerId: "player_2",
+        statusInstanceId: "status_test_FIRE_1",
+      },
+    };
+    fireState = engineReducer(
+      fireState,
+      {
+        type: "HANDLE_STATUS_WITH_CARD",
+        playerId: "player_2",
+        statusInstanceId: "status_test_FIRE_1",
+        cardInstanceId: "substance_h2o_01",
+      },
+      identityShuffle,
+    );
+    expect(getPublicRecentAction(fireState)).toEqual({
+      actorId: "player_2",
+      kind: "status-handling",
+      definitionId: "substance_h2o",
+    });
+
+    const diyState: GameState = {
+      ...createReadyState(),
+      log: [
+        {
+          id: "log_diy",
+          eventKey: "diy_virtual_attack",
+          params: {
+            playerId: "player_2",
+            recipeId: "diy_hcl_from_h_cl",
+            targetId: "player_1",
+            damageKind: "acid",
+            amount: 1,
+          },
+        },
+      ],
+    };
+    expect(getPublicRecentAction(diyState)).toEqual({
+      actorId: "player_2",
+      kind: "diy",
+      recipeId: "diy_hcl_from_h_cl",
+    });
+  });
+});

--- a/src/features/local-game/publicRecentAction.ts
+++ b/src/features/local-game/publicRecentAction.ts
@@ -1,0 +1,189 @@
+import type { DisplayLocale } from "../../app/locale";
+import { cardDefinitionsById } from "../../game/data/cardDefinitions";
+import type {
+  CardDefinitionId,
+  GameLogEntry,
+  GameState,
+  PlayerId,
+} from "../../game/engine/types";
+import {
+  getCardDisplayName,
+  getCardTypeDisplayName,
+  getDiyRecipeDisplayName,
+  getDiyVirtualProductDisplayName,
+} from "./presentationLocale";
+
+export type PublicRecentActionKind = "card-play" | "response" | "status-handling" | "diy";
+
+export type PublicRecentAction = Readonly<{
+  actorId: PlayerId;
+  kind: PublicRecentActionKind;
+  definitionId?: CardDefinitionId;
+  recipeId?: string;
+  productKey?: "CO2" | "H2O" | "SO2";
+}>;
+
+export type PublicRecentActionView = Readonly<{
+  actorId: PlayerId;
+  kind: PublicRecentActionKind;
+  name: string;
+  typeLabel: string;
+}>;
+
+function cardAction(
+  actorId: PlayerId,
+  kind: PublicRecentActionKind,
+  definitionId: CardDefinitionId,
+): PublicRecentAction {
+  return { actorId, kind, definitionId };
+}
+
+function fromPendingResponse(state: GameState): PublicRecentAction | undefined {
+  const source = state.pendingResponse?.sourceEffect.context.source;
+  if (!source) {
+    return undefined;
+  }
+  if (source.kind === "card") {
+    return cardAction(source.sourcePlayerId, "card-play", source.cardDefinitionId);
+  }
+  if (source.kind === "diy") {
+    return { actorId: source.sourcePlayerId, kind: "diy", recipeId: source.recipeId };
+  }
+  return undefined;
+}
+
+function fromLogEntry(entry: GameLogEntry): PublicRecentAction | undefined {
+  switch (entry.eventKey) {
+    case "card_play_attack":
+    case "card_play_reference":
+      return cardAction(entry.params.actorId, "card-play", entry.params.cardDefinitionId);
+    case "card_play_so2":
+      return cardAction(entry.params.actorId, "card-play", "substance_so2");
+    case "card_play_o2":
+      return cardAction(entry.params.actorId, "card-play", "substance_o2");
+    case "status_handled_fire":
+      return cardAction(entry.params.playerId, "status-handling", entry.params.cardDefinitionId);
+    case "skill_alkali_recovery":
+      return cardAction(entry.params.playerId, "card-play", entry.params.cardDefinitionId);
+    case "counterattack_pursuit":
+      return cardAction(entry.params.playerId, "card-play", entry.params.cardDefinitionId);
+    case "diy_virtual_attack":
+      return { actorId: entry.params.playerId, kind: "diy", recipeId: entry.params.recipeId };
+    case "diy_co2_remove_fire":
+      return { actorId: entry.params.playerId, kind: "diy", recipeId: "diy_co2_from_c_o_o", productKey: "CO2" };
+    case "diy_h2o_remove_fire":
+      return { actorId: entry.params.playerId, kind: "diy", recipeId: "diy_h2o_from_h_oh", productKey: "H2O" };
+    case "diy_so2_apply_leak":
+      return { actorId: entry.params.actorId, kind: "diy", recipeId: "diy_so2_from_s_o_o", productKey: "SO2" };
+    case "reaction": {
+      const cards = entry.reaction.participants.filter((participant) => participant.kind === "card");
+      const revealing =
+        cards.find((participant) => participant.role === "responder" || participant.role === "status-handler") ??
+        cards.find((participant) => participant.role === "attacker");
+      if (!revealing || revealing.kind !== "card") {
+        const diy = entry.reaction.participants.find((participant) => participant.kind === "diy");
+        if (diy && diy.kind === "diy") {
+          return { actorId: diy.playerId, kind: "diy", recipeId: diy.recipeId };
+        }
+        return undefined;
+      }
+      return cardAction(
+        revealing.playerId,
+        revealing.role === "responder" ? "response" : revealing.role === "status-handler" ? "status-handling" : "card-play",
+        revealing.cardDefinitionId,
+      );
+    }
+    default:
+      return undefined;
+  }
+}
+
+export function getPublicRecentAction(state: GameState): PublicRecentAction | undefined {
+  const pending = fromPendingResponse(state);
+  if (pending) {
+    return pending;
+  }
+  for (let index = state.log.length - 1; index >= 0; index -= 1) {
+    const recent = fromLogEntry(state.log[index]);
+    if (recent) {
+      return recent;
+    }
+  }
+  return undefined;
+}
+
+function diyResultName(action: PublicRecentAction, locale: DisplayLocale): string {
+  if (action.productKey) {
+    return action.productKey;
+  }
+  if (!action.recipeId) {
+    return "DIY";
+  }
+  const product = getDiyVirtualProductDisplayName(action.recipeId, locale);
+  return product === action.recipeId
+    ? getDiyRecipeDisplayName(action.recipeId, action.recipeId, locale)
+    : product;
+}
+
+export function formatPublicRecentAction(
+  action: PublicRecentAction,
+  locale: DisplayLocale,
+): PublicRecentActionView {
+  if (action.kind === "diy") {
+    return {
+      actorId: action.actorId,
+      kind: action.kind,
+      name: diyResultName(action, locale),
+      typeLabel: "DIY",
+    };
+  }
+
+  const definition = action.definitionId ? cardDefinitionsById.get(action.definitionId) : undefined;
+  return {
+    actorId: action.actorId,
+    kind: action.kind,
+    name: definition
+      ? getCardDisplayName(definition.id, definition.name, locale)
+      : (action.definitionId ?? ""),
+    typeLabel: definition ? getCardTypeDisplayName(definition.type, locale) : "",
+  };
+}
+
+export function describeIncomingResponseAnnouncement(
+  state: GameState,
+  locale: DisplayLocale,
+  viewerPlayerId?: PlayerId,
+): string | undefined {
+  if (state.phase !== "responseWindow" || !state.pendingResponse) {
+    return undefined;
+  }
+  const source = state.pendingResponse.sourceEffect.context.source;
+  const sourcePlayerId = source.kind === "card" || source.kind === "diy" || source.kind === "character-skill"
+    ? source.sourcePlayerId
+    : undefined;
+  const asOpponent = sourcePlayerId
+    ? sourcePlayerId !== (viewerPlayerId ?? state.pendingResponse.responderId)
+    : false;
+  const isEnglish = locale === "en";
+  if (source.kind === "card") {
+    const definition = cardDefinitionsById.get(source.cardDefinitionId);
+    const name = definition
+      ? getCardDisplayName(definition.id, definition.name, locale)
+      : source.cardDefinitionId;
+    const typeLabel = definition ? getCardTypeDisplayName(definition.type, locale) : "";
+    if (isEnglish) {
+      return asOpponent ? `Opponent played ${name} (${typeLabel})` : `You played ${name} (${typeLabel})`;
+    }
+    return asOpponent ? `对方打出 ${name}（${typeLabel}）` : `你打出 ${name}（${typeLabel}）`;
+  }
+  if (source.kind === "diy") {
+    const name = getDiyVirtualProductDisplayName(source.recipeId, locale);
+    if (isEnglish) {
+      return asOpponent
+        ? `Opponent used DIY to produce ${name} (DIY)`
+        : `You used DIY to produce ${name} (DIY)`;
+    }
+    return asOpponent ? `对方主动 DIY 生成 ${name}（DIY）` : `你主动 DIY 生成 ${name}（DIY）`;
+  }
+  return undefined;
+}

--- a/src/features/local-game/soloPrivateView.test.tsx
+++ b/src/features/local-game/soloPrivateView.test.tsx
@@ -1,0 +1,242 @@
+// @vitest-environment happy-dom
+
+import { StrictMode, act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it } from "vitest";
+import { LocaleProvider } from "../../app/locale";
+import { createInitialGame } from "../../game/engine/createInitialGame";
+import type { CardInstanceId, GameState, PlayerId } from "../../game/engine/types";
+import { identityShuffle } from "../../shared/random";
+import { LocalGamePage } from "./LocalGamePage";
+import type { LocalGameFactory } from "./localGameSession";
+
+function putCardInHand(
+  state: GameState,
+  playerId: PlayerId,
+  cardInstanceId: CardInstanceId,
+): GameState {
+  const card = state.cardInstances[cardInstanceId];
+  if (!card) {
+    throw new Error(`Missing card ${cardInstanceId}`);
+  }
+  return {
+    ...state,
+    players: state.players.map((player) => ({
+      ...player,
+      hand: player.id === playerId
+        ? [...player.hand.filter((id) => id !== cardInstanceId), cardInstanceId]
+        : player.hand.filter((id) => id !== cardInstanceId),
+    })),
+    deck: state.deck.filter((id) => id !== cardInstanceId),
+    discardPile: state.discardPile.filter((id) => id !== cardInstanceId),
+    cardInstances: {
+      ...state.cardInstances,
+      [cardInstanceId]: {
+        ...card,
+        ownerId: playerId,
+        zone: { type: "hand", playerId },
+      },
+    },
+  };
+}
+
+function moveAllCopiesToHand(
+  state: GameState,
+  playerId: PlayerId,
+  definitionId: string,
+): GameState {
+  const ids = Object.keys(state.cardInstances).filter(
+    (cardId) => state.cardInstances[cardId].definitionId === definitionId,
+  );
+  return ids.reduce(
+    (current, cardInstanceId) => putCardInHand(current, playerId, cardInstanceId),
+    state,
+  );
+}
+
+const privateViewFactory: LocalGameFactory = (characterIds) => {
+  let state = createInitialGame({
+    characterIds: [characterIds[0], characterIds[1]],
+    shuffle: identityShuffle,
+  });
+  state = moveAllCopiesToHand(state, "player_1", "substance_h2so4_dilute");
+  state = moveAllCopiesToHand(state, "player_2", "substance_caoh2_limewater");
+  state = moveAllCopiesToHand(state, "player_2", "ion_ca");
+  return state;
+};
+
+function playerPanel(container: HTMLElement, playerId: "player_1" | "player_2"): HTMLElement {
+  const panel = container.querySelector(`[aria-labelledby="${playerId}-title"]`);
+  if (!(panel instanceof HTMLElement)) {
+    throw new Error(`Missing ${playerId} panel`);
+  }
+  return panel;
+}
+
+async function renderPage() {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <StrictMode>
+        <LocaleProvider>
+          <LocalGamePage
+            createGame={privateViewFactory}
+            aiDelayMs={10000}
+          />
+        </LocaleProvider>
+      </StrictMode>,
+    );
+  });
+  const chineseButton = Array.from(container.querySelectorAll("button")).find(
+    (button) => button.textContent === "中文",
+  );
+  await act(async () => {
+    chineseButton?.click();
+  });
+  return { container, root };
+}
+
+async function selectCharacters(container: HTMLElement) {
+  const characterSelects = container.querySelectorAll(
+    "select[aria-label*='character'], select[aria-label*='角色']",
+  );
+  await act(async () => {
+    const playerA = characterSelects[0] as HTMLSelectElement;
+    playerA.value = "chemical_factory_ceo";
+    playerA.dispatchEvent(new Event("change", { bubbles: true }));
+    const playerB = characterSelects[1] as HTMLSelectElement;
+    playerB.value = "acid_king";
+    playerB.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+async function startGame(container: HTMLElement) {
+  const startButton = Array.from(container.querySelectorAll("button")).find(
+    (button) => button.textContent?.includes("开始游戏") || button.textContent?.includes("Start game"),
+  );
+  await act(async () => {
+    startButton?.click();
+  });
+}
+
+function assertNoOpponentCardLeak(scope: ParentNode) {
+  const text = scope.textContent ?? "";
+  expect(text).not.toContain("石灰水");
+  expect(text).not.toContain("Limewater");
+  expect(text).not.toContain("Ca(OH)2");
+  expect(text).not.toContain("substance_caoh2_limewater");
+  expect(text).not.toContain("Ca2+");
+  expect(text).not.toContain("ion_ca");
+  expect(text).not.toContain("MVP 0 中造成 1 点碱性伤害，或响应酸性伤害，或处理 SO2 泄漏。");
+  expect(text).not.toContain("Deal 1 alkaline damage");
+}
+
+describe("Phase 20C — Solo private human play view", () => {
+  it("shows opponent card backs and count, not localized names, rules, or card controls", async () => {
+    const { container, root } = await renderPage();
+    try {
+      await selectCharacters(container);
+      await startGame(container);
+
+      expect(container.querySelector("h1")?.textContent).toBe("本地人机对局");
+      expect(container.textContent).toContain("己方手牌；对手背面");
+
+      const opponent = playerPanel(container, "player_2");
+      const own = playerPanel(container, "player_1");
+      const opponentCount = Number(
+        opponent.querySelector(".hand-count-pill")?.textContent?.match(/(\d+)/)?.[1],
+      );
+      expect(opponentCount).toBeGreaterThan(0);
+      expect(opponent.querySelectorAll(".card-back")).toHaveLength(opponentCount);
+      expect(opponent.querySelectorAll(".debug-card__select")).toHaveLength(0);
+      expect(opponent.querySelectorAll("button")).toHaveLength(0);
+      expect(opponent.textContent).toContain("牌背");
+      expect(opponent.textContent).not.toContain("普通出牌");
+      expect(opponent.textContent).not.toContain("执行效果");
+      expect(opponent.textContent).not.toContain("可在当前对局中选择");
+      expect(opponent.querySelector(".hand-grid")?.textContent).not.toContain("调试详情");
+      assertNoOpponentCardLeak(opponent);
+
+      expect(own.textContent).toContain("稀 H2SO4");
+      expect(own.querySelectorAll(".card-face")).toHaveLength(own.querySelectorAll(".debug-card").length);
+
+      const actionPanel = container.querySelector(".action-panel");
+      expect(actionPanel).not.toBeNull();
+      assertNoOpponentCardLeak(actionPanel!);
+      expect(actionPanel?.textContent).toContain("稀 H2SO4");
+
+      const enterDiy = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent?.includes("进入主动 DIY"),
+      );
+      await act(async () => {
+        enterDiy?.click();
+      });
+      const diyPanel = container.querySelector(".diy-panel");
+      expect(diyPanel).not.toBeNull();
+      assertNoOpponentCardLeak(diyPanel!);
+      expect(diyPanel?.textContent).not.toContain("Ca2+");
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
+
+  it("keeps both hands public in local two-player mode", async () => {
+    const { container, root } = await renderPage();
+    try {
+      const modeSelect = container.querySelector(
+        "select[aria-label*='mode'], select[aria-label*='模式']",
+      ) as HTMLSelectElement;
+      await act(async () => {
+        modeSelect.value = "two_player";
+        modeSelect.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+      await selectCharacters(container);
+      await startGame(container);
+
+      expect(container.querySelector("h1")?.textContent).toBe("本地双人公开对局");
+      expect(container.textContent).toContain("手牌可见");
+
+      const opponent = playerPanel(container, "player_2");
+      expect(opponent.textContent).toContain("石灰水 Ca(OH)2");
+      expect(opponent.textContent).toContain("Ca2+");
+      expect(opponent.querySelectorAll(".card-back")).toHaveLength(0);
+      expect(opponent.querySelectorAll(".debug-card__select").length).toBeGreaterThan(0);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
+
+  it("hides localized English opponent names after switching locale", async () => {
+    const { container, root } = await renderPage();
+    try {
+      await selectCharacters(container);
+      await startGame(container);
+      const englishButton = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "English",
+      );
+      await act(async () => {
+        englishButton?.click();
+      });
+
+      expect(container.querySelector("h1")?.textContent).toBe("Solo vs AI");
+      const opponent = playerPanel(container, "player_2");
+      expect(opponent.textContent).toContain("Face down");
+      assertNoOpponentCardLeak(opponent);
+      expect(playerPanel(container, "player_1").textContent).toContain("Dilute H2SO4");
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
+});

--- a/src/features/local-game/soloPrivateView.test.tsx
+++ b/src/features/local-game/soloPrivateView.test.tsx
@@ -5,6 +5,7 @@ import { createRoot } from "react-dom/client";
 import { describe, expect, it } from "vitest";
 import { LocaleProvider } from "../../app/locale";
 import { createInitialGame } from "../../game/engine/createInitialGame";
+import { engineReducer } from "../../game/engine/reducer";
 import type { CardInstanceId, GameState, PlayerId } from "../../game/engine/types";
 import { identityShuffle } from "../../shared/random";
 import { LocalGamePage } from "./LocalGamePage";
@@ -54,15 +55,50 @@ function moveAllCopiesToHand(
   );
 }
 
-const privateViewFactory: LocalGameFactory = (characterIds) => {
-  let state = createInitialGame({
-    characterIds: [characterIds[0], characterIds[1]],
-    shuffle: identityShuffle,
-  });
-  state = moveAllCopiesToHand(state, "player_1", "substance_h2so4_dilute");
-  state = moveAllCopiesToHand(state, "player_2", "substance_caoh2_limewater");
-  state = moveAllCopiesToHand(state, "player_2", "ion_ca");
-  return state;
+function dealPrivateHands(state: GameState): GameState {
+  let next = moveAllCopiesToHand(state, "player_1", "substance_h2so4_dilute");
+  next = moveAllCopiesToHand(next, "player_2", "substance_caoh2_limewater");
+  return moveAllCopiesToHand(next, "player_2", "ion_ca");
+}
+
+const privateViewFactory: LocalGameFactory = (characterIds) =>
+  dealPrivateHands(
+    createInitialGame({
+      characterIds: [characterIds[0], characterIds[1]],
+      shuffle: identityShuffle,
+    }),
+  );
+
+const aiAttackViewFactory: LocalGameFactory = (characterIds) => {
+  let state = dealPrivateHands(
+    createInitialGame({
+      characterIds: [characterIds[0], characterIds[1]],
+      shuffle: identityShuffle,
+    }),
+  );
+  while (state.phase === "mainAction" && state.activePlayerId !== "player_2") {
+    state = engineReducer(
+      state,
+      { type: "PASS_ACTION", playerId: state.activePlayerId },
+      identityShuffle,
+    );
+  }
+  const playedId = state.players[1].hand.find(
+    (id) => state.cardInstances[id]?.definitionId === "substance_caoh2_limewater",
+  );
+  if (!playedId) {
+    throw new Error("Expected limewater in the opponent hand");
+  }
+  return engineReducer(
+    state,
+    {
+      type: "PLAY_CARD",
+      playerId: "player_2",
+      cardInstanceId: playedId,
+      targetPlayerId: "player_1",
+    },
+    identityShuffle,
+  );
 };
 
 function playerPanel(container: HTMLElement, playerId: "player_1" | "player_2"): HTMLElement {
@@ -73,7 +109,7 @@ function playerPanel(container: HTMLElement, playerId: "player_1" | "player_2"):
   return panel;
 }
 
-async function renderPage() {
+async function renderPage(createGame: LocalGameFactory = privateViewFactory) {
   Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
   const container = document.createElement("div");
   document.body.append(container);
@@ -83,7 +119,7 @@ async function renderPage() {
       <StrictMode>
         <LocaleProvider>
           <LocalGamePage
-            createGame={privateViewFactory}
+            createGame={createGame}
             aiDelayMs={10000}
           />
         </LocaleProvider>
@@ -232,6 +268,79 @@ describe("Phase 20C — Solo private human play view", () => {
       expect(opponent.textContent).toContain("Face down");
       assertNoOpponentCardLeak(opponent);
       expect(playerPanel(container, "player_1").textContent).toContain("Dilute H2SO4");
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
+
+  it("shows the AI's publicly played card name and type on the table and in the response window", async () => {
+    const { container, root } = await renderPage(aiAttackViewFactory);
+    try {
+      await selectCharacters(container);
+      await startGame(container);
+
+      const opponent = playerPanel(container, "player_2");
+      const recentAction = container.querySelector(".recent-public-action");
+      const responsePanel = container.querySelector(".response-panel");
+      const tableReference = container.querySelector(".table-reference-card");
+      const latestLog = container.querySelector(".game-log li.is-latest");
+
+      expect(recentAction?.textContent).toContain("石灰水 Ca(OH)2");
+      expect(recentAction?.textContent).toContain("实体");
+      expect(tableReference?.textContent).toContain("石灰水 Ca(OH)2");
+      expect(tableReference?.textContent).toContain("实体");
+      expect(responsePanel?.textContent).toContain("对方打出 石灰水 Ca(OH)2（实体）");
+      expect(latestLog?.textContent).toContain("石灰水 Ca(OH)2");
+      expect(opponent.querySelectorAll(".card-back").length).toBeGreaterThan(0);
+      expect(opponent.querySelectorAll(".card-face")).toHaveLength(0);
+      expect(opponent.textContent).not.toContain("石灰水");
+      expect(opponent.textContent).not.toContain("Ca2+");
+      expect(container.textContent).not.toContain("Ca2+");
+      expect(container.textContent).not.toContain(
+        "MVP 0 中造成 1 点碱性伤害，或响应酸性伤害，或处理 SO2 泄漏。",
+      );
+
+      const englishButton = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "English",
+      );
+      await act(async () => {
+        englishButton?.click();
+      });
+      expect(container.querySelector(".response-panel")?.textContent).toContain(
+        "Opponent played Limewater Ca(OH)2 (Substance)",
+      );
+      expect(container.querySelector(".recent-public-action")?.textContent).toContain("Substance");
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
+
+  it("still shows both hands after an AI-style public play in two-player mode", async () => {
+    const { container, root } = await renderPage(aiAttackViewFactory);
+    try {
+      const modeSelect = container.querySelector(
+        "select[aria-label*='mode'], select[aria-label*='模式']",
+      ) as HTMLSelectElement;
+      await act(async () => {
+        modeSelect.value = "two_player";
+        modeSelect.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+      await selectCharacters(container);
+      await startGame(container);
+
+      const opponent = playerPanel(container, "player_2");
+      expect(container.querySelector("h1")?.textContent).toBe("本地双人公开对局");
+      expect(opponent.textContent).toContain("石灰水 Ca(OH)2");
+      expect(opponent.textContent).toContain("Ca2+");
+      expect(opponent.querySelectorAll(".card-back")).toHaveLength(0);
+      expect(opponent.querySelectorAll(".debug-card__select").length).toBeGreaterThan(0);
+      expect(container.querySelector(".recent-public-action")?.textContent).toContain("石灰水 Ca(OH)2");
     } finally {
       await act(async () => {
         root.unmount();

--- a/src/features/local-game/soloVsAiSession.test.tsx
+++ b/src/features/local-game/soloVsAiSession.test.tsx
@@ -122,7 +122,7 @@ describe("Phase 19F — Solo vs NATBA-1 Session Integration", () => {
       });
 
       expect(container.textContent).toContain("实验室老师 · 备课");
-      expect(container.textContent).toContain("本地人机公开对局");
+      expect(container.textContent).toContain("本地人机对局");
 
       const candidateButtons = container.querySelectorAll(".preparation-candidate-grid button.debug-card__select");
       expect(candidateButtons.length).toBe(20);
@@ -231,7 +231,7 @@ describe("Phase 19F — Solo vs NATBA-1 Session Integration", () => {
 
       // No error banner; game progressed cleanly under NATBA-1.x default
       expect(container.querySelector(".error-banner")).toBeNull();
-      expect(container.textContent).toContain("本地人机公开对局");
+      expect(container.textContent).toContain("本地人机对局");
     } finally {
       await act(async () => {
         root.unmount();
@@ -303,7 +303,7 @@ describe("Phase 19F — Solo vs NATBA-1 Session Integration", () => {
 
       expect(natba0Invoked).toBeGreaterThan(0);
       expect(container.querySelector(".error-banner")).toBeNull();
-      expect(container.querySelector("h1")?.textContent).toBe("本地人机公开对局");
+      expect(container.querySelector("h1")?.textContent).toBe("本地人机对局");
       expect(container.querySelector("h1")?.textContent).not.toContain("NATBA-1");
     } finally {
       await act(async () => {
@@ -492,7 +492,7 @@ describe("Phase 19F — Solo vs NATBA-1 Session Integration", () => {
       });
 
       // In Chinese mode: check title
-      expect(container.querySelector("h1")?.textContent).toBe("本地人机公开对局");
+      expect(container.querySelector("h1")?.textContent).toBe("本地人机对局");
 
       // Switch to English: check title is Solo vs AI
       const enButton = Array.from(container.querySelectorAll("button")).find(

--- a/src/game/engine/humanPlayView.ts
+++ b/src/game/engine/humanPlayView.ts
@@ -20,6 +20,22 @@ function hiddenDeckId(index: number): CardInstanceId {
   return `${HIDDEN_DECK_PREFIX}${index}`;
 }
 
+function collectPublicCardInstanceIds(state: GameState): ReadonlySet<CardInstanceId> {
+  const ids = new Set<CardInstanceId>();
+  if (state.tableReference) {
+    ids.add(state.tableReference.cardInstanceId);
+  }
+  const pendingSource = state.pendingResponse?.sourceEffect.context.source;
+  if (pendingSource?.kind === "card") {
+    ids.add(pendingSource.cardInstanceId);
+  }
+  const counterSource = state.pendingExperimentCounterattack?.originalDamageContext.source;
+  if (counterSource?.kind === "card") {
+    ids.add(counterSource.cardInstanceId);
+  }
+  return ids;
+}
+
 function redactPreparationSelection(
   selection: LaboratoryPreparationSelection,
   hiddenPlayerIds: ReadonlySet<PlayerId>,
@@ -46,9 +62,12 @@ export function projectHumanPlayState(state: GameState, viewerPlayerId: PlayerId
     }
   }
 
+  const publicCardIds = collectPublicCardInstanceIds(state);
   const cardInstances = { ...state.cardInstances };
   for (const id of hiddenHandIds) {
-    delete cardInstances[id];
+    if (!publicCardIds.has(id)) {
+      delete cardInstances[id];
+    }
   }
   for (const id of state.deck) {
     delete cardInstances[id];

--- a/src/game/engine/humanPlayView.ts
+++ b/src/game/engine/humanPlayView.ts
@@ -1,0 +1,112 @@
+import type {
+  CardInstanceId,
+  GameState,
+  LaboratoryPreparationSelection,
+  PlayerId,
+} from "./types";
+
+export const HIDDEN_HAND_PREFIX = "hidden-hand:";
+export const HIDDEN_DECK_PREFIX = "hidden-deck:";
+
+export function isHiddenPlayCardId(id: CardInstanceId): boolean {
+  return id.startsWith(HIDDEN_HAND_PREFIX) || id.startsWith(HIDDEN_DECK_PREFIX);
+}
+
+function hiddenHandId(playerId: PlayerId, index: number): CardInstanceId {
+  return `${HIDDEN_HAND_PREFIX}${playerId}:${index}`;
+}
+
+function hiddenDeckId(index: number): CardInstanceId {
+  return `${HIDDEN_DECK_PREFIX}${index}`;
+}
+
+function redactPreparationSelection(
+  selection: LaboratoryPreparationSelection,
+  hiddenPlayerIds: ReadonlySet<PlayerId>,
+): LaboratoryPreparationSelection {
+  return {
+    playerId: selection.playerId,
+    candidateCardInstanceIds: hiddenPlayerIds.has(selection.playerId)
+      ? []
+      : [...selection.candidateCardInstanceIds],
+  };
+}
+
+export function projectHumanPlayState(state: GameState, viewerPlayerId: PlayerId): GameState {
+  const hiddenPlayerIds = new Set(
+    state.players.filter((player) => player.id !== viewerPlayerId).map((player) => player.id),
+  );
+  const hiddenHandIds = new Set<CardInstanceId>();
+  for (const player of state.players) {
+    if (!hiddenPlayerIds.has(player.id)) {
+      continue;
+    }
+    for (const id of player.hand) {
+      hiddenHandIds.add(id);
+    }
+  }
+
+  const cardInstances = { ...state.cardInstances };
+  for (const id of hiddenHandIds) {
+    delete cardInstances[id];
+  }
+  for (const id of state.deck) {
+    delete cardInstances[id];
+  }
+
+  const players = state.players.map((player) => {
+    const hand = hiddenPlayerIds.has(player.id)
+      ? player.hand.map((_, index) => hiddenHandId(player.id, index))
+      : [...player.hand];
+    return {
+      ...player,
+      hand,
+      statuses: player.statuses.map((status) => ({ ...status })),
+      characterUsage: {
+        perCycle: { ...player.characterUsage.perCycle },
+        perRound: { ...player.characterUsage.perRound },
+      },
+    };
+  });
+
+  const pendingLaboratoryPreparation = state.pendingLaboratoryPreparation
+    ? {
+        ...redactPreparationSelection(state.pendingLaboratoryPreparation, hiddenPlayerIds),
+        keepCount: state.pendingLaboratoryPreparation.keepCount,
+        remainingSelections: state.pendingLaboratoryPreparation.remainingSelections.map((selection) =>
+          redactPreparationSelection(selection, hiddenPlayerIds),
+        ),
+      }
+    : undefined;
+
+  const pendingExperimentCounterattack = state.pendingExperimentCounterattack
+    && hiddenPlayerIds.has(state.pendingExperimentCounterattack.responderPlayerId)
+    ? {
+        ...state.pendingExperimentCounterattack,
+        legalMetalCardInstanceIds: [],
+        legalPursuitCardInstanceIds: [],
+      }
+    : state.pendingExperimentCounterattack;
+
+  return {
+    ...state,
+    players,
+    cardInstances,
+    deck: state.deck.map((_, index) => hiddenDeckId(index)),
+    discardPile: [...state.discardPile],
+    tableReference: state.tableReference ? { ...state.tableReference } : undefined,
+    pendingLaboratoryPreparation,
+    pendingExperimentCounterattack,
+    pendingResponse: state.pendingResponse
+      ? {
+          ...state.pendingResponse,
+          effectsAfterPass: [...state.pendingResponse.effectsAfterPass],
+        }
+      : undefined,
+    pendingStatusHandling: state.pendingStatusHandling
+      ? { ...state.pendingStatusHandling }
+      : undefined,
+    effectQueue: [...state.effectQueue],
+    log: [...state.log],
+  };
+}

--- a/src/game/engine/visibility.ts
+++ b/src/game/engine/visibility.ts
@@ -1,3 +1,4 @@
-export type VisibilityMode = "public-debug";
+export type VisibilityMode = "public-debug" | "human-play";
 
 export const defaultVisibilityMode: VisibilityMode = "public-debug";
+export const officialSoloVisibilityMode: VisibilityMode = "human-play";

--- a/src/game/tests/humanPlayView.test.ts
+++ b/src/game/tests/humanPlayView.test.ts
@@ -118,6 +118,49 @@ describe("Phase 20C — Human Play View projection", () => {
     expect(state.cardInstances[opponentCardId]?.definitionId).toBe("substance_caoh2_limewater");
   });
 
+  it("keeps a publicly played opponent card while still hiding remaining hand cards", () => {
+    let state = createReadyMainGameState();
+    state = moveAllCopiesToHand(state, "player_1", "substance_h2so4_dilute");
+    state = moveAllCopiesToHand(state, "player_2", "substance_caoh2_limewater");
+    state = moveAllCopiesToHand(state, "player_2", "ion_ca");
+    if (state.activePlayerId !== "player_2") {
+      state = engineReducer(state, { type: "PASS_ACTION", playerId: state.activePlayerId }, identityShuffle);
+    }
+    const playedId = state.players[1].hand.find(
+      (id) => state.cardInstances[id]?.definitionId === "substance_caoh2_limewater",
+    );
+    const hiddenIonId = state.players[1].hand.find(
+      (id) => state.cardInstances[id]?.definitionId === "ion_ca",
+    );
+    if (!playedId || !hiddenIonId) {
+      throw new Error("Expected limewater and Ca2+ in the opponent hand");
+    }
+
+    state = engineReducer(
+      state,
+      {
+        type: "PLAY_CARD",
+        playerId: "player_2",
+        cardInstanceId: playedId,
+        targetPlayerId: "player_1",
+      },
+      identityShuffle,
+    );
+
+    const view = projectHumanPlayState(state, "player_1");
+    const viewSerialized = JSON.stringify(view);
+
+    expect(state.phase).toBe("responseWindow");
+    expect(state.players[1].hand).toContain(playedId);
+    expect(view.tableReference?.definitionId).toBe("substance_caoh2_limewater");
+    expect(view.cardInstances[playedId]?.definitionId).toBe("substance_caoh2_limewater");
+    expect(viewSerialized).toContain("substance_caoh2_limewater");
+    expect(view.cardInstances[hiddenIonId]).toBeUndefined();
+    expect(viewSerialized).not.toContain("ion_ca");
+    expect(viewSerialized).not.toContain(hiddenIonId);
+    expect(view.players[1].hand.every(isHiddenPlayCardId)).toBe(true);
+  });
+
   it("preserves public discard definitions and already-recorded log events", () => {
     let state = createReadyMainGameState();
     const discardedId = findCards(state, "substance_na2co3")[0];

--- a/src/game/tests/humanPlayView.test.ts
+++ b/src/game/tests/humanPlayView.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import { cardDefinitionsById } from "../data/cardDefinitions";
+import { identityShuffle } from "../../shared/random";
+import { createInitialGame } from "../engine/createInitialGame";
+import { engineReducer } from "../engine/reducer";
+import {
+  isHiddenPlayCardId,
+  projectHumanPlayState,
+} from "../engine/humanPlayView";
+import type { CardInstanceId, GameState, PlayerId } from "../engine/types";
+import {
+  getOfficialHumanViewerPlayerId,
+  getOfficialPlayState,
+  getOfficialVisibilityMode,
+} from "../../features/local-game/officialPlayView";
+
+function confirmPreparation(state: GameState): GameState {
+  const pending = state.pendingLaboratoryPreparation;
+  if (!pending) {
+    return state;
+  }
+  return engineReducer(state, {
+    type: "CONFIRM_LABORATORY_PREPARATION",
+    playerId: pending.playerId,
+    keptCardInstanceIds: pending.candidateCardInstanceIds.slice(0, 10),
+  });
+}
+
+function createReadyMainGameState(): GameState {
+  const state = createInitialGame({
+    characterIds: ["laboratory_teacher", "acid_king"],
+    shuffle: identityShuffle,
+  });
+  return confirmPreparation(state);
+}
+
+function putCardInHand(
+  state: GameState,
+  playerId: PlayerId,
+  cardInstanceId: CardInstanceId,
+): GameState {
+  const card = state.cardInstances[cardInstanceId];
+  if (!card) {
+    throw new Error(`Missing card ${cardInstanceId}`);
+  }
+  return {
+    ...state,
+    players: state.players.map((player) => ({
+      ...player,
+      hand: player.id === playerId
+        ? [...player.hand.filter((id) => id !== cardInstanceId), cardInstanceId]
+        : player.hand.filter((id) => id !== cardInstanceId),
+    })),
+    deck: state.deck.filter((id) => id !== cardInstanceId),
+    discardPile: state.discardPile.filter((id) => id !== cardInstanceId),
+    cardInstances: {
+      ...state.cardInstances,
+      [cardInstanceId]: {
+        ...card,
+        ownerId: playerId,
+        zone: { type: "hand", playerId },
+      },
+    },
+  };
+}
+
+function findCards(state: GameState, definitionId: string): CardInstanceId[] {
+  const ids = Object.keys(state.cardInstances).filter(
+    (cardId) => state.cardInstances[cardId].definitionId === definitionId,
+  );
+  if (ids.length === 0) {
+    throw new Error(`Missing card definition ${definitionId}`);
+  }
+  return ids;
+}
+
+function moveAllCopiesToHand(
+  state: GameState,
+  playerId: PlayerId,
+  definitionId: string,
+): GameState {
+  return findCards(state, definitionId).reduce(
+    (current, cardInstanceId) => putCardInHand(current, playerId, cardInstanceId),
+    state,
+  );
+}
+
+describe("Phase 20C — Human Play View projection", () => {
+  it("maps exactly one human controller to that viewer and two-player to public-debug", () => {
+    expect(getOfficialHumanViewerPlayerId(["human", "ai"])).toBe("player_1");
+    expect(getOfficialHumanViewerPlayerId(["ai", "human"])).toBe("player_2");
+    expect(getOfficialHumanViewerPlayerId(["human", "human"])).toBeUndefined();
+    expect(getOfficialHumanViewerPlayerId(["ai", "ai"])).toBeUndefined();
+    expect(getOfficialVisibilityMode(["human", "ai"])).toBe("human-play");
+    expect(getOfficialVisibilityMode(["human", "human"])).toBe("public-debug");
+  });
+
+  it("keeps the viewer's hand definitions and strips hidden opponent hand definitions", () => {
+    let state = createReadyMainGameState();
+    state = moveAllCopiesToHand(state, "player_1", "substance_h2so4_dilute");
+    state = moveAllCopiesToHand(state, "player_2", "substance_caoh2_limewater");
+    const ownCardId = findCards(state, "substance_h2so4_dilute")[0];
+    const opponentCardId = findCards(state, "substance_caoh2_limewater")[0];
+
+    const view = projectHumanPlayState(state, "player_1");
+    const originalOpponentHand = [...state.players[1].hand];
+    const viewSerialized = JSON.stringify(view);
+
+    expect(view.players[0].hand).toEqual(state.players[0].hand);
+    expect(view.cardInstances[ownCardId]?.definitionId).toBe("substance_h2so4_dilute");
+    expect(view.players[1].hand).toHaveLength(originalOpponentHand.length);
+    expect(view.players[1].hand.every(isHiddenPlayCardId)).toBe(true);
+    expect(view.cardInstances[opponentCardId]).toBeUndefined();
+    expect(viewSerialized).not.toContain("substance_caoh2_limewater");
+    expect(viewSerialized).not.toContain(opponentCardId);
+    expect(viewSerialized).toContain("substance_h2so4_dilute");
+    expect(state.players[1].hand).toEqual(originalOpponentHand);
+    expect(state.cardInstances[opponentCardId]?.definitionId).toBe("substance_caoh2_limewater");
+  });
+
+  it("preserves public discard definitions and already-recorded log events", () => {
+    let state = createReadyMainGameState();
+    const discardedId = findCards(state, "substance_na2co3")[0];
+    state = {
+      ...state,
+      deck: state.deck.filter((id) => id !== discardedId),
+      discardPile: [discardedId],
+      players: state.players.map((player) => ({
+        ...player,
+        hand: player.hand.filter((id) => id !== discardedId),
+      })),
+      cardInstances: {
+        ...state.cardInstances,
+        [discardedId]: {
+          ...state.cardInstances[discardedId],
+          ownerId: undefined,
+          zone: { type: "discard" },
+        },
+      },
+    };
+
+    const view = projectHumanPlayState(state, "player_1");
+    expect(view.discardPile).toEqual([discardedId]);
+    expect(view.cardInstances[discardedId]?.definitionId).toBe("substance_na2co3");
+    expect(view.log).toEqual(state.log);
+    expect(view.log.length).toBeGreaterThan(0);
+  });
+
+  it("keeps deck length but strips future deck identities and order", () => {
+    const state = createReadyMainGameState();
+    const view = projectHumanPlayState(state, "player_1");
+    const originalDeck = [...state.deck];
+
+    expect(view.deck).toHaveLength(originalDeck.length);
+    expect(view.deck.every(isHiddenPlayCardId)).toBe(true);
+    expect(view.deck).not.toEqual(originalDeck);
+    for (const id of originalDeck) {
+      expect(view.cardInstances[id]).toBeUndefined();
+    }
+    expect(state.deck).toEqual(originalDeck);
+  });
+
+  it("hides opponent laboratory preparation candidates while keeping the viewer's", () => {
+    const state = createInitialGame({
+      characterIds: ["laboratory_teacher", "acid_king"],
+      shuffle: identityShuffle,
+    });
+    const teacherView = projectHumanPlayState(state, "player_1");
+    const opponentView = projectHumanPlayState(state, "player_2");
+
+    expect(teacherView.pendingLaboratoryPreparation?.candidateCardInstanceIds).toEqual(
+      state.pendingLaboratoryPreparation?.candidateCardInstanceIds,
+    );
+    expect(opponentView.pendingLaboratoryPreparation?.candidateCardInstanceIds).toEqual([]);
+    expect(opponentView.pendingLaboratoryPreparation?.playerId).toBe("player_1");
+    expect(opponentView.pendingLaboratoryPreparation?.keepCount).toBe(10);
+  });
+
+  it("does not project two-player official play state", () => {
+    const state = createReadyMainGameState();
+    const playState = getOfficialPlayState(state, ["human", "human"]);
+    expect(playState).toBe(state);
+    expect(playState.players[1].hand).toEqual(state.players[1].hand);
+    expect(
+      playState.players[1].hand.every((id) => playState.cardInstances[id]?.definitionId),
+    ).toBe(true);
+  });
+
+  it("does not expose localized opponent card names through remaining view definitions", () => {
+    let state = createReadyMainGameState();
+    state = moveAllCopiesToHand(state, "player_2", "substance_caoh2_limewater");
+    const opponentCardId = findCards(state, "substance_caoh2_limewater")[0];
+    const view = projectHumanPlayState(state, "player_1");
+    const limewater = cardDefinitionsById.get("substance_caoh2_limewater");
+    const viewSerialized = JSON.stringify(view);
+
+    expect(limewater?.name).toBe("石灰水 Ca(OH)2");
+    expect(viewSerialized).not.toContain(limewater!.name);
+    expect(viewSerialized).not.toContain(limewater!.rulesText);
+    expect(viewSerialized).not.toContain("substance_caoh2_limewater");
+    expect(viewSerialized).not.toContain(opponentCardId);
+    expect(view.cardInstances[opponentCardId]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Solo vs AI renders through Human Play View. Opponent hands show backs + count. Local two-player stays public.

`javascriptGzip` 108000 → 120000 (Freeze §8).

Follow-up in this branch if needed: make the AI's just-played card obvious on the table (public last action), not Dou Dizhu layout.