### PR TITLE
feat(ui): official Dou Dizhu-style hand row

### DIFF
--- a/e2e/production/reaction-field.spec.ts
+++ b/e2e/production/reaction-field.spec.ts
@@ -430,7 +430,7 @@ test("正式构建在 / 验证 Phase 16 双语游戏日志、反应日志与 DIY
   await page.getByRole("button", { name: "中文" }).click();
 });
 
-test("正式构建人机只显示对手牌背与张数，双人仍公开手牌", async ({
+test("正式构建人机只显示对手牌背与张数，双人仍公开手牌，且手牌支持点选抬起与取消", async ({
   page,
   externalRequests,
   networkFailures,
@@ -446,16 +446,53 @@ test("正式构建人机只显示对手牌背与张数，双人仍公开手牌",
   await expect(page.getByRole("heading", { name: "本地人机对局" })).toBeVisible();
   await expect(page.getByText("己方手牌；对手背面")).toBeVisible();
 
+  // 1. Opponent hand in default Solo vs AI (CEO opponent has 14 cards)
   const opponent = page.locator('[aria-labelledby="player_2-title"]');
   const opponentCountText = await opponent.locator(".hand-count-pill").textContent();
   const opponentCount = Number(opponentCountText?.match(/(\d+)/)?.[1]);
   expect(opponentCount).toBe(14);
-  await expect(opponent.locator(".card-back")).toHaveCount(opponentCount);
+  await expect(opponent.locator(".hand-row-count-badge")).toHaveText("共 14 张");
+  await expect(opponent.locator(".official-hand-row.is-backs")).toBeVisible();
+  await expect(opponent.locator(".card-back.official-card--back")).toHaveCount(opponentCount);
   await expect(opponent.locator(".card-back img.card-back__image")).toHaveCount(opponentCount);
   await expect(opponent.locator('.card-back img[src*="card-back.png"]')).toHaveCount(opponentCount);
+  await expect(opponent.locator('.card-back img.card-frame__overlay[src*="card-frame.png"]')).toHaveCount(opponentCount);
   await expect(opponent.locator(".card-face")).toHaveCount(0);
   await expect(opponent.locator(".debug-card__select")).toHaveCount(0);
+  await expect(opponent.locator("button")).toHaveCount(0);
 
+  // 2. Return to setup, start CEO vs Acid King to test own hand selection in mainAction
+  await page.getByRole("button", { name: "返回角色选择" }).click();
+  await page.getByRole("button", { name: "确认返回" }).click();
+  await page.getByLabel("player_1 角色").selectOption("chemical_factory_ceo");
+  await page.getByLabel("player_2 角色").selectOption("acid_king");
+  await page.getByRole("button", { name: "开始游戏" }).click();
+  await expect(page.getByRole("heading", { exact: true, name: "主行动" })).toBeVisible();
+
+  const own = page.locator('[aria-labelledby="player_1-title"]');
+  await expect(own.locator(".official-hand-row")).toBeVisible();
+  const ownCards = own.locator(".official-card.card-face");
+  const ownCardCount = await ownCards.count();
+  expect(ownCardCount).toBe(14);
+  await expect(own.locator('.official-card img.card-frame__overlay[src*="card-frame.png"]')).toHaveCount(ownCardCount);
+
+  // First card interactive selection
+  const firstCard = ownCards.first();
+  const firstButton = firstCard.locator("button.debug-card__select");
+  await expect(firstCard).not.toHaveClass(/is-selected/);
+  await expect(firstButton).toHaveAttribute("aria-pressed", "false");
+
+  // Tap to select (lift up)
+  await firstButton.click();
+  await expect(firstCard).toHaveClass(/is-selected/);
+  await expect(firstButton).toHaveAttribute("aria-pressed", "true");
+
+  // Tap again to cancel selection (lift down)
+  await firstButton.click();
+  await expect(firstCard).not.toHaveClass(/is-selected/);
+  await expect(firstButton).toHaveAttribute("aria-pressed", "false");
+
+  // 3. Two-player mode: reveals card faces and names for both sides
   await page.getByRole("button", { name: "返回角色选择" }).click();
   await page.getByRole("button", { name: "确认返回" }).click();
   await page.getByLabel("对局模式").selectOption("two_player");
@@ -463,10 +500,18 @@ test("正式构建人机只显示对手牌背与张数，双人仍公开手牌",
   await page.getByLabel("player_2 角色").selectOption("acid_king");
   await page.getByRole("button", { name: "开始游戏" }).click();
   await expect(page.getByRole("heading", { name: "本地双人公开对局" })).toBeVisible();
+
   const twoPlayerOpponent = page.locator('[aria-labelledby="player_2-title"]');
-  await expect(twoPlayerOpponent.locator(".card-face")).toHaveCount(10);
+  await expect(twoPlayerOpponent.locator(".official-card.card-face")).toHaveCount(10);
   await expect(twoPlayerOpponent.locator(".card-back")).toHaveCount(0);
   await expect(twoPlayerOpponent.locator(".debug-card__select")).toHaveCount(10);
+  await expect(twoPlayerOpponent.locator(".official-card__name").first()).toBeVisible();
+
+  const twoPlayerOwn = page.locator('[aria-labelledby="player_1-title"]');
+  await expect(twoPlayerOwn.locator(".official-card.card-face")).toHaveCount(14);
+  await expect(twoPlayerOwn.locator(".card-back")).toHaveCount(0);
+  await expect(twoPlayerOwn.locator(".debug-card__select")).toHaveCount(14);
+  await expect(twoPlayerOwn.locator(".official-card__name").first()).toBeVisible();
 });
 
 test("正式对局壳在 390 竖屏单列，横屏 844 与 1024 双栏同屏", async ({

--- a/src/features/local-game/LocalGamePage.tsx
+++ b/src/features/local-game/LocalGamePage.tsx
@@ -76,6 +76,10 @@ function PlayingGame({
     setSelectedCardId(undefined);
   }, [session.revision]);
 
+  const handleSelectCard = useCallback((cardId: CardInstanceId | undefined) => {
+    setSelectedCardId((current) => (current === cardId ? undefined : cardId));
+  }, []);
+
   function dispatchGameAction(action: GameAction) {
     dispatch({ type: "DISPATCH_GAME_ACTION", action });
     setSelectedCardId(undefined);
@@ -103,7 +107,7 @@ function PlayingGame({
                 handSelectionDisabled={playGame.phase !== "mainAction"}
                 isDebug={isDebug}
                 key={player.id}
-                onSelectCard={setSelectedCardId}
+                onSelectCard={handleSelectCard}
                 player={player}
                 selectedCardId={selectedCardId}
                 showActivePlayerIndicator={playGame.phase !== "preparationSelection"}
@@ -139,7 +143,7 @@ function PlayingGame({
               <ActionPanel
                 dispatchGameAction={dispatchGameAction}
                 game={playGame}
-                onSelectCard={setSelectedCardId}
+                onSelectCard={handleSelectCard}
                 playerControllers={playerControllers}
                 selectedCardId={selectedCardId}
               />

--- a/src/features/local-game/components/OfficialCard.tsx
+++ b/src/features/local-game/components/OfficialCard.tsx
@@ -1,0 +1,101 @@
+import type { CardInstanceId, GameState } from "../../../game/engine/types";
+import { useLocale } from "../../../app/locale";
+import { formatList, getCardDefinition } from "../localGameView";
+import { getCardDisplayName } from "../presentationLocale";
+import { PLAY_BRAND_ASSETS } from "../playBrandAssets";
+
+export type OfficialCardProps = {
+  cardInstanceId: CardInstanceId;
+  game: GameState;
+  selected?: boolean;
+  disabled?: boolean;
+  onSelect?: (cardInstanceId: CardInstanceId) => void;
+  isDebug?: boolean;
+};
+
+export function OfficialCard({
+  cardInstanceId,
+  game,
+  selected = false,
+  disabled = false,
+  onSelect,
+  isDebug = false,
+}: OfficialCardProps) {
+  const definition = getCardDefinition(game, cardInstanceId);
+  const { locale } = useLocale();
+  const isEnglish = locale === "en";
+
+  if (!definition) {
+    return (
+      <article className="debug-card card-back is-missing official-card official-card--back">
+        <img
+          alt=""
+          aria-hidden="true"
+          className="card-back__image"
+          src={PLAY_BRAND_ASSETS.cardBack}
+        />
+        <img
+          alt=""
+          aria-hidden="true"
+          className="card-frame__overlay"
+          src={PLAY_BRAND_ASSETS.cardFrame}
+        />
+        <span className="card-back__caption">{isEnglish ? "Face down" : "牌背"}</span>
+      </article>
+    );
+  }
+
+  const isIon = definition.type === "ion";
+  const typeBadgeLabel = isIon
+    ? (isEnglish ? "Ion" : "离子")
+    : (isEnglish ? "Substance" : "实体");
+
+  return (
+    <article
+      className={`debug-card card-face official-card${selected ? " is-selected" : ""}${disabled ? " is-disabled" : ""}`}
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        className="card-frame__overlay"
+        src={PLAY_BRAND_ASSETS.cardFrame}
+      />
+      <button
+        aria-pressed={selected}
+        className="debug-card__select card-face__button official-card__button"
+        disabled={disabled}
+        onClick={() => onSelect?.(cardInstanceId)}
+        type="button"
+      >
+        <div className="card-face__badge-row official-card__top">
+          <span className={`card-face__type-badge ${isIon ? "is-ion" : "is-substance"}`}>
+            {typeBadgeLabel}
+          </span>
+          {definition.tags.length > 0 ? (
+            <span className="card-face__tag-chip">
+              {definition.tags[0]}
+            </span>
+          ) : null}
+        </div>
+        <div className="official-card__name-container">
+          <span className="debug-card__name card-face__name official-card__name">
+            {getCardDisplayName(definition.id, definition.name, locale)}
+          </span>
+        </div>
+        <div className="official-card__bottom">
+          <span className="debug-card__line card-face__line official-card__line">
+            {isEnglish ? "Selectable in this game" : "可在当前对局中选择"}
+          </span>
+        </div>
+      </button>
+      {isDebug ? (
+        <details className="debug-details debug-card__details">
+          <summary>{isEnglish ? "Debug details" : "调试详情"}</summary>
+          <span className="debug-card__meta">
+            {cardInstanceId} · {formatList(definition.tags)} · {formatList(definition.allowedTimings)}
+          </span>
+        </details>
+      ) : null}
+    </article>
+  );
+}

--- a/src/features/local-game/components/PlayerPanel.tsx
+++ b/src/features/local-game/components/PlayerPanel.tsx
@@ -8,7 +8,7 @@ import type {
 import type { PlayerController } from "../localGameSession";
 import { CharacterSkillList } from "./CharacterSelectionPanel";
 import { formatSkillDebugText } from "../characterPresentation";
-import { CardDebugCard } from "./CardDebugCard";
+import { OfficialCard } from "./OfficialCard";
 import {
   getCharacterDisplayName,
   getPlayerControllerDisplayName,
@@ -154,7 +154,18 @@ export function PlayerPanel({
           </details>
         ) : null}
       </div>
-      <div className="hand-grid" aria-label={isEnglish ? `${getPlayerDisplayName(player, locale)}'s hand` : `${getPlayerDisplayName(player, locale)}的手牌`}>
+      <div className="hand-row-header">
+        <span className="hand-row-title">
+          {isEnglish ? "Hand cards" : "手牌"}
+        </span>
+        <span className="hand-row-count-badge">
+          {isEnglish ? `${player.hand.length} cards` : `共 ${player.hand.length} 张`}
+        </span>
+      </div>
+      <div
+        aria-label={isEnglish ? `${getPlayerDisplayName(player, locale)}'s hand` : `${getPlayerDisplayName(player, locale)}的手牌`}
+        className={`hand-grid official-hand-row${handReveal === "backs" ? " is-backs" : ""}`}
+      >
         {handReveal === "backs"
           ? player.hand.map((_, index) => (
               <article
@@ -163,7 +174,7 @@ export function PlayerPanel({
                     ? `Face-down card ${index + 1} of ${player.hand.length}`
                     : `牌背 ${index + 1}/${player.hand.length}`
                 }
-                className="debug-card card-back"
+                className="debug-card card-back official-card official-card--back"
                 key={`${player.id}-back-${index}`}
               >
                 <img
@@ -172,11 +183,17 @@ export function PlayerPanel({
                   className="card-back__image"
                   src={PLAY_BRAND_ASSETS.cardBack}
                 />
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  className="card-frame__overlay"
+                  src={PLAY_BRAND_ASSETS.cardFrame}
+                />
                 <span className="card-back__caption">{isEnglish ? "Face down" : "牌背"}</span>
               </article>
             ))
           : player.hand.map((cardInstanceId) => (
-              <CardDebugCard
+              <OfficialCard
                 cardInstanceId={cardInstanceId}
                 disabled={effectiveHandDisabled}
                 game={game}

--- a/src/features/local-game/local-game.css
+++ b/src/features/local-game/local-game.css
@@ -962,19 +962,87 @@ dd {
   color: #8a4b05;
 }
 
-.hand-grid,
+.hand-row-header {
+  align-items: baseline;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: -4px;
+  padding: 0 2px;
+}
+
+.hand-row-title {
+  color: #17212b;
+  font-size: 0.88rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.hand-row-count-badge {
+  background: #f1f5f9;
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  color: #475569;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 1px 8px;
+}
+
 .candidate-grid {
   display: grid;
   gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
   min-width: 0;
 }
 
 .hand-grid {
+  display: grid;
+  gap: 8px;
   grid-template-columns: repeat(auto-fill, minmax(135px, 1fr));
+  min-width: 0;
 }
 
-.candidate-grid {
-  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+.player-panel .hand-grid,
+.official-hand-row {
+  align-items: flex-end;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: 10px;
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 24px 6px 10px;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+}
+
+.player-panel .hand-grid.is-backs,
+.official-hand-row.is-backs {
+  gap: 6px;
+}
+
+.player-panel .hand-grid::-webkit-scrollbar,
+.official-hand-row::-webkit-scrollbar {
+  height: 6px;
+}
+
+.player-panel .hand-grid::-webkit-scrollbar-track,
+.official-hand-row::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 3px;
+}
+
+.player-panel .hand-grid::-webkit-scrollbar-thumb,
+.official-hand-row::-webkit-scrollbar-thumb {
+  background: rgba(15, 127, 120, 0.35);
+  border-radius: 3px;
+}
+
+.player-panel .hand-grid::-webkit-scrollbar-thumb:hover,
+.official-hand-row::-webkit-scrollbar-thumb:hover {
+  background: rgba(15, 127, 120, 0.6);
 }
 
 .action-card-list {
@@ -1197,6 +1265,166 @@ dd {
   font-size: 0.72rem;
   line-height: 1.35;
   overflow-wrap: anywhere;
+}
+
+.official-card {
+  background: #f7fafc;
+  border: 1.5px solid #cbd5e1;
+  border-radius: 9px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.08);
+  box-sizing: border-box;
+  display: flex;
+  flex: 0 0 108px;
+  flex-direction: column;
+  height: 160px;
+  min-width: 108px;
+  overflow: hidden;
+  padding: 0;
+  position: relative;
+  transition: transform 160ms cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 160ms ease, border-color 160ms ease;
+  user-select: none;
+  width: 108px;
+}
+
+.official-card .card-frame__overlay {
+  border-radius: inherit;
+  height: 100%;
+  inset: 0;
+  object-fit: fill;
+  pointer-events: none;
+  position: absolute;
+  width: 100%;
+  z-index: 4;
+}
+
+.official-card__button {
+  align-items: stretch;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: space-between;
+  padding: 9px 8px 7px;
+  position: relative;
+  text-align: center;
+  width: 100%;
+  z-index: 1;
+}
+
+.official-card__button:focus-visible {
+  border-radius: inherit;
+  outline: 2px solid #0f7f78;
+  outline-offset: -2px;
+}
+
+.official-card__top {
+  align-items: center;
+  display: flex;
+  gap: 4px;
+  justify-content: space-between;
+  min-width: 0;
+  z-index: 2;
+}
+
+.official-card__name-container {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  min-width: 0;
+  padding: 4px 2px;
+  text-align: center;
+  z-index: 2;
+}
+
+.official-card .card-face__name {
+  color: #0b1b2b;
+  font-size: 0.95rem;
+  font-weight: 800;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+  text-shadow: 0 0 2px rgba(255, 255, 255, 0.9);
+}
+
+.official-card__bottom {
+  text-align: center;
+  z-index: 2;
+}
+
+.official-card .card-face__line {
+  color: #64748b;
+  display: block;
+  font-size: 0.62rem;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.official-card:not(.is-disabled):hover {
+  border-color: #0f7f78;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+  transform: translateY(-4px);
+}
+
+.official-card.is-selected {
+  border-color: #0f7f78 !important;
+  box-shadow: 0 12px 24px rgba(15, 127, 120, 0.35), 0 0 0 2.5px #0f7f78 !important;
+  transform: translateY(-16px) !important;
+  z-index: 10;
+}
+
+.official-card.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.official-card.is-disabled .official-card__button {
+  cursor: not-allowed;
+}
+
+.official-card--back {
+  align-items: center;
+  background: #0f2740;
+  border: 1px solid #1a3c5a;
+  cursor: default;
+  flex: 0 0 94px;
+  height: 140px;
+  justify-content: center;
+  min-width: 94px;
+  padding: 0;
+  width: 94px;
+}
+
+.official-card--back .card-back__image {
+  border-radius: inherit;
+  height: 100%;
+  inset: 0;
+  margin: 0;
+  max-width: none;
+  object-fit: cover;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
+}
+
+.official-card--back .card-back__caption {
+  background: rgba(11, 27, 43, 0.85);
+  border-radius: 4px;
+  bottom: 8px;
+  color: #f7fafc;
+  font-size: 0.65rem;
+  font-weight: 700;
+  left: 50%;
+  padding: 1px 6px;
+  position: absolute;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  z-index: 5;
 }
 
 .field-row {

--- a/src/features/local-game/officialHandRow.test.tsx
+++ b/src/features/local-game/officialHandRow.test.tsx
@@ -1,0 +1,299 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { StrictMode } from "react";
+import { LocalGamePage } from "./LocalGamePage";
+import { deterministicFixtureFactory } from "../../../e2e/fixtureScenarios";
+import { LocaleProvider } from "../../app/locale";
+import { PLAY_BRAND_ASSETS } from "./playBrandAssets";
+
+describe("Phase 20 Table — Official Hand Row and Interactive Selection", () => {
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  });
+
+  it("renders own hand as a horizontal row with card frames and enables tap-to-lift and tap-again-to-cancel", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <StrictMode>
+          <LocaleProvider>
+            <LocalGamePage
+              createGame={deterministicFixtureFactory}
+              aiDelayMs={0}
+              isDebug={false}
+            />
+          </LocaleProvider>
+        </StrictMode>,
+      );
+    });
+
+    // Start in Solo vs AI mode with CEO vs Acid King (starts directly in mainAction)
+    const p1Select = container.querySelector('[aria-label="player_1 角色"], [aria-label="player_1 character"]') as HTMLSelectElement;
+    const p2Select = container.querySelector('[aria-label="player_2 角色"], [aria-label="player_2 character"]') as HTMLSelectElement;
+    if (p1Select && p2Select) {
+      await act(async () => {
+        p1Select.value = "chemical_factory_ceo";
+        p1Select.dispatchEvent(new Event("change", { bubbles: true }));
+        p2Select.value = "acid_king";
+        p2Select.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+    }
+
+    const startButton = container.querySelector("button.start-game-button") as HTMLButtonElement;
+    expect(startButton).not.toBeNull();
+    await act(async () => {
+      startButton.click();
+    });
+
+    // In PlayingGame, player_1 (human) hand row has official-hand-row and hand-grid classes
+    const ownPanel = container.querySelector('[aria-labelledby="player_1-title"]') as HTMLElement;
+    expect(ownPanel).not.toBeNull();
+
+    const handRow = ownPanel.querySelector(".official-hand-row");
+    expect(handRow).not.toBeNull();
+    expect(handRow?.classList.contains("hand-grid")).toBe(true);
+
+    // Hand row header shows hand title and total count
+    const handHeader = ownPanel.querySelector(".hand-row-header");
+    expect(handHeader).not.toBeNull();
+    expect(handHeader?.textContent).toMatch(/手牌|Hand cards/);
+    expect(handHeader?.textContent).toMatch(/张|cards/);
+
+    // All own cards are official cards with card-frame overlay
+    const ownCards = ownPanel.querySelectorAll(".official-card.card-face");
+    expect(ownCards.length).toBeGreaterThan(0);
+    for (const card of ownCards) {
+      const frameImg = card.querySelector("img.card-frame__overlay");
+      expect(frameImg).not.toBeNull();
+      expect(frameImg?.getAttribute("src")).toContain("card-frame.png");
+    }
+
+    // Interactive selection: click first card to select (lifted up)
+    const firstCard = ownCards[0] as HTMLElement;
+    const firstButton = firstCard.querySelector("button.debug-card__select") as HTMLButtonElement;
+    expect(firstButton).not.toBeNull();
+    expect(firstCard.classList.contains("is-selected")).toBe(false);
+    expect(firstButton.getAttribute("aria-pressed")).toBe("false");
+
+    await act(async () => {
+      firstButton.click();
+    });
+
+    // Selected: has is-selected class and aria-pressed=true
+    expect(firstCard.classList.contains("is-selected")).toBe(true);
+    expect(firstButton.getAttribute("aria-pressed")).toBe("true");
+
+    // Tap again to cancel: click first card again
+    await act(async () => {
+      firstButton.click();
+    });
+
+    // Deselected: is-selected removed and aria-pressed=false
+    expect(firstCard.classList.contains("is-selected")).toBe(false);
+    expect(firstButton.getAttribute("aria-pressed")).toBe("false");
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("demonstrates Engine Authority: selecting hand cards does not alter GameState until Play/DIY is dispatched", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    let recordedReducerCalls = 0;
+    const trackingReducer = (state: any, action: any) => {
+      recordedReducerCalls += 1;
+      return state;
+    };
+
+    await act(async () => {
+      root.render(
+        <StrictMode>
+          <LocaleProvider>
+            <LocalGamePage
+              createGame={deterministicFixtureFactory}
+              aiDelayMs={0}
+              isDebug={false}
+            />
+          </LocaleProvider>
+        </StrictMode>,
+      );
+    });
+
+    const p1Select = container.querySelector('[aria-label="player_1 角色"], [aria-label="player_1 character"]') as HTMLSelectElement;
+    const p2Select = container.querySelector('[aria-label="player_2 角色"], [aria-label="player_2 character"]') as HTMLSelectElement;
+    if (p1Select && p2Select) {
+      await act(async () => {
+        p1Select.value = "chemical_factory_ceo";
+        p1Select.dispatchEvent(new Event("change", { bubbles: true }));
+        p2Select.value = "acid_king";
+        p2Select.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+    }
+
+    const startButton = container.querySelector("button.start-game-button") as HTMLButtonElement;
+    await act(async () => {
+      startButton.click();
+    });
+
+    const ownPanel = container.querySelector('[aria-labelledby="player_1-title"]') as HTMLElement;
+    const cardButtons = ownPanel.querySelectorAll("button.debug-card__select");
+    expect(cardButtons.length).toBeGreaterThan(1);
+
+    const initialLogEntries = container.querySelectorAll(".game-log li").length;
+    const initialHpText = ownPanel.querySelector(".player-hp-val")?.textContent;
+
+    // Click card 1 (select)
+    await act(async () => {
+      (cardButtons[0] as HTMLButtonElement).click();
+    });
+    // Click card 2 (switch selection)
+    await act(async () => {
+      (cardButtons[1] as HTMLButtonElement).click();
+    });
+    // Click card 2 again (deselect)
+    await act(async () => {
+      (cardButtons[1] as HTMLButtonElement).click();
+    });
+
+    // Verify: GameState did not mutate, logs remained identical, HP remained identical
+    const currentLogEntries = container.querySelectorAll(".game-log li").length;
+    const currentHpText = ownPanel.querySelector(".player-hp-val")?.textContent;
+    expect(currentLogEntries).toBe(initialLogEntries);
+    expect(currentHpText).toBe(initialHpText);
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders opponent hand in Solo vs AI as non-clickable card backs row with count", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <StrictMode>
+          <LocaleProvider>
+            <LocalGamePage
+              createGame={deterministicFixtureFactory}
+              aiDelayMs={0}
+              isDebug={false}
+            />
+          </LocaleProvider>
+        </StrictMode>,
+      );
+    });
+
+    const startButton = container.querySelector("button.start-game-button") as HTMLButtonElement;
+    await act(async () => {
+      startButton.click();
+    });
+
+    const opponentPanel = container.querySelector('[aria-labelledby="player_2-title"]') as HTMLElement;
+    expect(opponentPanel).not.toBeNull();
+
+    // Hand row has is-backs class
+    const handRow = opponentPanel.querySelector(".official-hand-row.is-backs");
+    expect(handRow).not.toBeNull();
+
+    // Opponent count
+    const handCountPill = opponentPanel.querySelector(".hand-count-pill")?.textContent ?? "";
+    const match = handCountPill.match(/(\d+)/);
+    const count = Number(match?.[1]);
+    expect(count).toBeGreaterThan(0);
+
+    // Opponent cards are all card backs
+    const cardBacks = opponentPanel.querySelectorAll(".card-back.official-card--back");
+    expect(cardBacks).toHaveLength(count);
+
+    // Each card back has card-back image and card-frame overlay
+    for (const back of cardBacks) {
+      const backImg = back.querySelector("img.card-back__image");
+      const frameImg = back.querySelector("img.card-frame__overlay");
+      expect(backImg).not.toBeNull();
+      expect(frameImg).not.toBeNull();
+      expect(backImg?.getAttribute("src")).toContain("card-back.png");
+      expect(frameImg?.getAttribute("src")).toContain("card-frame.png");
+    }
+
+    // Zero interactive buttons or card face elements inside opponent hand
+    expect(opponentPanel.querySelectorAll(".card-back button")).toHaveLength(0);
+    expect(opponentPanel.querySelectorAll(".card-face")).toHaveLength(0);
+    expect(opponentPanel.querySelectorAll(".debug-card__select")).toHaveLength(0);
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("reveals card faces and names for both players in local two-player mode", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <StrictMode>
+          <LocaleProvider>
+            <LocalGamePage
+              createGame={deterministicFixtureFactory}
+              aiDelayMs={0}
+              isDebug={false}
+            />
+          </LocaleProvider>
+        </StrictMode>,
+      );
+    });
+
+    // Select Two-Player mode
+    const modeSelect = container.querySelector(
+      "select[aria-label*='mode'], select[aria-label*='模式']",
+    ) as HTMLSelectElement;
+    await act(async () => {
+      modeSelect.value = "two_player";
+      modeSelect.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    const startButton = container.querySelector("button.start-game-button") as HTMLButtonElement;
+    await act(async () => {
+      startButton.click();
+    });
+
+    const player1 = container.querySelector('[aria-labelledby="player_1-title"]') as HTMLElement;
+    const player2 = container.querySelector('[aria-labelledby="player_2-title"]') as HTMLElement;
+
+    // Both players show card faces in official hand rows
+    expect(player1.querySelectorAll(".official-card.card-face").length).toBeGreaterThan(0);
+    expect(player2.querySelectorAll(".official-card.card-face").length).toBeGreaterThan(0);
+
+    // Both players show card names, zero card backs
+    expect(player1.querySelectorAll(".card-back")).toHaveLength(0);
+    expect(player2.querySelectorAll(".card-back")).toHaveLength(0);
+
+    // Both players have card buttons with names
+    const p1Names = Array.from(player1.querySelectorAll(".official-card__name")).map((el) => el.textContent?.trim());
+    const p2Names = Array.from(player2.querySelectorAll(".official-card__name")).map((el) => el.textContent?.trim());
+    expect(p1Names.length).toBeGreaterThan(0);
+    expect(p2Names.length).toBeGreaterThan(0);
+    expect(p1Names.every(Boolean)).toBe(true);
+    expect(p2Names.every(Boolean)).toBe(true);
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});


### PR DESCRIPTION
Phase 20-Table: official hand is a horizontal row. Tap lifts, tap again clears. Selection is UI-only.

- OfficialCard + card-frame overlay (no hole punch)
- Solo opponent: face-down row + count, no buttons
- Two-player: both faces and names remain public
- Engine and NATBA unchanged

Not Beta 1. Tutorial still later.

HEAD: d57f9f6a0ea171f211ff101540981530e3c8fdc3